### PR TITLE
Make explicit constructors for objects with few fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -37,7 +37,7 @@ dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -48,12 +48,12 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "base64"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -134,7 +134,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ dependencies = [
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -163,21 +163,21 @@ dependencies = [
 name = "conjure-serde"
 version = "0.2.1"
 dependencies = [
- "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conjure-test"
 version = "0.2.1"
 dependencies = [
- "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-codegen 0.2.1",
  "conjure-object 0.2.1",
  "conjure-serde 0.2.1",
- "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -206,17 +206,8 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
+name = "fuchsia-cprng"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -239,7 +230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.47"
+version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -248,7 +239,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -290,7 +281,7 @@ dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -311,28 +302,29 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -344,12 +336,20 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.3.0"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -357,7 +357,7 @@ name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -365,18 +365,28 @@ name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_os"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -386,7 +396,7 @@ name = "rand_pcg"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -395,7 +405,7 @@ name = "rand_xorshift"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -403,7 +413,7 @@ name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -426,7 +436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -438,7 +448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -531,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,8 +601,8 @@ version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -603,7 +613,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -629,7 +639,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -661,7 +671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -677,7 +687,7 @@ name = "wait-timeout"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -706,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
-"checksum base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "621fc7ecb8008f86d7fb9b95356cd692ce9514b80a86d85b397f32a22da7b9e2"
+"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1efcc46c18245a69c38fcc5cc650f16d3a59d034f3106e9ed63748f695730a"
 "checksum bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4440d5cb623bb7390ae27fec0bb6c61111969860f8e3ae198bfa0663645e67cf"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -719,12 +729,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81f7f8eb465745ea9b02e2704612a9946a59fa40572086c6fd49d6ddcf30bf31"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
-"checksum libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)" = "48450664a984b25d5b479554c29cc04e3150c97aa4c01da5604a2d4ed9151476"
+"checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
@@ -733,13 +742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proptest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27f275a76b824714046ce0b1e00323e06437e027f2d31b2b6272cae30afaf18d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum rand 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dee497e66d8d76bf08ce20c8d36e16f93749ab0bf89975b4f8ae5cee660c2da2"
-"checksum rand 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3906503e80ac6cbcacb2c2973fa8e473f24d7e2747c8c92bb230c2441cad96b5"
+"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-"checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46fbd5550acf75b0c2730f5dd1873751daf9beb8f11b44027778fae50d7feca"
+"checksum rand_jitter 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "080723c6145e37503a2224f801f252e14ac5531cb450f4502698542d188cb3c0"
+"checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
@@ -747,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
+"checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -759,7 +770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 "checksum serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adb6e51a6b3696b301bc221d785f898b4457c619b51d7ce195a6d20baecb37b3"
 "checksum serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)" = "a915306b0f1ac5607797697148c223bedeaa36bcc2e28a01441cd638cc6567b4"
-"checksum serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "574378d957d6dcdf1bbb5d562a15cbd5e644159432f84634b94e485267abbcc7"
+"checksum serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "4b90a9fbe1211e57d3e1c15670f1cb00802988fb23a1a4aad7a2b63544f1920e"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
@@ -775,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
-"checksum uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dab5c5526c5caa3d106653401a267fed923e7046f35895ffcb5ca42db64942e6"
+"checksum uuid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0238db0c5b605dd1cf51de0f21766f97fba2645897024461d6a00c036819a768"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum wait-timeout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f3bf741a801531993db6478b95682117471f76916f5e690dd8d45395b09349"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -309,6 +309,14 @@ impl Context {
         }
     }
 
+    pub fn option_inner_type<'a>(&self, def: &'a Type) -> Option<&'a Type> {
+        match def {
+            Type::Optional(def) => Some(def.item_type()),
+            Type::External(def) => self.option_inner_type(def.fallback()),
+            _ => None,
+        }
+    }
+
     pub fn borrowed_rust_type(&self, this_type: &TypeName, def: &Type) -> TokenStream {
         match def {
             Type::Primitive(def) => match *def {

--- a/conjure-codegen/src/example_types/any_example.rs
+++ b/conjure-codegen/src/example_types/any_example.rs
@@ -6,6 +6,14 @@ pub struct AnyExample {
     any: conjure_object::Value,
 }
 impl AnyExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(any: T) -> AnyExample
+    where
+        T: conjure_object::serde::Serialize,
+    {
+        AnyExample::builder().any(any).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/any_map_example.rs
+++ b/conjure-codegen/src/example_types/any_map_example.rs
@@ -6,6 +6,14 @@ pub struct AnyMapExample {
     items: std::collections::BTreeMap<String, conjure_object::Value>,
 }
 impl AnyMapExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(items: T) -> AnyMapExample
+    where
+        T: IntoIterator<Item = (String, conjure_object::Value)>,
+    {
+        AnyMapExample::builder().items(items).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/bearer_token_example.rs
+++ b/conjure-codegen/src/example_types/bearer_token_example.rs
@@ -6,6 +6,13 @@ pub struct BearerTokenExample {
     bearer_token_value: conjure_object::BearerToken,
 }
 impl BearerTokenExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(bearer_token_value: conjure_object::BearerToken) -> BearerTokenExample {
+        BearerTokenExample::builder()
+            .bearer_token_value(bearer_token_value)
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/binary_example.rs
+++ b/conjure-codegen/src/example_types/binary_example.rs
@@ -6,6 +6,14 @@ pub struct BinaryExample {
     binary: conjure_object::ByteBuf,
 }
 impl BinaryExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(binary: T) -> BinaryExample
+    where
+        T: Into<Vec<u8>>,
+    {
+        BinaryExample::builder().binary(binary).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/boolean_example.rs
+++ b/conjure-codegen/src/example_types/boolean_example.rs
@@ -6,6 +6,11 @@ pub struct BooleanExample {
     coin: bool,
 }
 impl BooleanExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(coin: bool) -> BooleanExample {
+        BooleanExample::builder().coin(coin).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/covariant_list_example.rs
+++ b/conjure-codegen/src/example_types/covariant_list_example.rs
@@ -7,6 +7,18 @@ pub struct CovariantListExample {
     external_items: Vec<String>,
 }
 impl CovariantListExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T, U>(items: T, external_items: U) -> CovariantListExample
+    where
+        T: IntoIterator<Item = conjure_object::Value>,
+        U: IntoIterator<Item = String>,
+    {
+        CovariantListExample::builder()
+            .items(items)
+            .external_items(external_items)
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/covariant_optional_example.rs
+++ b/conjure-codegen/src/example_types/covariant_optional_example.rs
@@ -6,6 +6,18 @@ pub struct CovariantOptionalExample {
     item: Option<conjure_object::Value>,
 }
 impl CovariantOptionalExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(item: T) -> CovariantOptionalExample
+    where
+        T: conjure_object::serde::Serialize,
+    {
+        CovariantOptionalExample::builder()
+            .item(Some(
+                conjure_object::serde_value::to_value(item).expect("value failed to serialize"),
+            ))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/date_time_example.rs
+++ b/conjure-codegen/src/example_types/date_time_example.rs
@@ -6,6 +6,11 @@ pub struct DateTimeExample {
     datetime: conjure_object::DateTime<conjure_object::Utc>,
 }
 impl DateTimeExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(datetime: conjure_object::DateTime<conjure_object::Utc>) -> DateTimeExample {
+        DateTimeExample::builder().datetime(datetime).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/double_example.rs
+++ b/conjure-codegen/src/example_types/double_example.rs
@@ -6,6 +6,11 @@ pub struct DoubleExample {
     double_value: f64,
 }
 impl DoubleExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(double_value: f64) -> DoubleExample {
+        DoubleExample::builder().double_value(double_value).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/empty_object_example.rs
+++ b/conjure-codegen/src/example_types/empty_object_example.rs
@@ -4,6 +4,11 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct EmptyObjectExample {}
 impl EmptyObjectExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new() -> EmptyObjectExample {
+        EmptyObjectExample::builder().build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/enum_field_example.rs
+++ b/conjure-codegen/src/example_types/enum_field_example.rs
@@ -6,6 +6,11 @@ pub struct EnumFieldExample {
     enum_: super::EnumExample,
 }
 impl EnumFieldExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(enum_: super::EnumExample) -> EnumFieldExample {
+        EnumFieldExample::builder().enum_(enum_).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/integer_example.rs
+++ b/conjure-codegen/src/example_types/integer_example.rs
@@ -6,6 +6,11 @@ pub struct IntegerExample {
     integer: i32,
 }
 impl IntegerExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(integer: i32) -> IntegerExample {
+        IntegerExample::builder().integer(integer).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/list_example.rs
+++ b/conjure-codegen/src/example_types/list_example.rs
@@ -8,6 +8,20 @@ pub struct ListExample {
     double_items: Vec<f64>,
 }
 impl ListExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T, U, V>(items: T, primitive_items: U, double_items: V) -> ListExample
+    where
+        T: IntoIterator<Item = String>,
+        U: IntoIterator<Item = i32>,
+        V: IntoIterator<Item = f64>,
+    {
+        ListExample::builder()
+            .items(items)
+            .primitive_items(primitive_items)
+            .double_items(double_items)
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/map_example.rs
+++ b/conjure-codegen/src/example_types/map_example.rs
@@ -6,6 +6,14 @@ pub struct MapExample {
     items: std::collections::BTreeMap<String, String>,
 }
 impl MapExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(items: T) -> MapExample
+    where
+        T: IntoIterator<Item = (String, String)>,
+    {
+        MapExample::builder().items(items).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/optional_example.rs
+++ b/conjure-codegen/src/example_types/optional_example.rs
@@ -6,6 +6,14 @@ pub struct OptionalExample {
     item: Option<String>,
 }
 impl OptionalExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(item: T) -> OptionalExample
+    where
+        T: Into<String>,
+    {
+        OptionalExample::builder().item(Some(item.into())).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/rid_example.rs
+++ b/conjure-codegen/src/example_types/rid_example.rs
@@ -6,6 +6,11 @@ pub struct RidExample {
     rid_value: conjure_object::ResourceIdentifier,
 }
 impl RidExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(rid_value: conjure_object::ResourceIdentifier) -> RidExample {
+        RidExample::builder().rid_value(rid_value).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/safe_long_example.rs
+++ b/conjure-codegen/src/example_types/safe_long_example.rs
@@ -6,6 +6,13 @@ pub struct SafeLongExample {
     safe_long_value: conjure_object::SafeLong,
 }
 impl SafeLongExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(safe_long_value: conjure_object::SafeLong) -> SafeLongExample {
+        SafeLongExample::builder()
+            .safe_long_value(safe_long_value)
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/set_example.rs
+++ b/conjure-codegen/src/example_types/set_example.rs
@@ -6,6 +6,14 @@ pub struct SetExample {
     items: std::collections::BTreeSet<String>,
 }
 impl SetExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(items: T) -> SetExample
+    where
+        T: IntoIterator<Item = String>,
+    {
+        SetExample::builder().items(items).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/string_example.rs
+++ b/conjure-codegen/src/example_types/string_example.rs
@@ -6,6 +6,14 @@ pub struct StringExample {
     string: String,
 }
 impl StringExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(string: T) -> StringExample
+    where
+        T: Into<String>,
+    {
+        StringExample::builder().string(string).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/example_types/uuid_example.rs
+++ b/conjure-codegen/src/example_types/uuid_example.rs
@@ -6,6 +6,11 @@ pub struct UuidExample {
     uuid: conjure_object::Uuid,
 }
 impl UuidExample {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(uuid: conjure_object::Uuid) -> UuidExample {
+        UuidExample::builder().uuid(uuid).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -91,6 +91,15 @@
 //! assert_eq!(object.optional_item(), Some("bar"));
 //! ```
 //!
+//! Objects with 3 or fewer fields also have an explicit constructor:
+//!
+//! ```rust
+//! # use conjure_codegen::example_types::BooleanExample;
+//! let object = BooleanExample::new(true);
+//!
+//! assert_eq!(object.coin(), true);
+//! ```
+//!
 //! The generated structs implement `Debug`, `Clone`, `PartialEq`, `PartialOrd`, `Serialize`, and `Deserialize`. They
 //! also implement `Eq`, `Ord`, and `Hash` if they do not contain a `double` value, and `Copy` if they consist entirely
 //! of copyable primitive types.

--- a/conjure-codegen/src/types/alias_definition.rs
+++ b/conjure-codegen/src/types/alias_definition.rs
@@ -8,6 +8,19 @@ pub struct AliasDefinition {
     docs: Option<super::Documentation>,
 }
 impl AliasDefinition {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(
+        type_name: super::TypeName,
+        alias: super::Type,
+        docs: super::Documentation,
+    ) -> AliasDefinition {
+        AliasDefinition::builder()
+            .type_name(type_name)
+            .alias(alias)
+            .docs(Some(docs))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/body_parameter_type.rs
+++ b/conjure-codegen/src/types/body_parameter_type.rs
@@ -4,6 +4,11 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct BodyParameterType {}
 impl BodyParameterType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new() -> BodyParameterType {
+        BodyParameterType::builder().build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/cookie_auth_type.rs
+++ b/conjure-codegen/src/types/cookie_auth_type.rs
@@ -6,6 +6,14 @@ pub struct CookieAuthType {
     cookie_name: String,
 }
 impl CookieAuthType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(cookie_name: T) -> CookieAuthType
+    where
+        T: Into<String>,
+    {
+        CookieAuthType::builder().cookie_name(cookie_name).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/enum_definition.rs
+++ b/conjure-codegen/src/types/enum_definition.rs
@@ -8,6 +8,22 @@ pub struct EnumDefinition {
     docs: Option<super::Documentation>,
 }
 impl EnumDefinition {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(
+        type_name: super::TypeName,
+        values: T,
+        docs: super::Documentation,
+    ) -> EnumDefinition
+    where
+        T: IntoIterator<Item = super::EnumValueDefinition>,
+    {
+        EnumDefinition::builder()
+            .type_name(type_name)
+            .values(values)
+            .docs(Some(docs))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/enum_value_definition.rs
+++ b/conjure-codegen/src/types/enum_value_definition.rs
@@ -7,6 +7,17 @@ pub struct EnumValueDefinition {
     docs: Option<super::Documentation>,
 }
 impl EnumValueDefinition {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(value: T, docs: super::Documentation) -> EnumValueDefinition
+    where
+        T: Into<String>,
+    {
+        EnumValueDefinition::builder()
+            .value(value)
+            .docs(Some(docs))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/external_reference.rs
+++ b/conjure-codegen/src/types/external_reference.rs
@@ -7,6 +7,14 @@ pub struct ExternalReference {
     fallback: Box<super::Type>,
 }
 impl ExternalReference {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(external_reference: super::TypeName, fallback: super::Type) -> ExternalReference {
+        ExternalReference::builder()
+            .external_reference(external_reference)
+            .fallback(fallback)
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/field_definition.rs
+++ b/conjure-codegen/src/types/field_definition.rs
@@ -8,6 +8,19 @@ pub struct FieldDefinition {
     docs: Option<super::Documentation>,
 }
 impl FieldDefinition {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(
+        field_name: super::FieldName,
+        type_: super::Type,
+        docs: super::Documentation,
+    ) -> FieldDefinition {
+        FieldDefinition::builder()
+            .field_name(field_name)
+            .type_(type_)
+            .docs(Some(docs))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/header_auth_type.rs
+++ b/conjure-codegen/src/types/header_auth_type.rs
@@ -4,6 +4,11 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct HeaderAuthType {}
 impl HeaderAuthType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new() -> HeaderAuthType {
+        HeaderAuthType::builder().build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/header_parameter_type.rs
+++ b/conjure-codegen/src/types/header_parameter_type.rs
@@ -6,6 +6,11 @@ pub struct HeaderParameterType {
     param_id: super::ParameterId,
 }
 impl HeaderParameterType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(param_id: super::ParameterId) -> HeaderParameterType {
+        HeaderParameterType::builder().param_id(param_id).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/list_type.rs
+++ b/conjure-codegen/src/types/list_type.rs
@@ -6,6 +6,11 @@ pub struct ListType {
     item_type: Box<super::Type>,
 }
 impl ListType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(item_type: super::Type) -> ListType {
+        ListType::builder().item_type(item_type).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/map_type.rs
+++ b/conjure-codegen/src/types/map_type.rs
@@ -7,6 +7,14 @@ pub struct MapType {
     value_type: Box<super::Type>,
 }
 impl MapType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(key_type: super::Type, value_type: super::Type) -> MapType {
+        MapType::builder()
+            .key_type(key_type)
+            .value_type(value_type)
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/object_definition.rs
+++ b/conjure-codegen/src/types/object_definition.rs
@@ -8,6 +8,22 @@ pub struct ObjectDefinition {
     docs: Option<super::Documentation>,
 }
 impl ObjectDefinition {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(
+        type_name: super::TypeName,
+        fields: T,
+        docs: super::Documentation,
+    ) -> ObjectDefinition
+    where
+        T: IntoIterator<Item = super::FieldDefinition>,
+    {
+        ObjectDefinition::builder()
+            .type_name(type_name)
+            .fields(fields)
+            .docs(Some(docs))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/optional_type.rs
+++ b/conjure-codegen/src/types/optional_type.rs
@@ -6,6 +6,11 @@ pub struct OptionalType {
     item_type: Box<super::Type>,
 }
 impl OptionalType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(item_type: super::Type) -> OptionalType {
+        OptionalType::builder().item_type(item_type).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/path_parameter_type.rs
+++ b/conjure-codegen/src/types/path_parameter_type.rs
@@ -4,6 +4,11 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct PathParameterType {}
 impl PathParameterType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new() -> PathParameterType {
+        PathParameterType::builder().build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/query_parameter_type.rs
+++ b/conjure-codegen/src/types/query_parameter_type.rs
@@ -6,6 +6,11 @@ pub struct QueryParameterType {
     param_id: super::ParameterId,
 }
 impl QueryParameterType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(param_id: super::ParameterId) -> QueryParameterType {
+        QueryParameterType::builder().param_id(param_id).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/service_definition.rs
+++ b/conjure-codegen/src/types/service_definition.rs
@@ -8,6 +8,22 @@ pub struct ServiceDefinition {
     docs: Option<super::Documentation>,
 }
 impl ServiceDefinition {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(
+        service_name: super::TypeName,
+        endpoints: T,
+        docs: super::Documentation,
+    ) -> ServiceDefinition
+    where
+        T: IntoIterator<Item = super::EndpointDefinition>,
+    {
+        ServiceDefinition::builder()
+            .service_name(service_name)
+            .endpoints(endpoints)
+            .docs(Some(docs))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/set_type.rs
+++ b/conjure-codegen/src/types/set_type.rs
@@ -6,6 +6,11 @@ pub struct SetType {
     item_type: Box<super::Type>,
 }
 impl SetType {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new(item_type: super::Type) -> SetType {
+        SetType::builder().item_type(item_type).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/type_name.rs
+++ b/conjure-codegen/src/types/type_name.rs
@@ -7,6 +7,15 @@ pub struct TypeName {
     package: String,
 }
 impl TypeName {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T, U>(name: T, package: U) -> TypeName
+    where
+        T: Into<String>,
+        U: Into<String>,
+    {
+        TypeName::builder().name(name).package(package).build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-codegen/src/types/union_definition.rs
+++ b/conjure-codegen/src/types/union_definition.rs
@@ -8,6 +8,22 @@ pub struct UnionDefinition {
     docs: Option<super::Documentation>,
 }
 impl UnionDefinition {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(
+        type_name: super::TypeName,
+        union_: T,
+        docs: super::Documentation,
+    ) -> UnionDefinition
+    where
+        T: IntoIterator<Item = super::FieldDefinition>,
+    {
+        UnionDefinition::builder()
+            .type_name(type_name)
+            .union_(union_)
+            .docs(Some(docs))
+            .build()
+    }
     #[doc = r" Returns a new builder."]
     #[inline]
     pub fn builder() -> Builder {

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -183,3 +183,14 @@ fn union_trailing_fields() {
         .unwrap();
     assert!(e.is_data());
 }
+
+#[test]
+fn optional_field_constructor() {
+    let builder = OptionalConstructorFields::builder()
+        .list(vec![1, 2])
+        .string("hi".to_string())
+        .integer(3)
+        .build();
+    let constructor = OptionalConstructorFields::new(vec![1, 2], "hi", 3);
+    assert_eq!(builder, constructor);
+}

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -82,6 +82,91 @@
     "type" : "alias",
     "alias" : {
       "typeName" : {
+        "name" : "OptionalAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "INTEGER"
+          }
+        }
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "MapAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "map",
+        "map" : {
+          "keyType" : {
+            "type" : "primitive",
+            "primitive" : "INTEGER"
+          },
+          "valueType" : {
+            "type" : "primitive",
+            "primitive" : "INTEGER"
+          }
+        }
+      }
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "OptionalConstructorFields",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "list",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "list",
+              "list" : {
+                "itemType" : {
+                  "type" : "primitive",
+                  "primitive" : "INTEGER"
+                }
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "string",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
+      }, {
+        "fieldName" : "integer",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
         "name" : "OptionalObjectAlias",
         "package" : "com.palantir.conjure"
       },
@@ -226,44 +311,6 @@
           }
         }
       } ]
-    }
-  }, {
-    "type" : "alias",
-    "alias" : {
-      "typeName" : {
-        "name" : "OptionalAlias",
-        "package" : "com.palantir.conjure"
-      },
-      "alias" : {
-        "type" : "optional",
-        "optional" : {
-          "itemType" : {
-            "type" : "primitive",
-            "primitive" : "INTEGER"
-          }
-        }
-      }
-    }
-  }, {
-    "type" : "alias",
-    "alias" : {
-      "typeName" : {
-        "name" : "MapAlias",
-        "package" : "com.palantir.conjure"
-      },
-      "alias" : {
-        "type" : "map",
-        "map" : {
-          "keyType" : {
-            "type" : "primitive",
-            "primitive" : "INTEGER"
-          },
-          "valueType" : {
-            "type" : "primitive",
-            "primitive" : "INTEGER"
-          }
-        }
-      }
     }
   }, {
     "type" : "alias",

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -48,3 +48,8 @@ types:
           unionAlias: UnionAlias
           optionalOfUnionAlias: optional<UnionAlias>
           optionalObjectAlias: OptionalObjectAlias
+      OptionalConstructorFields:
+        fields:
+          list: optional<list<integer>>
+          string: optional<string>
+          integer: optional<integer>


### PR DESCRIPTION
This matches conjure-java's behavior. Optional fields are treated as
required in the constructor.