### PR TITLE
Simplify type parameters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+conjure-codegen/src/types/** linguist-generated=true
+conjure-codegen/src/example_types/** linguist-generated=true
+*.json linguist-generated=true

--- a/conjure-codegen/src/aliases.rs
+++ b/conjure-codegen/src/aliases.rs
@@ -75,18 +75,18 @@ pub fn generate(ctx: &Context, def: &AliasDefinition) -> TokenStream {
         }
 
         impl ser::Serialize for #name {
-            fn serialize<S_>(&self, s: S_) -> #result<S_::Ok, S_::Error>
+            fn serialize<S>(&self, s: S) -> #result<S::Ok, S::Error>
             where
-                S_: ser::Serializer
+                S: ser::Serializer
             {
                 self.0.serialize(s)
             }
         }
 
         impl<'de> de::Deserialize<'de> for #name {
-            fn deserialize<D_>(d: D_) -> #result<#name, D_::Error>
+            fn deserialize<D>(d: D) -> #result<#name, D::Error>
             where
-                D_: de::Deserializer<'de>
+                D: de::Deserializer<'de>
             {
                 de::Deserialize::deserialize(d).map(#name)
             }

--- a/conjure-codegen/src/enums.rs
+++ b/conjure-codegen/src/enums.rs
@@ -120,18 +120,18 @@ fn generate_enum(ctx: &Context, def: &EnumDefinition) -> TokenStream {
         }
 
         impl ser::Serialize for #name {
-            fn serialize<S_>(&self, s: S_) -> #result<S_::Ok, S_::Error>
+            fn serialize<S>(&self, s: S) -> #result<S::Ok, S::Error>
             where
-                S_: ser::Serializer,
+                S: ser::Serializer,
             {
                 s.serialize_str(self.as_str())
             }
         }
 
         impl<'de> de::Deserialize<'de> for #name {
-            fn deserialize<D_>(d: D_) -> #result<#name, D_::Error>
+            fn deserialize<D>(d: D) -> #result<#name, D::Error>
             where
-                D_: de::Deserializer<'de>
+                D: de::Deserializer<'de>
             {
                 d.deserialize_str(Visitor_)
             }
@@ -146,9 +146,9 @@ fn generate_enum(ctx: &Context, def: &EnumDefinition) -> TokenStream {
                 fmt.write_str("string")
             }
 
-            fn visit_str<E_>(self, v: &str) -> #result<#name, E_>
+            fn visit_str<E>(self, v: &str) -> #result<#name, E>
             where
-                E_: de::Error,
+                E: de::Error,
             {
                 match v {
                     #(#visit_str_arms)*

--- a/conjure-codegen/src/example_types/alias_as_map_key_example.rs
+++ b/conjure-codegen/src/example_types/alias_as_map_key_example.rs
@@ -260,9 +260,9 @@ impl From<AliasAsMapKeyExample> for Builder {
     }
 }
 impl ser::Serialize for AliasAsMapKeyExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_strings = self.strings.is_empty();
@@ -319,9 +319,9 @@ impl ser::Serialize for AliasAsMapKeyExample {
     }
 }
 impl<'de> de::Deserialize<'de> for AliasAsMapKeyExample {
-    fn deserialize<D_>(d: D_) -> Result<AliasAsMapKeyExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<AliasAsMapKeyExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "AliasAsMapKeyExample",
@@ -344,9 +344,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<AliasAsMapKeyExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<AliasAsMapKeyExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut strings = None;
         let mut rids = None;
@@ -419,9 +419,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -432,9 +432,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "strings" => Field_::Strings,

--- a/conjure-codegen/src/example_types/any_example.rs
+++ b/conjure-codegen/src/example_types/any_example.rs
@@ -58,9 +58,9 @@ impl From<AnyExample> for Builder {
     }
 }
 impl ser::Serialize for AnyExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -69,9 +69,9 @@ impl ser::Serialize for AnyExample {
     }
 }
 impl<'de> de::Deserialize<'de> for AnyExample {
-    fn deserialize<D_>(d: D_) -> Result<AnyExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<AnyExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("AnyExample", &["any"], Visitor_)
     }
@@ -82,9 +82,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<AnyExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<AnyExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut any = None;
         while let Some(field_) = map_.next_key()? {
@@ -107,9 +107,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -120,9 +120,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "any" => Field_::Any,

--- a/conjure-codegen/src/example_types/any_map_example.rs
+++ b/conjure-codegen/src/example_types/any_map_example.rs
@@ -43,10 +43,10 @@ impl Builder {
         self.items.extend(items);
         self
     }
-    pub fn insert_items<K, V>(&mut self, key: K, value: V) -> &mut Self
+    pub fn insert_items<T, T>(&mut self, key: K, value: V) -> &mut Self
     where
-        K: Into<String>,
-        V: conjure_object::serde::Serialize,
+        T: Into<String>,
+        T: conjure_object::serde::Serialize,
     {
         self.items.insert(
             key.into(),
@@ -73,9 +73,9 @@ impl From<AnyMapExample> for Builder {
     }
 }
 impl ser::Serialize for AnyMapExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_items = self.items.is_empty();
@@ -90,9 +90,9 @@ impl ser::Serialize for AnyMapExample {
     }
 }
 impl<'de> de::Deserialize<'de> for AnyMapExample {
-    fn deserialize<D_>(d: D_) -> Result<AnyMapExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<AnyMapExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("AnyMapExample", &["items"], Visitor_)
     }
@@ -103,9 +103,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<AnyMapExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<AnyMapExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut items = None;
         while let Some(field_) = map_.next_key()? {
@@ -128,9 +128,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -141,9 +141,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "items" => Field_::Items,

--- a/conjure-codegen/src/example_types/any_map_example.rs
+++ b/conjure-codegen/src/example_types/any_map_example.rs
@@ -43,10 +43,10 @@ impl Builder {
         self.items.extend(items);
         self
     }
-    pub fn insert_items<T, T>(&mut self, key: K, value: V) -> &mut Self
+    pub fn insert_items<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
-        T: Into<String>,
-        T: conjure_object::serde::Serialize,
+        K: Into<String>,
+        V: conjure_object::serde::Serialize,
     {
         self.items.insert(
             key.into(),

--- a/conjure-codegen/src/example_types/bearer_token_alias_example.rs
+++ b/conjure-codegen/src/example_types/bearer_token_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for BearerTokenAliasExample {
     }
 }
 impl ser::Serialize for BearerTokenAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for BearerTokenAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<BearerTokenAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<BearerTokenAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(BearerTokenAliasExample)
     }

--- a/conjure-codegen/src/example_types/bearer_token_example.rs
+++ b/conjure-codegen/src/example_types/bearer_token_example.rs
@@ -62,9 +62,9 @@ impl From<BearerTokenExample> for Builder {
     }
 }
 impl ser::Serialize for BearerTokenExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -73,9 +73,9 @@ impl ser::Serialize for BearerTokenExample {
     }
 }
 impl<'de> de::Deserialize<'de> for BearerTokenExample {
-    fn deserialize<D_>(d: D_) -> Result<BearerTokenExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<BearerTokenExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("BearerTokenExample", &["bearerTokenValue"], Visitor_)
     }
@@ -86,9 +86,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<BearerTokenExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<BearerTokenExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut bearer_token_value = None;
         while let Some(field_) = map_.next_key()? {
@@ -111,9 +111,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -124,9 +124,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "bearerTokenValue" => Field_::BearerTokenValue,

--- a/conjure-codegen/src/example_types/binary_alias_example.rs
+++ b/conjure-codegen/src/example_types/binary_alias_example.rs
@@ -15,17 +15,17 @@ impl std::ops::DerefMut for BinaryAliasExample {
     }
 }
 impl ser::Serialize for BinaryAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for BinaryAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<BinaryAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<BinaryAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(BinaryAliasExample)
     }

--- a/conjure-codegen/src/example_types/binary_example.rs
+++ b/conjure-codegen/src/example_types/binary_example.rs
@@ -59,9 +59,9 @@ impl From<BinaryExample> for Builder {
     }
 }
 impl ser::Serialize for BinaryExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -70,9 +70,9 @@ impl ser::Serialize for BinaryExample {
     }
 }
 impl<'de> de::Deserialize<'de> for BinaryExample {
-    fn deserialize<D_>(d: D_) -> Result<BinaryExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<BinaryExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("BinaryExample", &["binary"], Visitor_)
     }
@@ -83,9 +83,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<BinaryExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<BinaryExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut binary = None;
         while let Some(field_) = map_.next_key()? {
@@ -108,9 +108,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -121,9 +121,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "binary" => Field_::Binary,

--- a/conjure-codegen/src/example_types/boolean_alias_example.rs
+++ b/conjure-codegen/src/example_types/boolean_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for BooleanAliasExample {
     }
 }
 impl ser::Serialize for BooleanAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for BooleanAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<BooleanAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<BooleanAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(BooleanAliasExample)
     }

--- a/conjure-codegen/src/example_types/boolean_example.rs
+++ b/conjure-codegen/src/example_types/boolean_example.rs
@@ -54,9 +54,9 @@ impl From<BooleanExample> for Builder {
     }
 }
 impl ser::Serialize for BooleanExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for BooleanExample {
     }
 }
 impl<'de> de::Deserialize<'de> for BooleanExample {
-    fn deserialize<D_>(d: D_) -> Result<BooleanExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<BooleanExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("BooleanExample", &["coin"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<BooleanExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<BooleanExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut coin = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "coin" => Field_::Coin,

--- a/conjure-codegen/src/example_types/covariant_list_example.rs
+++ b/conjure-codegen/src/example_types/covariant_list_example.rs
@@ -105,9 +105,9 @@ impl From<CovariantListExample> for Builder {
     }
 }
 impl ser::Serialize for CovariantListExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_items = self.items.is_empty();
@@ -129,9 +129,9 @@ impl ser::Serialize for CovariantListExample {
     }
 }
 impl<'de> de::Deserialize<'de> for CovariantListExample {
-    fn deserialize<D_>(d: D_) -> Result<CovariantListExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<CovariantListExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "CovariantListExample",
@@ -146,9 +146,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<CovariantListExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<CovariantListExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut items = None;
         let mut external_items = None;
@@ -181,9 +181,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -194,9 +194,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "items" => Field_::Items,

--- a/conjure-codegen/src/example_types/covariant_optional_example.rs
+++ b/conjure-codegen/src/example_types/covariant_optional_example.rs
@@ -59,9 +59,9 @@ impl From<CovariantOptionalExample> for Builder {
     }
 }
 impl ser::Serialize for CovariantOptionalExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_item = self.item.is_none();
@@ -76,9 +76,9 @@ impl ser::Serialize for CovariantOptionalExample {
     }
 }
 impl<'de> de::Deserialize<'de> for CovariantOptionalExample {
-    fn deserialize<D_>(d: D_) -> Result<CovariantOptionalExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<CovariantOptionalExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("CovariantOptionalExample", &["item"], Visitor_)
     }
@@ -89,9 +89,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<CovariantOptionalExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<CovariantOptionalExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut item = None;
         while let Some(field_) = map_.next_key()? {
@@ -114,9 +114,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -127,9 +127,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "item" => Field_::Item,

--- a/conjure-codegen/src/example_types/date_time_alias_example.rs
+++ b/conjure-codegen/src/example_types/date_time_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for DateTimeAliasExample {
     }
 }
 impl ser::Serialize for DateTimeAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for DateTimeAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<DateTimeAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<DateTimeAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(DateTimeAliasExample)
     }

--- a/conjure-codegen/src/example_types/date_time_example.rs
+++ b/conjure-codegen/src/example_types/date_time_example.rs
@@ -57,9 +57,9 @@ impl From<DateTimeExample> for Builder {
     }
 }
 impl ser::Serialize for DateTimeExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -68,9 +68,9 @@ impl ser::Serialize for DateTimeExample {
     }
 }
 impl<'de> de::Deserialize<'de> for DateTimeExample {
-    fn deserialize<D_>(d: D_) -> Result<DateTimeExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<DateTimeExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("DateTimeExample", &["datetime"], Visitor_)
     }
@@ -81,9 +81,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<DateTimeExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<DateTimeExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut datetime = None;
         while let Some(field_) = map_.next_key()? {
@@ -106,9 +106,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -119,9 +119,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "datetime" => Field_::Datetime,

--- a/conjure-codegen/src/example_types/double_alias_example.rs
+++ b/conjure-codegen/src/example_types/double_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for DoubleAliasExample {
     }
 }
 impl ser::Serialize for DoubleAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for DoubleAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<DoubleAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<DoubleAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(DoubleAliasExample)
     }

--- a/conjure-codegen/src/example_types/double_example.rs
+++ b/conjure-codegen/src/example_types/double_example.rs
@@ -57,9 +57,9 @@ impl From<DoubleExample> for Builder {
     }
 }
 impl ser::Serialize for DoubleExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -68,9 +68,9 @@ impl ser::Serialize for DoubleExample {
     }
 }
 impl<'de> de::Deserialize<'de> for DoubleExample {
-    fn deserialize<D_>(d: D_) -> Result<DoubleExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<DoubleExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("DoubleExample", &["doubleValue"], Visitor_)
     }
@@ -81,9 +81,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<DoubleExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<DoubleExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut double_value = None;
         while let Some(field_) = map_.next_key()? {
@@ -106,9 +106,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -119,9 +119,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "doubleValue" => Field_::DoubleValue,

--- a/conjure-codegen/src/example_types/empty_object_example.rs
+++ b/conjure-codegen/src/example_types/empty_object_example.rs
@@ -35,9 +35,9 @@ impl From<EmptyObjectExample> for Builder {
     }
 }
 impl ser::Serialize for EmptyObjectExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 0usize;
         let map = s.serialize_map(Some(size))?;
@@ -45,9 +45,9 @@ impl ser::Serialize for EmptyObjectExample {
     }
 }
 impl<'de> de::Deserialize<'de> for EmptyObjectExample {
-    fn deserialize<D_>(d: D_) -> Result<EmptyObjectExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<EmptyObjectExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("EmptyObjectExample", &[], Visitor_)
     }
@@ -58,9 +58,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<EmptyObjectExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<EmptyObjectExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         while let Some(field_) = map_.next_key()? {
             match field_ {
@@ -76,9 +76,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -89,9 +89,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             _ => Field_::Unknown_,

--- a/conjure-codegen/src/example_types/enum_example.rs
+++ b/conjure-codegen/src/example_types/enum_example.rs
@@ -25,17 +25,17 @@ impl fmt::Display for EnumExample {
     }
 }
 impl ser::Serialize for EnumExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         s.serialize_str(self.as_str())
     }
 }
 impl<'de> de::Deserialize<'de> for EnumExample {
-    fn deserialize<D_>(d: D_) -> Result<EnumExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<EnumExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(Visitor_)
     }
@@ -46,9 +46,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, v: &str) -> Result<EnumExample, E_>
+    fn visit_str<E>(self, v: &str) -> Result<EnumExample, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         match v {
             "ONE" => Ok(EnumExample::One),

--- a/conjure-codegen/src/example_types/enum_field_example.rs
+++ b/conjure-codegen/src/example_types/enum_field_example.rs
@@ -54,9 +54,9 @@ impl From<EnumFieldExample> for Builder {
     }
 }
 impl ser::Serialize for EnumFieldExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for EnumFieldExample {
     }
 }
 impl<'de> de::Deserialize<'de> for EnumFieldExample {
-    fn deserialize<D_>(d: D_) -> Result<EnumFieldExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<EnumFieldExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("EnumFieldExample", &["enum"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<EnumFieldExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<EnumFieldExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut enum_ = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "enum" => Field_::Enum,

--- a/conjure-codegen/src/example_types/integer_alias_example.rs
+++ b/conjure-codegen/src/example_types/integer_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for IntegerAliasExample {
     }
 }
 impl ser::Serialize for IntegerAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for IntegerAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<IntegerAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<IntegerAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(IntegerAliasExample)
     }

--- a/conjure-codegen/src/example_types/integer_example.rs
+++ b/conjure-codegen/src/example_types/integer_example.rs
@@ -54,9 +54,9 @@ impl From<IntegerExample> for Builder {
     }
 }
 impl ser::Serialize for IntegerExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for IntegerExample {
     }
 }
 impl<'de> de::Deserialize<'de> for IntegerExample {
-    fn deserialize<D_>(d: D_) -> Result<IntegerExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<IntegerExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("IntegerExample", &["integer"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<IntegerExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<IntegerExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut integer = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "integer" => Field_::Integer,

--- a/conjure-codegen/src/example_types/list_example.rs
+++ b/conjure-codegen/src/example_types/list_example.rs
@@ -129,9 +129,9 @@ impl From<ListExample> for Builder {
     }
 }
 impl ser::Serialize for ListExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_items = self.items.is_empty();
@@ -160,9 +160,9 @@ impl ser::Serialize for ListExample {
     }
 }
 impl<'de> de::Deserialize<'de> for ListExample {
-    fn deserialize<D_>(d: D_) -> Result<ListExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ListExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ListExample",
@@ -177,9 +177,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ListExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ListExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut items = None;
         let mut primitive_items = None;
@@ -220,9 +220,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -233,9 +233,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "items" => Field_::Items,

--- a/conjure-codegen/src/example_types/many_field_example.rs
+++ b/conjure-codegen/src/example_types/many_field_example.rs
@@ -170,10 +170,10 @@ impl Builder {
         self
     }
     #[doc = "docs for map field"]
-    pub fn insert_map<T, T>(&mut self, key: K, value: V) -> &mut Self
+    pub fn insert_map<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
-        T: Into<String>,
-        T: Into<String>,
+        K: Into<String>,
+        V: Into<String>,
     {
         self.map.insert(key.into(), value.into());
         self

--- a/conjure-codegen/src/example_types/many_field_example.rs
+++ b/conjure-codegen/src/example_types/many_field_example.rs
@@ -170,10 +170,10 @@ impl Builder {
         self
     }
     #[doc = "docs for map field"]
-    pub fn insert_map<K, V>(&mut self, key: K, value: V) -> &mut Self
+    pub fn insert_map<T, T>(&mut self, key: K, value: V) -> &mut Self
     where
-        K: Into<String>,
-        V: Into<String>,
+        T: Into<String>,
+        T: Into<String>,
     {
         self.map.insert(key.into(), value.into());
         self
@@ -224,9 +224,9 @@ impl From<ManyFieldExample> for Builder {
     }
 }
 impl ser::Serialize for ManyFieldExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 4usize;
         let skip_optional_item = self.optional_item.is_none();
@@ -266,9 +266,9 @@ impl ser::Serialize for ManyFieldExample {
     }
 }
 impl<'de> de::Deserialize<'de> for ManyFieldExample {
-    fn deserialize<D_>(d: D_) -> Result<ManyFieldExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ManyFieldExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ManyFieldExample",
@@ -292,9 +292,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ManyFieldExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ManyFieldExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut string = None;
         let mut integer = None;
@@ -375,9 +375,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -388,9 +388,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "string" => Field_::String,

--- a/conjure-codegen/src/example_types/map_alias_example.rs
+++ b/conjure-codegen/src/example_types/map_alias_example.rs
@@ -15,17 +15,17 @@ impl std::ops::DerefMut for MapAliasExample {
     }
 }
 impl ser::Serialize for MapAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for MapAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<MapAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<MapAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(MapAliasExample)
     }

--- a/conjure-codegen/src/example_types/map_example.rs
+++ b/conjure-codegen/src/example_types/map_example.rs
@@ -43,10 +43,10 @@ impl Builder {
         self.items.extend(items);
         self
     }
-    pub fn insert_items<K, V>(&mut self, key: K, value: V) -> &mut Self
+    pub fn insert_items<T, T>(&mut self, key: K, value: V) -> &mut Self
     where
-        K: Into<String>,
-        V: Into<String>,
+        T: Into<String>,
+        T: Into<String>,
     {
         self.items.insert(key.into(), value.into());
         self
@@ -70,9 +70,9 @@ impl From<MapExample> for Builder {
     }
 }
 impl ser::Serialize for MapExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_items = self.items.is_empty();
@@ -87,9 +87,9 @@ impl ser::Serialize for MapExample {
     }
 }
 impl<'de> de::Deserialize<'de> for MapExample {
-    fn deserialize<D_>(d: D_) -> Result<MapExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<MapExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("MapExample", &["items"], Visitor_)
     }
@@ -100,9 +100,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<MapExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<MapExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut items = None;
         while let Some(field_) = map_.next_key()? {
@@ -125,9 +125,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -138,9 +138,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "items" => Field_::Items,

--- a/conjure-codegen/src/example_types/map_example.rs
+++ b/conjure-codegen/src/example_types/map_example.rs
@@ -43,10 +43,10 @@ impl Builder {
         self.items.extend(items);
         self
     }
-    pub fn insert_items<T, T>(&mut self, key: K, value: V) -> &mut Self
+    pub fn insert_items<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
-        T: Into<String>,
-        T: Into<String>,
+        K: Into<String>,
+        V: Into<String>,
     {
         self.items.insert(key.into(), value.into());
         self

--- a/conjure-codegen/src/example_types/nested_string_alias_example.rs
+++ b/conjure-codegen/src/example_types/nested_string_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for NestedStringAliasExample {
     }
 }
 impl ser::Serialize for NestedStringAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for NestedStringAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<NestedStringAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<NestedStringAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(NestedStringAliasExample)
     }

--- a/conjure-codegen/src/example_types/optional_example.rs
+++ b/conjure-codegen/src/example_types/optional_example.rs
@@ -55,9 +55,9 @@ impl From<OptionalExample> for Builder {
     }
 }
 impl ser::Serialize for OptionalExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_item = self.item.is_none();
@@ -72,9 +72,9 @@ impl ser::Serialize for OptionalExample {
     }
 }
 impl<'de> de::Deserialize<'de> for OptionalExample {
-    fn deserialize<D_>(d: D_) -> Result<OptionalExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<OptionalExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("OptionalExample", &["item"], Visitor_)
     }
@@ -85,9 +85,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<OptionalExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<OptionalExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut item = None;
         while let Some(field_) = map_.next_key()? {
@@ -110,9 +110,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -123,9 +123,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "item" => Field_::Item,

--- a/conjure-codegen/src/example_types/primitive_optionals_example.rs
+++ b/conjure-codegen/src/example_types/primitive_optionals_example.rs
@@ -139,9 +139,9 @@ impl From<PrimitiveOptionalsExample> for Builder {
     }
 }
 impl ser::Serialize for PrimitiveOptionalsExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_num = self.num.is_none();
@@ -198,9 +198,9 @@ impl ser::Serialize for PrimitiveOptionalsExample {
     }
 }
 impl<'de> de::Deserialize<'de> for PrimitiveOptionalsExample {
-    fn deserialize<D_>(d: D_) -> Result<PrimitiveOptionalsExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<PrimitiveOptionalsExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "PrimitiveOptionalsExample",
@@ -223,9 +223,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<PrimitiveOptionalsExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<PrimitiveOptionalsExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut num = None;
         let mut bool = None;
@@ -298,9 +298,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -311,9 +311,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "num" => Field_::Num,

--- a/conjure-codegen/src/example_types/reference_alias_example.rs
+++ b/conjure-codegen/src/example_types/reference_alias_example.rs
@@ -15,17 +15,17 @@ impl std::ops::DerefMut for ReferenceAliasExample {
     }
 }
 impl ser::Serialize for ReferenceAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for ReferenceAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<ReferenceAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ReferenceAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(ReferenceAliasExample)
     }

--- a/conjure-codegen/src/example_types/reserved_key_example.rs
+++ b/conjure-codegen/src/example_types/reserved_key_example.rs
@@ -127,9 +127,9 @@ impl From<ReservedKeyExample> for Builder {
     }
 }
 impl ser::Serialize for ReservedKeyExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 5usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -145,9 +145,9 @@ impl ser::Serialize for ReservedKeyExample {
     }
 }
 impl<'de> de::Deserialize<'de> for ReservedKeyExample {
-    fn deserialize<D_>(d: D_) -> Result<ReservedKeyExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ReservedKeyExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ReservedKeyExample",
@@ -168,9 +168,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ReservedKeyExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ReservedKeyExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut package = None;
         let mut interface = None;
@@ -229,9 +229,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -242,9 +242,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "package" => Field_::Package,

--- a/conjure-codegen/src/example_types/rid_alias_example.rs
+++ b/conjure-codegen/src/example_types/rid_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for RidAliasExample {
     }
 }
 impl ser::Serialize for RidAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for RidAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<RidAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<RidAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(RidAliasExample)
     }

--- a/conjure-codegen/src/example_types/rid_example.rs
+++ b/conjure-codegen/src/example_types/rid_example.rs
@@ -54,9 +54,9 @@ impl From<RidExample> for Builder {
     }
 }
 impl ser::Serialize for RidExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for RidExample {
     }
 }
 impl<'de> de::Deserialize<'de> for RidExample {
-    fn deserialize<D_>(d: D_) -> Result<RidExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<RidExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("RidExample", &["ridValue"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<RidExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<RidExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut rid_value = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "ridValue" => Field_::RidValue,

--- a/conjure-codegen/src/example_types/safe_long_alias_example.rs
+++ b/conjure-codegen/src/example_types/safe_long_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for SafeLongAliasExample {
     }
 }
 impl ser::Serialize for SafeLongAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for SafeLongAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<SafeLongAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<SafeLongAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(SafeLongAliasExample)
     }

--- a/conjure-codegen/src/example_types/safe_long_example.rs
+++ b/conjure-codegen/src/example_types/safe_long_example.rs
@@ -59,9 +59,9 @@ impl From<SafeLongExample> for Builder {
     }
 }
 impl ser::Serialize for SafeLongExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -70,9 +70,9 @@ impl ser::Serialize for SafeLongExample {
     }
 }
 impl<'de> de::Deserialize<'de> for SafeLongExample {
-    fn deserialize<D_>(d: D_) -> Result<SafeLongExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<SafeLongExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("SafeLongExample", &["safeLongValue"], Visitor_)
     }
@@ -83,9 +83,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<SafeLongExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<SafeLongExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut safe_long_value = None;
         while let Some(field_) = map_.next_key()? {
@@ -108,9 +108,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -121,9 +121,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "safeLongValue" => Field_::SafeLongValue,

--- a/conjure-codegen/src/example_types/set_example.rs
+++ b/conjure-codegen/src/example_types/set_example.rs
@@ -69,9 +69,9 @@ impl From<SetExample> for Builder {
     }
 }
 impl ser::Serialize for SetExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 0usize;
         let skip_items = self.items.is_empty();
@@ -86,9 +86,9 @@ impl ser::Serialize for SetExample {
     }
 }
 impl<'de> de::Deserialize<'de> for SetExample {
-    fn deserialize<D_>(d: D_) -> Result<SetExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<SetExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("SetExample", &["items"], Visitor_)
     }
@@ -99,9 +99,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<SetExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<SetExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut items = None;
         while let Some(field_) = map_.next_key()? {
@@ -124,9 +124,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -137,9 +137,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "items" => Field_::Items,

--- a/conjure-codegen/src/example_types/single_union.rs
+++ b/conjure-codegen/src/example_types/single_union.rs
@@ -9,9 +9,9 @@ pub enum SingleUnion {
     Unknown(Unknown),
 }
 impl ser::Serialize for SingleUnion {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut map = s.serialize_map(Some(2))?;
         match self {
@@ -28,9 +28,9 @@ impl ser::Serialize for SingleUnion {
     }
 }
 impl<'de> de::Deserialize<'de> for SingleUnion {
-    fn deserialize<D_>(d: D_) -> Result<SingleUnion, D_::Error>
+    fn deserialize<D>(d: D) -> Result<SingleUnion, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_map(Visitor_)
     }
@@ -41,9 +41,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("union SingleUnion")
     }
-    fn visit_map<A_>(self, mut map: A_) -> Result<SingleUnion, A_::Error>
+    fn visit_map<A>(self, mut map: A) -> Result<SingleUnion, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let v = match map.next_key::<UnionField_<Variant_>>()? {
             Some(UnionField_::Type) => {
@@ -119,9 +119,9 @@ impl Variant_ {
     }
 }
 impl<'de> de::Deserialize<'de> for Variant_ {
-    fn deserialize<D_>(d: D_) -> Result<Variant_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Variant_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(VariantVisitor_)
     }
@@ -132,9 +132,9 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Variant_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Variant_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "foo" => Variant_::Foo,

--- a/conjure-codegen/src/example_types/string_alias_example.rs
+++ b/conjure-codegen/src/example_types/string_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for StringAliasExample {
     }
 }
 impl ser::Serialize for StringAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for StringAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<StringAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<StringAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(StringAliasExample)
     }

--- a/conjure-codegen/src/example_types/string_example.rs
+++ b/conjure-codegen/src/example_types/string_example.rs
@@ -59,9 +59,9 @@ impl From<StringExample> for Builder {
     }
 }
 impl ser::Serialize for StringExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -70,9 +70,9 @@ impl ser::Serialize for StringExample {
     }
 }
 impl<'de> de::Deserialize<'de> for StringExample {
-    fn deserialize<D_>(d: D_) -> Result<StringExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<StringExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("StringExample", &["string"], Visitor_)
     }
@@ -83,9 +83,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<StringExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<StringExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut string = None;
         while let Some(field_) = map_.next_key()? {
@@ -108,9 +108,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -121,9 +121,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "string" => Field_::String,

--- a/conjure-codegen/src/example_types/union_.rs
+++ b/conjure-codegen/src/example_types/union_.rs
@@ -10,9 +10,9 @@ pub enum Union {
     Unknown(Unknown),
 }
 impl ser::Serialize for Union {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut map = s.serialize_map(Some(2))?;
         match self {
@@ -33,9 +33,9 @@ impl ser::Serialize for Union {
     }
 }
 impl<'de> de::Deserialize<'de> for Union {
-    fn deserialize<D_>(d: D_) -> Result<Union, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Union, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_map(Visitor_)
     }
@@ -46,9 +46,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("union Union")
     }
-    fn visit_map<A_>(self, mut map: A_) -> Result<Union, A_::Error>
+    fn visit_map<A>(self, mut map: A) -> Result<Union, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let v = match map.next_key::<UnionField_<Variant_>>()? {
             Some(UnionField_::Type) => {
@@ -134,9 +134,9 @@ impl Variant_ {
     }
 }
 impl<'de> de::Deserialize<'de> for Variant_ {
-    fn deserialize<D_>(d: D_) -> Result<Variant_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Variant_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(VariantVisitor_)
     }
@@ -147,9 +147,9 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Variant_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Variant_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "foo" => Variant_::Foo,

--- a/conjure-codegen/src/example_types/union_type_example.rs
+++ b/conjure-codegen/src/example_types/union_type_example.rs
@@ -16,9 +16,9 @@ pub enum UnionTypeExample {
     Unknown(Unknown),
 }
 impl ser::Serialize for UnionTypeExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut map = s.serialize_map(Some(2))?;
         match self {
@@ -59,9 +59,9 @@ impl ser::Serialize for UnionTypeExample {
     }
 }
 impl<'de> de::Deserialize<'de> for UnionTypeExample {
-    fn deserialize<D_>(d: D_) -> Result<UnionTypeExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<UnionTypeExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_map(Visitor_)
     }
@@ -72,9 +72,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("union UnionTypeExample")
     }
-    fn visit_map<A_>(self, mut map: A_) -> Result<UnionTypeExample, A_::Error>
+    fn visit_map<A>(self, mut map: A) -> Result<UnionTypeExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let v = match map.next_key::<UnionField_<Variant_>>()? {
             Some(UnionField_::Type) => {
@@ -210,9 +210,9 @@ impl Variant_ {
     }
 }
 impl<'de> de::Deserialize<'de> for Variant_ {
-    fn deserialize<D_>(d: D_) -> Result<Variant_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Variant_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(VariantVisitor_)
     }
@@ -223,9 +223,9 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Variant_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Variant_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "stringExample" => Variant_::StringExample,

--- a/conjure-codegen/src/example_types/uuid_alias_example.rs
+++ b/conjure-codegen/src/example_types/uuid_alias_example.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for UuidAliasExample {
     }
 }
 impl ser::Serialize for UuidAliasExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for UuidAliasExample {
-    fn deserialize<D_>(d: D_) -> Result<UuidAliasExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<UuidAliasExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(UuidAliasExample)
     }

--- a/conjure-codegen/src/example_types/uuid_example.rs
+++ b/conjure-codegen/src/example_types/uuid_example.rs
@@ -54,9 +54,9 @@ impl From<UuidExample> for Builder {
     }
 }
 impl ser::Serialize for UuidExample {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for UuidExample {
     }
 }
 impl<'de> de::Deserialize<'de> for UuidExample {
-    fn deserialize<D_>(d: D_) -> Result<UuidExample, D_::Error>
+    fn deserialize<D>(d: D) -> Result<UuidExample, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("UuidExample", &["uuid"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<UuidExample, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<UuidExample, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut uuid = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "uuid" => Field_::Uuid,

--- a/conjure-codegen/src/objects.rs
+++ b/conjure-codegen/src/objects.rs
@@ -453,14 +453,9 @@ fn generate_setter(
                             argument_bound,
                             assign_rhs,
                         } => {
-                            let param = if ctx.type_name(def.type_name().name()) == "K" {
-                                quote!(L)
-                            } else {
-                                quote!(K)
-                            };
-                            wheres.push(quote!(T: #argument_bound));
-                            params.push(quote!(T));
-                            (param, assign_rhs)
+                            wheres.push(quote!(K: #argument_bound));
+                            params.push(quote!(K));
+                            (quote!(K), assign_rhs)
                         }
                     };
 
@@ -473,14 +468,9 @@ fn generate_setter(
                             argument_bound,
                             assign_rhs,
                         } => {
-                            let param = if ctx.type_name(def.type_name().name()) == "V" {
-                                quote!(W)
-                            } else {
-                                quote!(V)
-                            };
-                            wheres.push(quote!(T: #argument_bound));
-                            params.push(quote!(T));
-                            (param, assign_rhs)
+                            wheres.push(quote!(V: #argument_bound));
+                            params.push(quote!(V));
+                            (quote!(V), assign_rhs)
                         }
                     };
 

--- a/conjure-codegen/src/objects.rs
+++ b/conjure-codegen/src/objects.rs
@@ -330,12 +330,6 @@ fn generate_setter(
 
     let name = ctx.field_name(field.field_name());
 
-    let param = if ctx.type_name(def.type_name().name()) == "T" {
-        quote!(U)
-    } else {
-        quote!(T)
-    };
-
     match ctx.setter_bounds(def.type_name(), field.type_(), quote!(#name)) {
         SetterBounds::Simple {
             argument_type,
@@ -358,9 +352,9 @@ fn generate_setter(
             quote! {
                 #docs
                 #required
-                pub fn #name<#param>(&mut self, #name: #param) -> &mut Self
+                pub fn #name<T>(&mut self, #name: T) -> &mut Self
                 where
-                    #param: #argument_bound
+                    T: #argument_bound
                 {
                     self.#name = #assign_rhs;
                     self
@@ -393,9 +387,9 @@ fn generate_setter(
                             argument_bound,
                             assign_rhs,
                         } => (
-                            quote!(<#param>),
-                            quote!(#param),
-                            quote!(where #param: #argument_bound),
+                            quote!(<T>),
+                            quote!(T),
+                            quote!(where T: #argument_bound),
                             assign_rhs,
                         ),
                     };
@@ -424,9 +418,9 @@ fn generate_setter(
                             argument_bound,
                             assign_rhs,
                         } => (
-                            quote!(<#param>),
-                            quote!(#param),
-                            quote!(where #param: #argument_bound),
+                            quote!(<T>),
+                            quote!(T),
+                            quote!(where T: #argument_bound),
                             assign_rhs,
                         ),
                     };
@@ -464,8 +458,8 @@ fn generate_setter(
                             } else {
                                 quote!(K)
                             };
-                            wheres.push(quote!(#param: #argument_bound));
-                            params.push(quote!(#param));
+                            wheres.push(quote!(T: #argument_bound));
+                            params.push(quote!(T));
                             (param, assign_rhs)
                         }
                     };
@@ -484,8 +478,8 @@ fn generate_setter(
                             } else {
                                 quote!(V)
                             };
-                            wheres.push(quote!(#param: #argument_bound));
-                            params.push(quote!(#param));
+                            wheres.push(quote!(T: #argument_bound));
+                            params.push(quote!(T));
                             (param, assign_rhs)
                         }
                     };
@@ -515,18 +509,18 @@ fn generate_setter(
 
             quote! {
                 #docs
-                pub fn #name<#param>(&mut self, #name: #param) -> &mut Self
+                pub fn #name<T>(&mut self, #name: T) -> &mut Self
                 where
-                    #param: #argument_bound
+                    T: #argument_bound
                 {
                     self.#name = #name.into_iter().collect();
                     self
                 }
 
                 #docs
-                pub fn #extend_name<#param>(&mut self, #name: #param) -> &mut Self
+                pub fn #extend_name<T>(&mut self, #name: T) -> &mut Self
                 where
-                    #param: #argument_bound
+                    T: #argument_bound
                 {
                     self.#name.extend(#name);
                     self
@@ -596,9 +590,9 @@ fn generate_serialize(ctx: &Context, def: &ObjectDefinition) -> TokenStream {
 
     quote! {
         impl ser::Serialize for #name {
-            fn serialize<S_>(&self, s: S_) -> #result<S_::Ok, S_::Error>
+            fn serialize<S>(&self, s: S) -> #result<S::Ok, S::Error>
             where
-                S_: ser::Serializer,
+                S: ser::Serializer,
             {
                 let #size_mut size = #size;
                 #(#empty_checks)*
@@ -650,9 +644,9 @@ fn generate_deserialize(ctx: &Context, def: &ObjectDefinition) -> TokenStream {
 
     quote! {
         impl<'de> de::Deserialize<'de> for #name {
-            fn deserialize<D_>(d: D_) -> #result<#name, D_::Error>
+            fn deserialize<D>(d: D) -> #result<#name, D::Error>
             where
-                D_: de::Deserializer<'de>
+                D: de::Deserializer<'de>
             {
                 d.deserialize_struct(#name_str, &[#(#field_names, )*], Visitor_)
             }
@@ -667,9 +661,9 @@ fn generate_deserialize(ctx: &Context, def: &ObjectDefinition) -> TokenStream {
                 fmt.write_str("map")
             }
 
-            fn visit_map<A_>(self, mut map_: A_) -> #result<#name, A_::Error>
+            fn visit_map<A>(self, mut map_: A) -> #result<#name, A::Error>
             where
-                A_: de::MapAccess<'de>
+                A: de::MapAccess<'de>
             {
                 #(
                     let mut #fields = #repeat_none;
@@ -724,9 +718,9 @@ fn generate_field(ctx: &Context, def: &ObjectDefinition) -> TokenStream {
         }
 
         impl<'de> de::Deserialize<'de> for Field_ {
-            fn deserialize<D_>(d: D_) -> #result<Field_, D_::Error>
+            fn deserialize<D>(d: D) -> #result<Field_, D::Error>
             where
-                D_: de::Deserializer<'de>
+                D: de::Deserializer<'de>
             {
                 d.deserialize_str(FieldVisitor_)
             }
@@ -741,9 +735,9 @@ fn generate_field(ctx: &Context, def: &ObjectDefinition) -> TokenStream {
                 fmt.write_str("string")
             }
 
-            fn visit_str<E_>(self, value: &str) -> #result<Field_, E_>
+            fn visit_str<E>(self, value: &str) -> #result<Field_, E>
             where
-                E_: de::Error
+                E: de::Error
             {
                 let v = match value {
                     #(

--- a/conjure-codegen/src/types/alias_definition.rs
+++ b/conjure-codegen/src/types/alias_definition.rs
@@ -92,9 +92,9 @@ impl From<AliasDefinition> for Builder {
     }
 }
 impl ser::Serialize for AliasDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 2usize;
         let skip_docs = self.docs.is_none();
@@ -111,9 +111,9 @@ impl ser::Serialize for AliasDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for AliasDefinition {
-    fn deserialize<D_>(d: D_) -> Result<AliasDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<AliasDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("AliasDefinition", &["typeName", "alias", "docs"], Visitor_)
     }
@@ -124,9 +124,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<AliasDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<AliasDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut type_name = None;
         let mut alias = None;
@@ -167,9 +167,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -180,9 +180,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "typeName" => Field_::TypeName,

--- a/conjure-codegen/src/types/argument_definition.rs
+++ b/conjure-codegen/src/types/argument_definition.rs
@@ -123,9 +123,9 @@ impl From<ArgumentDefinition> for Builder {
     }
 }
 impl ser::Serialize for ArgumentDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 3usize;
         let skip_docs = self.docs.is_none();
@@ -150,9 +150,9 @@ impl ser::Serialize for ArgumentDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for ArgumentDefinition {
-    fn deserialize<D_>(d: D_) -> Result<ArgumentDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ArgumentDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ArgumentDefinition",
@@ -167,9 +167,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ArgumentDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ArgumentDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut arg_name = None;
         let mut type_ = None;
@@ -226,9 +226,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -239,9 +239,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "argName" => Field_::ArgName,

--- a/conjure-codegen/src/types/argument_name.rs
+++ b/conjure-codegen/src/types/argument_name.rs
@@ -21,17 +21,17 @@ impl std::ops::DerefMut for ArgumentName {
     }
 }
 impl ser::Serialize for ArgumentName {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for ArgumentName {
-    fn deserialize<D_>(d: D_) -> Result<ArgumentName, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ArgumentName, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(ArgumentName)
     }

--- a/conjure-codegen/src/types/auth_type.rs
+++ b/conjure-codegen/src/types/auth_type.rs
@@ -8,9 +8,9 @@ pub enum AuthType {
     Cookie(super::CookieAuthType),
 }
 impl ser::Serialize for AuthType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut map = s.serialize_map(Some(2))?;
         match self {
@@ -27,9 +27,9 @@ impl ser::Serialize for AuthType {
     }
 }
 impl<'de> de::Deserialize<'de> for AuthType {
-    fn deserialize<D_>(d: D_) -> Result<AuthType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<AuthType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_map(Visitor_)
     }
@@ -40,9 +40,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("union AuthType")
     }
-    fn visit_map<A_>(self, mut map: A_) -> Result<AuthType, A_::Error>
+    fn visit_map<A>(self, mut map: A) -> Result<AuthType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let v = match map.next_key::<UnionField_<Variant_>>()? {
             Some(UnionField_::Type) => {
@@ -111,9 +111,9 @@ impl Variant_ {
     }
 }
 impl<'de> de::Deserialize<'de> for Variant_ {
-    fn deserialize<D_>(d: D_) -> Result<Variant_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Variant_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(VariantVisitor_)
     }
@@ -124,9 +124,9 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Variant_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Variant_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "header" => Variant_::Header,

--- a/conjure-codegen/src/types/body_parameter_type.rs
+++ b/conjure-codegen/src/types/body_parameter_type.rs
@@ -35,9 +35,9 @@ impl From<BodyParameterType> for Builder {
     }
 }
 impl ser::Serialize for BodyParameterType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 0usize;
         let map = s.serialize_map(Some(size))?;
@@ -45,9 +45,9 @@ impl ser::Serialize for BodyParameterType {
     }
 }
 impl<'de> de::Deserialize<'de> for BodyParameterType {
-    fn deserialize<D_>(d: D_) -> Result<BodyParameterType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<BodyParameterType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("BodyParameterType", &[], Visitor_)
     }
@@ -58,9 +58,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<BodyParameterType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<BodyParameterType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         while let Some(field_) = map_.next_key()? {
             match field_ {
@@ -76,9 +76,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -89,9 +89,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             _ => Field_::Unknown_,

--- a/conjure-codegen/src/types/conjure_definition.rs
+++ b/conjure-codegen/src/types/conjure_definition.rs
@@ -127,9 +127,9 @@ impl From<ConjureDefinition> for Builder {
     }
 }
 impl ser::Serialize for ConjureDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 1usize;
         let skip_errors = self.errors.is_empty();
@@ -159,9 +159,9 @@ impl ser::Serialize for ConjureDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for ConjureDefinition {
-    fn deserialize<D_>(d: D_) -> Result<ConjureDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ConjureDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ConjureDefinition",
@@ -176,9 +176,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ConjureDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ConjureDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut version = None;
         let mut errors = None;
@@ -227,9 +227,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -240,9 +240,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "version" => Field_::Version,

--- a/conjure-codegen/src/types/cookie_auth_type.rs
+++ b/conjure-codegen/src/types/cookie_auth_type.rs
@@ -62,9 +62,9 @@ impl From<CookieAuthType> for Builder {
     }
 }
 impl ser::Serialize for CookieAuthType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -73,9 +73,9 @@ impl ser::Serialize for CookieAuthType {
     }
 }
 impl<'de> de::Deserialize<'de> for CookieAuthType {
-    fn deserialize<D_>(d: D_) -> Result<CookieAuthType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<CookieAuthType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("CookieAuthType", &["cookieName"], Visitor_)
     }
@@ -86,9 +86,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<CookieAuthType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<CookieAuthType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut cookie_name = None;
         while let Some(field_) = map_.next_key()? {
@@ -111,9 +111,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -124,9 +124,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "cookieName" => Field_::CookieName,

--- a/conjure-codegen/src/types/documentation.rs
+++ b/conjure-codegen/src/types/documentation.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for Documentation {
     }
 }
 impl ser::Serialize for Documentation {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for Documentation {
-    fn deserialize<D_>(d: D_) -> Result<Documentation, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Documentation, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(Documentation)
     }

--- a/conjure-codegen/src/types/endpoint_definition.rs
+++ b/conjure-codegen/src/types/endpoint_definition.rs
@@ -197,9 +197,9 @@ impl From<EndpointDefinition> for Builder {
     }
 }
 impl ser::Serialize for EndpointDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 3usize;
         let skip_auth = self.auth.is_none();
@@ -252,9 +252,9 @@ impl ser::Serialize for EndpointDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for EndpointDefinition {
-    fn deserialize<D_>(d: D_) -> Result<EndpointDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<EndpointDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "EndpointDefinition",
@@ -279,9 +279,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<EndpointDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<EndpointDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut endpoint_name = None;
         let mut http_method = None;
@@ -370,9 +370,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -383,9 +383,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "endpointName" => Field_::EndpointName,

--- a/conjure-codegen/src/types/endpoint_name.rs
+++ b/conjure-codegen/src/types/endpoint_name.rs
@@ -21,17 +21,17 @@ impl std::ops::DerefMut for EndpointName {
     }
 }
 impl ser::Serialize for EndpointName {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for EndpointName {
-    fn deserialize<D_>(d: D_) -> Result<EndpointName, D_::Error>
+    fn deserialize<D>(d: D) -> Result<EndpointName, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(EndpointName)
     }

--- a/conjure-codegen/src/types/enum_definition.rs
+++ b/conjure-codegen/src/types/enum_definition.rs
@@ -106,9 +106,9 @@ impl From<EnumDefinition> for Builder {
     }
 }
 impl ser::Serialize for EnumDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 1usize;
         let skip_values = self.values.is_empty();
@@ -131,9 +131,9 @@ impl ser::Serialize for EnumDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for EnumDefinition {
-    fn deserialize<D_>(d: D_) -> Result<EnumDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<EnumDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("EnumDefinition", &["typeName", "values", "docs"], Visitor_)
     }
@@ -144,9 +144,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<EnumDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<EnumDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut type_name = None;
         let mut values = None;
@@ -187,9 +187,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -200,9 +200,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "typeName" => Field_::TypeName,

--- a/conjure-codegen/src/types/enum_value_definition.rs
+++ b/conjure-codegen/src/types/enum_value_definition.rs
@@ -77,9 +77,9 @@ impl From<EnumValueDefinition> for Builder {
     }
 }
 impl ser::Serialize for EnumValueDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 1usize;
         let skip_docs = self.docs.is_none();
@@ -95,9 +95,9 @@ impl ser::Serialize for EnumValueDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for EnumValueDefinition {
-    fn deserialize<D_>(d: D_) -> Result<EnumValueDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<EnumValueDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("EnumValueDefinition", &["value", "docs"], Visitor_)
     }
@@ -108,9 +108,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<EnumValueDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<EnumValueDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut value = None;
         let mut docs = None;
@@ -140,9 +140,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -153,9 +153,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "value" => Field_::Value,

--- a/conjure-codegen/src/types/error_code.rs
+++ b/conjure-codegen/src/types/error_code.rs
@@ -37,17 +37,17 @@ impl fmt::Display for ErrorCode {
     }
 }
 impl ser::Serialize for ErrorCode {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         s.serialize_str(self.as_str())
     }
 }
 impl<'de> de::Deserialize<'de> for ErrorCode {
-    fn deserialize<D_>(d: D_) -> Result<ErrorCode, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ErrorCode, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(Visitor_)
     }
@@ -58,9 +58,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, v: &str) -> Result<ErrorCode, E_>
+    fn visit_str<E>(self, v: &str) -> Result<ErrorCode, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         match v {
             "PERMISSION_DENIED" => Ok(ErrorCode::PermissionDenied),

--- a/conjure-codegen/src/types/error_definition.rs
+++ b/conjure-codegen/src/types/error_definition.rs
@@ -149,9 +149,9 @@ impl From<ErrorDefinition> for Builder {
     }
 }
 impl ser::Serialize for ErrorDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 3usize;
         let skip_docs = self.docs.is_none();
@@ -183,9 +183,9 @@ impl ser::Serialize for ErrorDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for ErrorDefinition {
-    fn deserialize<D_>(d: D_) -> Result<ErrorDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ErrorDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ErrorDefinition",
@@ -207,9 +207,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ErrorDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ErrorDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut error_name = None;
         let mut docs = None;
@@ -274,9 +274,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -287,9 +287,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "errorName" => Field_::ErrorName,

--- a/conjure-codegen/src/types/error_namespace.rs
+++ b/conjure-codegen/src/types/error_namespace.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for ErrorNamespace {
     }
 }
 impl ser::Serialize for ErrorNamespace {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for ErrorNamespace {
-    fn deserialize<D_>(d: D_) -> Result<ErrorNamespace, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ErrorNamespace, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(ErrorNamespace)
     }

--- a/conjure-codegen/src/types/external_reference.rs
+++ b/conjure-codegen/src/types/external_reference.rs
@@ -79,9 +79,9 @@ impl From<ExternalReference> for Builder {
     }
 }
 impl ser::Serialize for ExternalReference {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 2usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -91,9 +91,9 @@ impl ser::Serialize for ExternalReference {
     }
 }
 impl<'de> de::Deserialize<'de> for ExternalReference {
-    fn deserialize<D_>(d: D_) -> Result<ExternalReference, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ExternalReference, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ExternalReference",
@@ -108,9 +108,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ExternalReference, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ExternalReference, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut external_reference = None;
         let mut fallback = None;
@@ -143,9 +143,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -156,9 +156,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "externalReference" => Field_::ExternalReference,

--- a/conjure-codegen/src/types/field_definition.rs
+++ b/conjure-codegen/src/types/field_definition.rs
@@ -95,9 +95,9 @@ impl From<FieldDefinition> for Builder {
     }
 }
 impl ser::Serialize for FieldDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 2usize;
         let skip_docs = self.docs.is_none();
@@ -114,9 +114,9 @@ impl ser::Serialize for FieldDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for FieldDefinition {
-    fn deserialize<D_>(d: D_) -> Result<FieldDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<FieldDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("FieldDefinition", &["fieldName", "type", "docs"], Visitor_)
     }
@@ -127,9 +127,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<FieldDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<FieldDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut field_name = None;
         let mut type_ = None;
@@ -170,9 +170,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -183,9 +183,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "fieldName" => Field_::FieldName,

--- a/conjure-codegen/src/types/field_name.rs
+++ b/conjure-codegen/src/types/field_name.rs
@@ -21,17 +21,17 @@ impl std::ops::DerefMut for FieldName {
     }
 }
 impl ser::Serialize for FieldName {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for FieldName {
-    fn deserialize<D_>(d: D_) -> Result<FieldName, D_::Error>
+    fn deserialize<D>(d: D) -> Result<FieldName, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(FieldName)
     }

--- a/conjure-codegen/src/types/header_auth_type.rs
+++ b/conjure-codegen/src/types/header_auth_type.rs
@@ -35,9 +35,9 @@ impl From<HeaderAuthType> for Builder {
     }
 }
 impl ser::Serialize for HeaderAuthType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 0usize;
         let map = s.serialize_map(Some(size))?;
@@ -45,9 +45,9 @@ impl ser::Serialize for HeaderAuthType {
     }
 }
 impl<'de> de::Deserialize<'de> for HeaderAuthType {
-    fn deserialize<D_>(d: D_) -> Result<HeaderAuthType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<HeaderAuthType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("HeaderAuthType", &[], Visitor_)
     }
@@ -58,9 +58,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<HeaderAuthType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<HeaderAuthType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         while let Some(field_) = map_.next_key()? {
             match field_ {
@@ -76,9 +76,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -89,9 +89,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             _ => Field_::Unknown_,

--- a/conjure-codegen/src/types/header_parameter_type.rs
+++ b/conjure-codegen/src/types/header_parameter_type.rs
@@ -54,9 +54,9 @@ impl From<HeaderParameterType> for Builder {
     }
 }
 impl ser::Serialize for HeaderParameterType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for HeaderParameterType {
     }
 }
 impl<'de> de::Deserialize<'de> for HeaderParameterType {
-    fn deserialize<D_>(d: D_) -> Result<HeaderParameterType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<HeaderParameterType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("HeaderParameterType", &["paramId"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<HeaderParameterType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<HeaderParameterType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut param_id = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "paramId" => Field_::ParamId,

--- a/conjure-codegen/src/types/http_method.rs
+++ b/conjure-codegen/src/types/http_method.rs
@@ -25,17 +25,17 @@ impl fmt::Display for HttpMethod {
     }
 }
 impl ser::Serialize for HttpMethod {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         s.serialize_str(self.as_str())
     }
 }
 impl<'de> de::Deserialize<'de> for HttpMethod {
-    fn deserialize<D_>(d: D_) -> Result<HttpMethod, D_::Error>
+    fn deserialize<D>(d: D) -> Result<HttpMethod, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(Visitor_)
     }
@@ -46,9 +46,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, v: &str) -> Result<HttpMethod, E_>
+    fn visit_str<E>(self, v: &str) -> Result<HttpMethod, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         match v {
             "GET" => Ok(HttpMethod::Get),

--- a/conjure-codegen/src/types/http_path.rs
+++ b/conjure-codegen/src/types/http_path.rs
@@ -20,17 +20,17 @@ impl std::ops::DerefMut for HttpPath {
     }
 }
 impl ser::Serialize for HttpPath {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for HttpPath {
-    fn deserialize<D_>(d: D_) -> Result<HttpPath, D_::Error>
+    fn deserialize<D>(d: D) -> Result<HttpPath, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(HttpPath)
     }

--- a/conjure-codegen/src/types/list_type.rs
+++ b/conjure-codegen/src/types/list_type.rs
@@ -54,9 +54,9 @@ impl From<ListType> for Builder {
     }
 }
 impl ser::Serialize for ListType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for ListType {
     }
 }
 impl<'de> de::Deserialize<'de> for ListType {
-    fn deserialize<D_>(d: D_) -> Result<ListType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ListType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("ListType", &["itemType"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ListType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ListType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut item_type = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "itemType" => Field_::ItemType,

--- a/conjure-codegen/src/types/map_type.rs
+++ b/conjure-codegen/src/types/map_type.rs
@@ -75,9 +75,9 @@ impl From<MapType> for Builder {
     }
 }
 impl ser::Serialize for MapType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 2usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -87,9 +87,9 @@ impl ser::Serialize for MapType {
     }
 }
 impl<'de> de::Deserialize<'de> for MapType {
-    fn deserialize<D_>(d: D_) -> Result<MapType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<MapType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("MapType", &["keyType", "valueType"], Visitor_)
     }
@@ -100,9 +100,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<MapType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<MapType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut key_type = None;
         let mut value_type = None;
@@ -135,9 +135,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -148,9 +148,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "keyType" => Field_::KeyType,

--- a/conjure-codegen/src/types/object_definition.rs
+++ b/conjure-codegen/src/types/object_definition.rs
@@ -106,9 +106,9 @@ impl From<ObjectDefinition> for Builder {
     }
 }
 impl ser::Serialize for ObjectDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 1usize;
         let skip_fields = self.fields.is_empty();
@@ -131,9 +131,9 @@ impl ser::Serialize for ObjectDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for ObjectDefinition {
-    fn deserialize<D_>(d: D_) -> Result<ObjectDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ObjectDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ObjectDefinition",
@@ -148,9 +148,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ObjectDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ObjectDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut type_name = None;
         let mut fields = None;
@@ -191,9 +191,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -204,9 +204,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "typeName" => Field_::TypeName,

--- a/conjure-codegen/src/types/optional_type.rs
+++ b/conjure-codegen/src/types/optional_type.rs
@@ -54,9 +54,9 @@ impl From<OptionalType> for Builder {
     }
 }
 impl ser::Serialize for OptionalType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for OptionalType {
     }
 }
 impl<'de> de::Deserialize<'de> for OptionalType {
-    fn deserialize<D_>(d: D_) -> Result<OptionalType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<OptionalType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("OptionalType", &["itemType"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<OptionalType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<OptionalType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut item_type = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "itemType" => Field_::ItemType,

--- a/conjure-codegen/src/types/parameter_id.rs
+++ b/conjure-codegen/src/types/parameter_id.rs
@@ -21,17 +21,17 @@ impl std::ops::DerefMut for ParameterId {
     }
 }
 impl ser::Serialize for ParameterId {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         self.0.serialize(s)
     }
 }
 impl<'de> de::Deserialize<'de> for ParameterId {
-    fn deserialize<D_>(d: D_) -> Result<ParameterId, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ParameterId, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         de::Deserialize::deserialize(d).map(ParameterId)
     }

--- a/conjure-codegen/src/types/parameter_type.rs
+++ b/conjure-codegen/src/types/parameter_type.rs
@@ -10,9 +10,9 @@ pub enum ParameterType {
     Query(super::QueryParameterType),
 }
 impl ser::Serialize for ParameterType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut map = s.serialize_map(Some(2))?;
         match self {
@@ -37,9 +37,9 @@ impl ser::Serialize for ParameterType {
     }
 }
 impl<'de> de::Deserialize<'de> for ParameterType {
-    fn deserialize<D_>(d: D_) -> Result<ParameterType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ParameterType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_map(Visitor_)
     }
@@ -50,9 +50,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("union ParameterType")
     }
-    fn visit_map<A_>(self, mut map: A_) -> Result<ParameterType, A_::Error>
+    fn visit_map<A>(self, mut map: A) -> Result<ParameterType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let v = match map.next_key::<UnionField_<Variant_>>()? {
             Some(UnionField_::Type) => {
@@ -141,9 +141,9 @@ impl Variant_ {
     }
 }
 impl<'de> de::Deserialize<'de> for Variant_ {
-    fn deserialize<D_>(d: D_) -> Result<Variant_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Variant_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(VariantVisitor_)
     }
@@ -154,9 +154,9 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Variant_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Variant_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "body" => Variant_::Body,

--- a/conjure-codegen/src/types/path_parameter_type.rs
+++ b/conjure-codegen/src/types/path_parameter_type.rs
@@ -35,9 +35,9 @@ impl From<PathParameterType> for Builder {
     }
 }
 impl ser::Serialize for PathParameterType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 0usize;
         let map = s.serialize_map(Some(size))?;
@@ -45,9 +45,9 @@ impl ser::Serialize for PathParameterType {
     }
 }
 impl<'de> de::Deserialize<'de> for PathParameterType {
-    fn deserialize<D_>(d: D_) -> Result<PathParameterType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<PathParameterType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("PathParameterType", &[], Visitor_)
     }
@@ -58,9 +58,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<PathParameterType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<PathParameterType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         while let Some(field_) = map_.next_key()? {
             match field_ {
@@ -76,9 +76,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -89,9 +89,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             _ => Field_::Unknown_,

--- a/conjure-codegen/src/types/primitive_type.rs
+++ b/conjure-codegen/src/types/primitive_type.rs
@@ -39,17 +39,17 @@ impl fmt::Display for PrimitiveType {
     }
 }
 impl ser::Serialize for PrimitiveType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         s.serialize_str(self.as_str())
     }
 }
 impl<'de> de::Deserialize<'de> for PrimitiveType {
-    fn deserialize<D_>(d: D_) -> Result<PrimitiveType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<PrimitiveType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(Visitor_)
     }
@@ -60,9 +60,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, v: &str) -> Result<PrimitiveType, E_>
+    fn visit_str<E>(self, v: &str) -> Result<PrimitiveType, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         match v {
             "STRING" => Ok(PrimitiveType::String),

--- a/conjure-codegen/src/types/query_parameter_type.rs
+++ b/conjure-codegen/src/types/query_parameter_type.rs
@@ -54,9 +54,9 @@ impl From<QueryParameterType> for Builder {
     }
 }
 impl ser::Serialize for QueryParameterType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for QueryParameterType {
     }
 }
 impl<'de> de::Deserialize<'de> for QueryParameterType {
-    fn deserialize<D_>(d: D_) -> Result<QueryParameterType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<QueryParameterType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("QueryParameterType", &["paramId"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<QueryParameterType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<QueryParameterType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut param_id = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "paramId" => Field_::ParamId,

--- a/conjure-codegen/src/types/service_definition.rs
+++ b/conjure-codegen/src/types/service_definition.rs
@@ -109,9 +109,9 @@ impl From<ServiceDefinition> for Builder {
     }
 }
 impl ser::Serialize for ServiceDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 1usize;
         let skip_endpoints = self.endpoints.is_empty();
@@ -134,9 +134,9 @@ impl ser::Serialize for ServiceDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for ServiceDefinition {
-    fn deserialize<D_>(d: D_) -> Result<ServiceDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<ServiceDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct(
             "ServiceDefinition",
@@ -151,9 +151,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<ServiceDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<ServiceDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut service_name = None;
         let mut endpoints = None;
@@ -194,9 +194,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -207,9 +207,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "serviceName" => Field_::ServiceName,

--- a/conjure-codegen/src/types/set_type.rs
+++ b/conjure-codegen/src/types/set_type.rs
@@ -54,9 +54,9 @@ impl From<SetType> for Builder {
     }
 }
 impl ser::Serialize for SetType {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 1usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -65,9 +65,9 @@ impl ser::Serialize for SetType {
     }
 }
 impl<'de> de::Deserialize<'de> for SetType {
-    fn deserialize<D_>(d: D_) -> Result<SetType, D_::Error>
+    fn deserialize<D>(d: D) -> Result<SetType, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("SetType", &["itemType"], Visitor_)
     }
@@ -78,9 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<SetType, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<SetType, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut item_type = None;
         while let Some(field_) = map_.next_key()? {
@@ -103,9 +103,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -116,9 +116,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "itemType" => Field_::ItemType,

--- a/conjure-codegen/src/types/type_.rs
+++ b/conjure-codegen/src/types/type_.rs
@@ -14,9 +14,9 @@ pub enum Type {
     External(super::ExternalReference),
 }
 impl ser::Serialize for Type {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut map = s.serialize_map(Some(2))?;
         match self {
@@ -53,9 +53,9 @@ impl ser::Serialize for Type {
     }
 }
 impl<'de> de::Deserialize<'de> for Type {
-    fn deserialize<D_>(d: D_) -> Result<Type, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Type, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_map(Visitor_)
     }
@@ -66,9 +66,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("union Type")
     }
-    fn visit_map<A_>(self, mut map: A_) -> Result<Type, A_::Error>
+    fn visit_map<A>(self, mut map: A) -> Result<Type, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let v = match map.next_key::<UnionField_<Variant_>>()? {
             Some(UnionField_::Type) => {
@@ -187,9 +187,9 @@ impl Variant_ {
     }
 }
 impl<'de> de::Deserialize<'de> for Variant_ {
-    fn deserialize<D_>(d: D_) -> Result<Variant_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Variant_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(VariantVisitor_)
     }
@@ -200,9 +200,9 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Variant_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Variant_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "primitive" => Variant_::Primitive,

--- a/conjure-codegen/src/types/type_definition.rs
+++ b/conjure-codegen/src/types/type_definition.rs
@@ -10,9 +10,9 @@ pub enum TypeDefinition {
     Union(super::UnionDefinition),
 }
 impl ser::Serialize for TypeDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut map = s.serialize_map(Some(2))?;
         match self {
@@ -37,9 +37,9 @@ impl ser::Serialize for TypeDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for TypeDefinition {
-    fn deserialize<D_>(d: D_) -> Result<TypeDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<TypeDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_map(Visitor_)
     }
@@ -50,9 +50,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("union TypeDefinition")
     }
-    fn visit_map<A_>(self, mut map: A_) -> Result<TypeDefinition, A_::Error>
+    fn visit_map<A>(self, mut map: A) -> Result<TypeDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let v = match map.next_key::<UnionField_<Variant_>>()? {
             Some(UnionField_::Type) => {
@@ -141,9 +141,9 @@ impl Variant_ {
     }
 }
 impl<'de> de::Deserialize<'de> for Variant_ {
-    fn deserialize<D_>(d: D_) -> Result<Variant_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Variant_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(VariantVisitor_)
     }
@@ -154,9 +154,9 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Variant_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Variant_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "alias" => Variant_::Alias,

--- a/conjure-codegen/src/types/type_name.rs
+++ b/conjure-codegen/src/types/type_name.rs
@@ -81,9 +81,9 @@ impl From<TypeName> for Builder {
     }
 }
 impl ser::Serialize for TypeName {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let size = 2usize;
         let mut map = s.serialize_map(Some(size))?;
@@ -93,9 +93,9 @@ impl ser::Serialize for TypeName {
     }
 }
 impl<'de> de::Deserialize<'de> for TypeName {
-    fn deserialize<D_>(d: D_) -> Result<TypeName, D_::Error>
+    fn deserialize<D>(d: D) -> Result<TypeName, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("TypeName", &["name", "package"], Visitor_)
     }
@@ -106,9 +106,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<TypeName, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<TypeName, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut name = None;
         let mut package = None;
@@ -138,9 +138,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -151,9 +151,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "name" => Field_::Name,

--- a/conjure-codegen/src/types/union_definition.rs
+++ b/conjure-codegen/src/types/union_definition.rs
@@ -106,9 +106,9 @@ impl From<UnionDefinition> for Builder {
     }
 }
 impl ser::Serialize for UnionDefinition {
-    fn serialize<S_>(&self, s: S_) -> Result<S_::Ok, S_::Error>
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
-        S_: ser::Serializer,
+        S: ser::Serializer,
     {
         let mut size = 1usize;
         let skip_union_ = self.union_.is_empty();
@@ -131,9 +131,9 @@ impl ser::Serialize for UnionDefinition {
     }
 }
 impl<'de> de::Deserialize<'de> for UnionDefinition {
-    fn deserialize<D_>(d: D_) -> Result<UnionDefinition, D_::Error>
+    fn deserialize<D>(d: D) -> Result<UnionDefinition, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_struct("UnionDefinition", &["typeName", "union", "docs"], Visitor_)
     }
@@ -144,9 +144,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("map")
     }
-    fn visit_map<A_>(self, mut map_: A_) -> Result<UnionDefinition, A_::Error>
+    fn visit_map<A>(self, mut map_: A) -> Result<UnionDefinition, A::Error>
     where
-        A_: de::MapAccess<'de>,
+        A: de::MapAccess<'de>,
     {
         let mut type_name = None;
         let mut union_ = None;
@@ -187,9 +187,9 @@ enum Field_ {
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
-    fn deserialize<D_>(d: D_) -> Result<Field_, D_::Error>
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
     where
-        D_: de::Deserializer<'de>,
+        D: de::Deserializer<'de>,
     {
         d.deserialize_str(FieldVisitor_)
     }
@@ -200,9 +200,9 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
     fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.write_str("string")
     }
-    fn visit_str<E_>(self, value: &str) -> Result<Field_, E_>
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
     where
-        E_: de::Error,
+        E: de::Error,
     {
         let v = match value {
             "typeName" => Field_::TypeName,

--- a/conjure-codegen/src/unions.rs
+++ b/conjure-codegen/src/unions.rs
@@ -115,9 +115,9 @@ fn generate_enum(ctx: &Context, def: &UnionDefinition) -> TokenStream {
         }
 
         impl ser::Serialize for #name {
-            fn serialize<S_>(&self, s: S_) -> #result<S_::Ok, S_::Error>
+            fn serialize<S>(&self, s: S) -> #result<S::Ok, S::Error>
             where
-                S_: ser::Serializer
+                S: ser::Serializer
             {
                 let mut map = s.serialize_map(#some(2))?;
 
@@ -190,9 +190,9 @@ fn generate_deserialize(ctx: &Context, def: &UnionDefinition) -> TokenStream {
 
     quote! {
         impl<'de> de::Deserialize<'de> for #name {
-            fn deserialize<D_>(d: D_) -> #result<#name, D_::Error>
+            fn deserialize<D>(d: D) -> #result<#name, D::Error>
             where
-                D_: de::Deserializer<'de>
+                D: de::Deserializer<'de>
             {
                 d.deserialize_map(Visitor_)
             }
@@ -207,9 +207,9 @@ fn generate_deserialize(ctx: &Context, def: &UnionDefinition) -> TokenStream {
                 fmt.write_str(#expecting)
             }
 
-            fn visit_map<A_>(self, mut map: A_) -> #result<#name, A_::Error>
+            fn visit_map<A>(self, mut map: A) -> #result<#name, A::Error>
             where
-                A_: de::MapAccess<'de>
+                A: de::MapAccess<'de>
             {
                 let v = match map.next_key::<UnionField_<Variant_>>()? {
                     #some(UnionField_::Type) => {
@@ -328,9 +328,9 @@ fn generate_variant(ctx: &Context, def: &UnionDefinition) -> TokenStream {
         }
 
         impl<'de> de::Deserialize<'de> for Variant_ {
-            fn deserialize<D_>(d: D_) -> #result<Variant_, D_::Error>
+            fn deserialize<D>(d: D) -> #result<Variant_, D::Error>
             where
-                D_: de::Deserializer<'de>
+                D: de::Deserializer<'de>
             {
                 d.deserialize_str(VariantVisitor_)
             }
@@ -345,9 +345,9 @@ fn generate_variant(ctx: &Context, def: &UnionDefinition) -> TokenStream {
                 fmt.write_str("string")
             }
 
-            fn visit_str<E_>(self, value: &str) -> #result<Variant_, E_>
+            fn visit_str<E>(self, value: &str) -> #result<Variant_, E>
             where
-                E_: de::Error,
+                E: de::Error,
             {
                 let v = match value {
                     #(


### PR DESCRIPTION
Conjure type names can't be single character so we don't need to worry
about collisions here.
