### PR TITLE
Fix constructors

### DIFF
--- a/conjure-codegen/src/example_types/any_example.rs
+++ b/conjure-codegen/src/example_types/any_example.rs
@@ -12,7 +12,9 @@ impl AnyExample {
     where
         T: conjure_object::serde::Serialize,
     {
-        AnyExample::builder().any(any).build()
+        AnyExample {
+            any: conjure_object::serde_value::to_value(any).expect("value failed to serialize"),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/any_map_example.rs
+++ b/conjure-codegen/src/example_types/any_map_example.rs
@@ -12,7 +12,9 @@ impl AnyMapExample {
     where
         T: IntoIterator<Item = (String, conjure_object::Value)>,
     {
-        AnyMapExample::builder().items(items).build()
+        AnyMapExample {
+            items: items.into_iter().collect(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/bearer_token_example.rs
+++ b/conjure-codegen/src/example_types/bearer_token_example.rs
@@ -9,9 +9,9 @@ impl BearerTokenExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(bearer_token_value: conjure_object::BearerToken) -> BearerTokenExample {
-        BearerTokenExample::builder()
-            .bearer_token_value(bearer_token_value)
-            .build()
+        BearerTokenExample {
+            bearer_token_value: bearer_token_value,
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/binary_example.rs
+++ b/conjure-codegen/src/example_types/binary_example.rs
@@ -12,7 +12,9 @@ impl BinaryExample {
     where
         T: Into<Vec<u8>>,
     {
-        BinaryExample::builder().binary(binary).build()
+        BinaryExample {
+            binary: binary.into().into(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/boolean_example.rs
+++ b/conjure-codegen/src/example_types/boolean_example.rs
@@ -9,7 +9,7 @@ impl BooleanExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(coin: bool) -> BooleanExample {
-        BooleanExample::builder().coin(coin).build()
+        BooleanExample { coin: coin }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/covariant_list_example.rs
+++ b/conjure-codegen/src/example_types/covariant_list_example.rs
@@ -14,10 +14,10 @@ impl CovariantListExample {
         T: IntoIterator<Item = conjure_object::Value>,
         U: IntoIterator<Item = String>,
     {
-        CovariantListExample::builder()
-            .items(items)
-            .external_items(external_items)
-            .build()
+        CovariantListExample {
+            items: items.into_iter().collect(),
+            external_items: external_items.into_iter().collect(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/covariant_optional_example.rs
+++ b/conjure-codegen/src/example_types/covariant_optional_example.rs
@@ -12,11 +12,11 @@ impl CovariantOptionalExample {
     where
         T: conjure_object::serde::Serialize,
     {
-        CovariantOptionalExample::builder()
-            .item(Some(
+        CovariantOptionalExample {
+            item: Some(
                 conjure_object::serde_value::to_value(item).expect("value failed to serialize"),
-            ))
-            .build()
+            ),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/date_time_example.rs
+++ b/conjure-codegen/src/example_types/date_time_example.rs
@@ -9,7 +9,7 @@ impl DateTimeExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(datetime: conjure_object::DateTime<conjure_object::Utc>) -> DateTimeExample {
-        DateTimeExample::builder().datetime(datetime).build()
+        DateTimeExample { datetime: datetime }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/double_example.rs
+++ b/conjure-codegen/src/example_types/double_example.rs
@@ -9,7 +9,9 @@ impl DoubleExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(double_value: f64) -> DoubleExample {
-        DoubleExample::builder().double_value(double_value).build()
+        DoubleExample {
+            double_value: double_value,
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/empty_object_example.rs
+++ b/conjure-codegen/src/example_types/empty_object_example.rs
@@ -7,7 +7,7 @@ impl EmptyObjectExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new() -> EmptyObjectExample {
-        EmptyObjectExample::builder().build()
+        EmptyObjectExample {}
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/enum_field_example.rs
+++ b/conjure-codegen/src/example_types/enum_field_example.rs
@@ -9,7 +9,7 @@ impl EnumFieldExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(enum_: super::EnumExample) -> EnumFieldExample {
-        EnumFieldExample::builder().enum_(enum_).build()
+        EnumFieldExample { enum_: enum_ }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/integer_example.rs
+++ b/conjure-codegen/src/example_types/integer_example.rs
@@ -9,7 +9,7 @@ impl IntegerExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(integer: i32) -> IntegerExample {
-        IntegerExample::builder().integer(integer).build()
+        IntegerExample { integer: integer }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/list_example.rs
+++ b/conjure-codegen/src/example_types/list_example.rs
@@ -16,11 +16,11 @@ impl ListExample {
         U: IntoIterator<Item = i32>,
         V: IntoIterator<Item = f64>,
     {
-        ListExample::builder()
-            .items(items)
-            .primitive_items(primitive_items)
-            .double_items(double_items)
-            .build()
+        ListExample {
+            items: items.into_iter().collect(),
+            primitive_items: primitive_items.into_iter().collect(),
+            double_items: double_items.into_iter().collect(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/map_example.rs
+++ b/conjure-codegen/src/example_types/map_example.rs
@@ -12,7 +12,9 @@ impl MapExample {
     where
         T: IntoIterator<Item = (String, String)>,
     {
-        MapExample::builder().items(items).build()
+        MapExample {
+            items: items.into_iter().collect(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/optional_example.rs
+++ b/conjure-codegen/src/example_types/optional_example.rs
@@ -12,7 +12,9 @@ impl OptionalExample {
     where
         T: Into<String>,
     {
-        OptionalExample::builder().item(Some(item.into())).build()
+        OptionalExample {
+            item: Some(item.into()),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/rid_example.rs
+++ b/conjure-codegen/src/example_types/rid_example.rs
@@ -9,7 +9,9 @@ impl RidExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(rid_value: conjure_object::ResourceIdentifier) -> RidExample {
-        RidExample::builder().rid_value(rid_value).build()
+        RidExample {
+            rid_value: rid_value,
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/safe_long_example.rs
+++ b/conjure-codegen/src/example_types/safe_long_example.rs
@@ -9,9 +9,9 @@ impl SafeLongExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(safe_long_value: conjure_object::SafeLong) -> SafeLongExample {
-        SafeLongExample::builder()
-            .safe_long_value(safe_long_value)
-            .build()
+        SafeLongExample {
+            safe_long_value: safe_long_value,
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/set_example.rs
+++ b/conjure-codegen/src/example_types/set_example.rs
@@ -12,7 +12,9 @@ impl SetExample {
     where
         T: IntoIterator<Item = String>,
     {
-        SetExample::builder().items(items).build()
+        SetExample {
+            items: items.into_iter().collect(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/string_example.rs
+++ b/conjure-codegen/src/example_types/string_example.rs
@@ -12,7 +12,9 @@ impl StringExample {
     where
         T: Into<String>,
     {
-        StringExample::builder().string(string).build()
+        StringExample {
+            string: string.into(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/example_types/uuid_example.rs
+++ b/conjure-codegen/src/example_types/uuid_example.rs
@@ -9,7 +9,7 @@ impl UuidExample {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(uuid: conjure_object::Uuid) -> UuidExample {
-        UuidExample::builder().uuid(uuid).build()
+        UuidExample { uuid: uuid }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/alias_definition.rs
+++ b/conjure-codegen/src/types/alias_definition.rs
@@ -15,11 +15,11 @@ impl AliasDefinition {
         alias: super::Type,
         docs: super::Documentation,
     ) -> AliasDefinition {
-        AliasDefinition::builder()
-            .type_name(type_name)
-            .alias(alias)
-            .docs(Some(docs))
-            .build()
+        AliasDefinition {
+            type_name: Box::new(type_name),
+            alias: Box::new(alias),
+            docs: Some(docs),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/body_parameter_type.rs
+++ b/conjure-codegen/src/types/body_parameter_type.rs
@@ -7,7 +7,7 @@ impl BodyParameterType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new() -> BodyParameterType {
-        BodyParameterType::builder().build()
+        BodyParameterType {}
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/cookie_auth_type.rs
+++ b/conjure-codegen/src/types/cookie_auth_type.rs
@@ -12,7 +12,9 @@ impl CookieAuthType {
     where
         T: Into<String>,
     {
-        CookieAuthType::builder().cookie_name(cookie_name).build()
+        CookieAuthType {
+            cookie_name: cookie_name.into(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/enum_definition.rs
+++ b/conjure-codegen/src/types/enum_definition.rs
@@ -18,11 +18,11 @@ impl EnumDefinition {
     where
         T: IntoIterator<Item = super::EnumValueDefinition>,
     {
-        EnumDefinition::builder()
-            .type_name(type_name)
-            .values(values)
-            .docs(Some(docs))
-            .build()
+        EnumDefinition {
+            type_name: Box::new(type_name),
+            values: values.into_iter().collect(),
+            docs: Some(docs),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/enum_value_definition.rs
+++ b/conjure-codegen/src/types/enum_value_definition.rs
@@ -13,10 +13,10 @@ impl EnumValueDefinition {
     where
         T: Into<String>,
     {
-        EnumValueDefinition::builder()
-            .value(value)
-            .docs(Some(docs))
-            .build()
+        EnumValueDefinition {
+            value: value.into(),
+            docs: Some(docs),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/external_reference.rs
+++ b/conjure-codegen/src/types/external_reference.rs
@@ -10,10 +10,10 @@ impl ExternalReference {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(external_reference: super::TypeName, fallback: super::Type) -> ExternalReference {
-        ExternalReference::builder()
-            .external_reference(external_reference)
-            .fallback(fallback)
-            .build()
+        ExternalReference {
+            external_reference: Box::new(external_reference),
+            fallback: Box::new(fallback),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/field_definition.rs
+++ b/conjure-codegen/src/types/field_definition.rs
@@ -15,11 +15,11 @@ impl FieldDefinition {
         type_: super::Type,
         docs: super::Documentation,
     ) -> FieldDefinition {
-        FieldDefinition::builder()
-            .field_name(field_name)
-            .type_(type_)
-            .docs(Some(docs))
-            .build()
+        FieldDefinition {
+            field_name: field_name,
+            type_: Box::new(type_),
+            docs: Some(docs),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/header_auth_type.rs
+++ b/conjure-codegen/src/types/header_auth_type.rs
@@ -7,7 +7,7 @@ impl HeaderAuthType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new() -> HeaderAuthType {
-        HeaderAuthType::builder().build()
+        HeaderAuthType {}
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/header_parameter_type.rs
+++ b/conjure-codegen/src/types/header_parameter_type.rs
@@ -9,7 +9,7 @@ impl HeaderParameterType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(param_id: super::ParameterId) -> HeaderParameterType {
-        HeaderParameterType::builder().param_id(param_id).build()
+        HeaderParameterType { param_id: param_id }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/list_type.rs
+++ b/conjure-codegen/src/types/list_type.rs
@@ -9,7 +9,9 @@ impl ListType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(item_type: super::Type) -> ListType {
-        ListType::builder().item_type(item_type).build()
+        ListType {
+            item_type: Box::new(item_type),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/map_type.rs
+++ b/conjure-codegen/src/types/map_type.rs
@@ -10,10 +10,10 @@ impl MapType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(key_type: super::Type, value_type: super::Type) -> MapType {
-        MapType::builder()
-            .key_type(key_type)
-            .value_type(value_type)
-            .build()
+        MapType {
+            key_type: Box::new(key_type),
+            value_type: Box::new(value_type),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/object_definition.rs
+++ b/conjure-codegen/src/types/object_definition.rs
@@ -18,11 +18,11 @@ impl ObjectDefinition {
     where
         T: IntoIterator<Item = super::FieldDefinition>,
     {
-        ObjectDefinition::builder()
-            .type_name(type_name)
-            .fields(fields)
-            .docs(Some(docs))
-            .build()
+        ObjectDefinition {
+            type_name: Box::new(type_name),
+            fields: fields.into_iter().collect(),
+            docs: Some(docs),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/optional_type.rs
+++ b/conjure-codegen/src/types/optional_type.rs
@@ -9,7 +9,9 @@ impl OptionalType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(item_type: super::Type) -> OptionalType {
-        OptionalType::builder().item_type(item_type).build()
+        OptionalType {
+            item_type: Box::new(item_type),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/path_parameter_type.rs
+++ b/conjure-codegen/src/types/path_parameter_type.rs
@@ -7,7 +7,7 @@ impl PathParameterType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new() -> PathParameterType {
-        PathParameterType::builder().build()
+        PathParameterType {}
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/query_parameter_type.rs
+++ b/conjure-codegen/src/types/query_parameter_type.rs
@@ -9,7 +9,7 @@ impl QueryParameterType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(param_id: super::ParameterId) -> QueryParameterType {
-        QueryParameterType::builder().param_id(param_id).build()
+        QueryParameterType { param_id: param_id }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/service_definition.rs
+++ b/conjure-codegen/src/types/service_definition.rs
@@ -18,11 +18,11 @@ impl ServiceDefinition {
     where
         T: IntoIterator<Item = super::EndpointDefinition>,
     {
-        ServiceDefinition::builder()
-            .service_name(service_name)
-            .endpoints(endpoints)
-            .docs(Some(docs))
-            .build()
+        ServiceDefinition {
+            service_name: Box::new(service_name),
+            endpoints: endpoints.into_iter().collect(),
+            docs: Some(docs),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/set_type.rs
+++ b/conjure-codegen/src/types/set_type.rs
@@ -9,7 +9,9 @@ impl SetType {
     #[doc = r" Constructs a new instance of the type."]
     #[inline]
     pub fn new(item_type: super::Type) -> SetType {
-        SetType::builder().item_type(item_type).build()
+        SetType {
+            item_type: Box::new(item_type),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/type_name.rs
+++ b/conjure-codegen/src/types/type_name.rs
@@ -14,7 +14,10 @@ impl TypeName {
         T: Into<String>,
         U: Into<String>,
     {
-        TypeName::builder().name(name).package(package).build()
+        TypeName {
+            name: name.into(),
+            package: package.into(),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-codegen/src/types/union_definition.rs
+++ b/conjure-codegen/src/types/union_definition.rs
@@ -18,11 +18,11 @@ impl UnionDefinition {
     where
         T: IntoIterator<Item = super::FieldDefinition>,
     {
-        UnionDefinition::builder()
-            .type_name(type_name)
-            .union_(union_)
-            .docs(Some(docs))
-            .build()
+        UnionDefinition {
+            type_name: Box::new(type_name),
+            union_: union_.into_iter().collect(),
+            docs: Some(docs),
+        }
     }
     #[doc = r" Returns a new builder."]
     #[inline]

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -193,4 +193,10 @@ fn optional_field_constructor() {
         .build();
     let constructor = OptionalConstructorFields::new(vec![1, 2], "hi", 3);
     assert_eq!(builder, constructor);
+
+    let builder = OptionalConstructorFields2::builder()
+        .object(TestObject::new(0))
+        .build();
+    let constructor = OptionalConstructorFields2::new(TestObject::new(0));
+    assert_eq!(builder, constructor);
 }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -120,6 +120,29 @@
     "type" : "object",
     "object" : {
       "typeName" : {
+        "name" : "OptionalConstructorFields2",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "object",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TestObject",
+                "package" : "com.palantir.conjure"
+              }
+            }
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
         "name" : "OptionalConstructorFields",
         "package" : "com.palantir.conjure"
       },

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -53,3 +53,6 @@ types:
           list: optional<list<integer>>
           string: optional<string>
           integer: optional<integer>
+      OptionalConstructorFields2:
+        fields:
+          object: optional<TestObject>


### PR DESCRIPTION
We can't use assign_rhs and pass that into the builder method for
objects, since that adds a Box layer we don't want. Instead, just assign
to the fields directly instead of going through the builder at all.

Closes #17