### PR TITLE
Support error propagation

### DIFF
--- a/conjure-codegen/src/errors.rs
+++ b/conjure-codegen/src/errors.rs
@@ -37,6 +37,8 @@ fn generate_error_type(ctx: &Context, def: &ErrorDefinition) -> TokenStream {
     let type_name = ctx.type_name(def.error_name().name());
     let code = ctx.type_name(def.code().as_str());
     let name = format!("{}:{}", def.namespace(), def.error_name().name());
+    let option = ctx.option_ident(def.error_name());
+    let none = ctx.none_ident(def.error_name());
 
     let mut safe_args = def
         .safe_args()
@@ -55,6 +57,11 @@ fn generate_error_type(ctx: &Context, def: &ErrorDefinition) -> TokenStream {
             #[inline]
             fn name(&self) -> &str {
                 #name
+            }
+
+            #[inline]
+            fn instance_id(&self) -> #option<conjure_object::Uuid> {
+                #none
             }
 
             #[inline]

--- a/conjure-codegen/src/example_types/another/different_package.rs
+++ b/conjure-codegen/src/example_types/another/different_package.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for DifferentPackage {
         "Conjure:DifferentPackage"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-codegen/src/example_types/product/invalid_service_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_service_definition.rs
@@ -193,6 +193,10 @@ impl conjure_error::ErrorType for InvalidServiceDefinition {
         "Conjure:InvalidServiceDefinition"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &["serviceName"]
     }

--- a/conjure-codegen/src/example_types/product/invalid_type_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_type_definition.rs
@@ -179,6 +179,10 @@ impl conjure_error::ErrorType for InvalidTypeDefinition {
         "Conjure:InvalidTypeDefinition"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &["typeName"]
     }

--- a/conjure-codegen/src/example_types/product/java_compilation_failed.rs
+++ b/conjure-codegen/src/example_types/product/java_compilation_failed.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for JavaCompilationFailed {
         "ConjureJava:JavaCompilationFailed"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/lib.rs
+++ b/conjure-error/src/lib.rs
@@ -122,18 +122,22 @@ where
 }
 
 impl ErrorType for SerializableError {
+    #[inline]
     fn code(&self) -> ErrorCode {
         self.error_code().clone()
     }
 
+    #[inline]
     fn name(&self) -> &str {
         self.error_name()
     }
 
+    #[inline]
     fn instance_id(&self) -> Option<Uuid> {
         Some(self.error_instance_id())
     }
 
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/lib.rs
+++ b/conjure-error/src/lib.rs
@@ -21,7 +21,7 @@
 extern crate self as conjure_error;
 
 use conjure_object::{Uuid, Value};
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use crate::ser::ParametersSerializer;
 
@@ -60,13 +60,88 @@ pub trait ErrorType {
     /// The name must be formatted like `NamespaceName:ErrorName`.
     fn name(&self) -> &str;
 
+    /// Returns the error's instance ID, if it stores one.
+    ///
+    /// Conjure-generated error types return `None`, but other implementations, like those for `SerializableError`
+    /// and `WithInstanceId` return a value.
+    fn instance_id(&self) -> Option<Uuid>;
+
     /// Returns a sorted slice of the names of the error's safe parameters.
     fn safe_args(&self) -> &'static [&'static str];
+
+    /// Wraps the error in another that overrides its instance ID.
+    #[inline]
+    fn with_instance_id(self, instance_id: Uuid) -> WithInstanceId<Self>
+    where
+        Self: Sized,
+    {
+        WithInstanceId {
+            error: self,
+            instance_id,
+        }
+    }
+}
+
+/// An `ErrorType` which wraps another and overrides its instance ID.
+pub struct WithInstanceId<T> {
+    error: T,
+    instance_id: Uuid,
+}
+
+impl<T> ErrorType for WithInstanceId<T>
+where
+    T: ErrorType,
+{
+    fn code(&self) -> ErrorCode {
+        self.error.code()
+    }
+
+    fn name(&self) -> &str {
+        self.error.name()
+    }
+
+    fn instance_id(&self) -> Option<Uuid> {
+        Some(self.instance_id)
+    }
+
+    fn safe_args(&self) -> &'static [&'static str] {
+        self.error.safe_args()
+    }
+}
+
+impl<T> Serialize for WithInstanceId<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.error.serialize(s)
+    }
+}
+
+impl ErrorType for SerializableError {
+    fn code(&self) -> ErrorCode {
+        self.error_code().clone()
+    }
+
+    fn name(&self) -> &str {
+        self.error_name()
+    }
+
+    fn instance_id(&self) -> Option<Uuid> {
+        Some(self.error_instance_id())
+    }
+
+    fn safe_args(&self) -> &'static [&'static str] {
+        &[]
+    }
 }
 
 /// Encodes a Conjure error into its serialized form.
 ///
-/// The error's instance ID will be randomly generated.
+/// The error's instance ID will be randomly generated if not provided by the error.
 ///
 /// # Panics
 ///
@@ -90,7 +165,7 @@ where
     builder
         .error_code(error.code())
         .error_name(error.name())
-        .error_instance_id(Uuid::new_v4())
+        .error_instance_id(error.instance_id().unwrap_or_else(Uuid::new_v4))
         .build()
 }
 

--- a/conjure-error/src/lib.rs
+++ b/conjure-error/src/lib.rs
@@ -62,7 +62,7 @@ pub trait ErrorType {
 
     /// Returns the error's instance ID, if it stores one.
     ///
-    /// Conjure-generated error types return `None`, but other implementations, like those for `SerializableError`
+    /// Conjure-generated error types return `None`, but other implementations like those for `SerializableError`
     /// and `WithInstanceId` return a value.
     fn instance_id(&self) -> Option<Uuid>;
 

--- a/conjure-error/src/types/conflict.rs
+++ b/conjure-error/src/types/conflict.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for Conflict {
         "Default:Conflict"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/types/failed_precondition.rs
+++ b/conjure-error/src/types/failed_precondition.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for FailedPrecondition {
         "Default:FailedPrecondition"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/types/internal.rs
+++ b/conjure-error/src/types/internal.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for Internal {
         "Default:Internal"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/types/invalid_argument.rs
+++ b/conjure-error/src/types/invalid_argument.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for InvalidArgument {
         "Default:InvalidArgument"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/types/not_found.rs
+++ b/conjure-error/src/types/not_found.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for NotFound {
         "Default:NotFound"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/types/permission_denied.rs
+++ b/conjure-error/src/types/permission_denied.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for PermissionDenied {
         "Default:PermissionDenied"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/types/request_entity_too_large.rs
+++ b/conjure-error/src/types/request_entity_too_large.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for RequestEntityTooLarge {
         "Default:RequestEntityTooLarge"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }

--- a/conjure-error/src/types/timeout.rs
+++ b/conjure-error/src/types/timeout.rs
@@ -110,6 +110,10 @@ impl conjure_error::ErrorType for Timeout {
         "Default:Timeout"
     }
     #[inline]
+    fn instance_id(&self) -> Option<conjure_object::Uuid> {
+        None
+    }
+    #[inline]
     fn safe_args(&self) -> &'static [&'static str] {
         &[]
     }


### PR DESCRIPTION
There are two use cases we want to handle here that weren't possible
before:

1. One service makes a request to another and it returns an error. That
    by default translates into a 500, but we want to use the same error
    instance ID to make it easier to follow the flow of the error
    through the network of services.
2. One services is acting as a proxy for another service, and does want
    propagate the exact error upstream.

To support this, the ErrorType trait has a new instance_id method which
returns the error's instance ID if it's stored internally. All of the
Conjure-generated errors simply return None (and we generate a random ID
when serializing).

The new ErrorType::with_instance_id method can be used to augment an
existing error with a specific instance ID to handle case 1.

SerializableError now implements ErrorType and overrides the instance_id
method. This handles case 2.