### PR TITLE
Fix server deserializer

### DIFF
--- a/conjure-serde/src/json/de/mod.rs
+++ b/conjure-serde/src/json/de/mod.rs
@@ -11,5 +11,93 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use serde::de;
+use std::f32;
+use std::f64;
+use std::fmt;
+
 pub mod client;
 pub mod server;
+
+macro_rules! delegate_visit {
+    ($($method:ident = $ty:ty,)*) => {
+        $(
+            fn $method<E>(self, v: $ty) -> Result<T::Value, E>
+            where
+                E: de::Error,
+            {
+                (self.0).$method(v)
+            }
+        )*
+    };
+}
+
+macro_rules! float_visitor {
+    ($name:ident, $method:ident, $module:ident) => {
+        struct $name<T>(T);
+
+        impl<'de, T> de::Visitor<'de> for $name<T>
+        where
+            T: de::Visitor<'de>,
+        {
+            type Value = T::Value;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                self.0.expecting(formatter)
+            }
+
+            delegate_visit!(
+                visit_i8 = i8,
+                visit_i16 = i16,
+                visit_i32 = i32,
+                visit_i64 = i64,
+                visit_i128 = i128,
+                visit_u8 = u8,
+                visit_u16 = u16,
+                visit_u32 = u32,
+                visit_u64 = u64,
+                visit_u128 = u128,
+                visit_f32 = f32,
+                visit_f64 = f64,
+            );
+
+            fn visit_str<E>(self, v: &str) -> Result<T::Value, E>
+            where
+                E: de::Error,
+            {
+                match v {
+                    "NaN" => (self.0).$method($module::NAN),
+                    "Infinity" => (self.0).$method($module::INFINITY),
+                    "-Infinity" => (self.0).$method($module::NEG_INFINITY),
+                    _ => self.0.visit_str(v),
+                }
+            }
+        }
+    };
+}
+
+float_visitor!(F32Visitor, visit_f32, f32);
+float_visitor!(F64Visitor, visit_f64, f64);
+
+struct ByteBufVisitor<T>(T);
+
+impl<'de, T> de::Visitor<'de> for ByteBufVisitor<T>
+where
+    T: de::Visitor<'de>,
+{
+    type Value = T::Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a base64 string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<T::Value, E>
+    where
+        E: de::Error,
+    {
+        match base64::decode(v) {
+            Ok(v) => self.0.visit_byte_buf(v),
+            Err(_) => Err(E::invalid_value(de::Unexpected::Str(v), &self)),
+        }
+    }
+}


### PR DESCRIPTION
The server deserializer has the same behavior as the client deserializer
but also rejects unknown fields, so we previously tried to have the
server deserializer wrap the client deserializer. However, we
accidentally added an extra layer of nesting at one of the wrapping
stages so you'd end up with an exponential number of nested visitors as
the type heirarchy increasees.

We could have fixed that, but it's really hard to think about where the
nesting needs to be applied, and easier to just implement them both
separately side by side.