### PR TITLE
Publish a POM to bintray

### DIFF
--- a/.circleci/bintray-publish.sh
+++ b/.circleci/bintray-publish.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+
+$file=$1
+$name=$(basename $file)
+
+curl -f -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T "$file" "https://api.bintray.com/content/palantir/releases/conjure-rust/$CIRCLE_TAG/com/palantir/conjure/rust/conjure-rust/$CIRCLE_TAG/$name?publish=1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,10 @@ jobs:
           done
           cp .circleci/conjure-rust $bin
           tar cvzf /tmp/$name.tgz -C $base $name
-          curl -f -u $BINTRAY_USERNAME:$BINTRAY_PASSWORD -T /tmp/$name.tgz "https://api.bintray.com/content/palantir/releases/conjure-rust/$CIRCLE_TAG/com/palantir/conjure/rust/conjure-rust/$CIRCLE_TAG/$name.tgz?publish=1"
+          ./.circleci/bintray-publish.sh /tmp/$name.tgz
+
+          sed -e "s/%VERSION%/$CIRCLE_TAG/g" .circleci/conjure-rust.pom > /tmp/$name.pom
+          ./.circleci/bintray-publish.sh /tmp/$name.pom
 
 workflows:
   version: 2

--- a/.circleci/conjure-rust.pom
+++ b/.circleci/conjure-rust.pom
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.palantir.conjure.rust</groupId>
+  <artifactId>conjure-rust</artifactId>
+  <version>%VERSION%</version>
+  <packaging>tgz</packaging>
+</project>


### PR DESCRIPTION
This is required for conjure-gradle to be able to track down the tarball