### PR TITLE
Add an Error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
 name = "conjure-error"
 version = "0.3.1"
 dependencies = [
+ "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-object 0.3.1",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ version = "0.3.1"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-object 0.3.1",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,6 +250,15 @@ version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "memchr"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +282,35 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -479,6 +518,14 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +539,24 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -538,6 +603,16 @@ dependencies = [
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "smallvec"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -725,10 +800,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proptest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27f275a76b824714046ce0b1e00323e06437e027f2d31b2b6272cae30afaf18d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -752,13 +831,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
 "checksum serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a663f873dedc4eac1a559d4c6bc0d0b2c34dc5ac4702e105014b8281489e44f"
 "checksum serde_bytes 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "defbb8a83d7f34cc8380751eeb892b825944222888aff18996ea7901f24aec88"
 "checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 
 [dependencies]
 backtrace = "0.3"
+parking_lot = "0.7"
 serde = "1.0"
 serde-value = "0.5"
 uuid = { version = "0.7", features = ["v4"] }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/palantir/conjure-rust"
 readme = "../README.md"
 
 [dependencies]
+backtrace = "0.3"
 serde = "1.0"
 serde-value = "0.5"
 uuid = { version = "0.7", features = ["v4"] }

--- a/conjure-error/src/error.rs
+++ b/conjure-error/src/error.rs
@@ -1,3 +1,17 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use conjure_object::Value;
 use parking_lot::Mutex;
 use serde::Serialize;

--- a/conjure-error/src/error.rs
+++ b/conjure-error/src/error.rs
@@ -1,0 +1,361 @@
+use backtrace::Backtrace;
+use conjure_object::Value;
+use serde::Serialize;
+use std::borrow::Cow;
+use std::collections::hash_map::{self, HashMap};
+use std::error;
+use std::ops::Index;
+use std::time::Duration;
+
+use crate::{ErrorType, Internal, SerializableError};
+
+/// Information about a throttle error.
+#[derive(Debug)]
+pub struct ThrottleError {
+    duration: Option<Duration>,
+}
+
+impl ThrottleError {
+    /// Returns the amount of time the client should wait before retrying, if provided.
+    #[inline]
+    pub fn duration(&self) -> Option<Duration> {
+        self.duration
+    }
+}
+
+/// Information about an unavailable error.
+#[derive(Debug)]
+pub struct UnavailableError(());
+
+/// Information about the specific type of an `Error`.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// A general service error.
+    Service(SerializableError),
+    /// A QoS error indicating that the client should throttle itself.
+    Throttle(ThrottleError),
+    /// A QoS error indicating that the server was unable to handle the request.
+    Unavailable(UnavailableError),
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+#[derive(Debug)]
+struct Inner {
+    cause: Box<dyn error::Error + Sync + Send>,
+    cause_safe: bool,
+    kind: ErrorKind,
+    safe_params: HashMap<Cow<'static, str>, Value>,
+    unsafe_params: HashMap<Cow<'static, str>, Value>,
+    backtraces: Vec<Backtrace>,
+}
+
+/// A standard error type for network services.
+///
+/// An error consists of several components:
+///
+/// * The cause of the error, represented as a type implementing the Rust `Error` trait. The cause can either be
+///     declared safe or unsafe to log.
+/// * The error's kind, indicating how the service should handle the error e.g. in a response to a client.
+/// * Backtraces, including one taken at the time the error was created.
+/// * Parameters adding extra context about the error. They can be declared either safe or unsafe to log.
+///
+/// Note that this type does *not* implement the standard library's `Error` trait.
+#[derive(Debug)]
+pub struct Error(Box<Inner>);
+
+impl Error {
+    /// Creates a service error with an unsafe cause.
+    pub fn service<E, T>(cause: E, error_type: T) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+        T: ErrorType + Serialize,
+    {
+        Error::service_inner(
+            cause.into(),
+            false,
+            crate::encode(&error_type),
+            error_type.safe_args(),
+        )
+    }
+
+    /// Creates a service error with a safe cause.
+    pub fn service_safe<E, T>(cause: E, error_type: T) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+        T: ErrorType + Serialize,
+    {
+        Error::service_inner(
+            cause.into(),
+            true,
+            crate::encode(&error_type),
+            error_type.safe_args(),
+        )
+    }
+
+    fn service_inner(
+        cause: Box<dyn error::Error + Sync + Send>,
+        cause_safe: bool,
+        error: SerializableError,
+        safe_args: &[&str],
+    ) -> Error {
+        let mut safe_params = HashMap::new();
+        let mut unsafe_params = HashMap::new();
+
+        for (key, value) in error.parameters() {
+            let key = Cow::Owned(key.clone());
+            let value = Value::String(value.clone());
+            if safe_args.contains(&&*key) {
+                safe_params.insert(key, value);
+            } else {
+                unsafe_params.insert(key, value);
+            }
+        }
+
+        let mut error = Error::new(cause, cause_safe, ErrorKind::Service(error));
+        error.0.safe_params = safe_params;
+        error.0.unsafe_params = unsafe_params;
+        error
+    }
+
+    /// Creates an error indicating that the client should throttle itself with an unsafe cause.
+    pub fn throttle<E>(cause: E) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::new(
+            cause.into(),
+            false,
+            ErrorKind::Throttle(ThrottleError { duration: None }),
+        )
+    }
+
+    /// Creates an error indicating that the client should throttle itself with a safe cause.
+    pub fn throttle_safe<E>(cause: E) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::new(
+            cause.into(),
+            true,
+            ErrorKind::Throttle(ThrottleError { duration: None }),
+        )
+    }
+
+    /// Creates an error indicating that the client should throttle itself for a specific duration with an unsafe
+    /// cause.
+    pub fn throttle_for<E>(cause: E, duration: Duration) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::new(
+            cause.into(),
+            false,
+            ErrorKind::Throttle(ThrottleError {
+                duration: Some(duration),
+            }),
+        )
+    }
+
+    /// Creates an error indicating that the client should throttle itself for a specific duration with a safe
+    /// cause.
+    pub fn throttle_for_safe<E>(cause: E, duration: Duration) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::new(
+            cause.into(),
+            true,
+            ErrorKind::Throttle(ThrottleError {
+                duration: Some(duration),
+            }),
+        )
+    }
+
+    /// Creates an error indicating that the server was unable to serve the client's request with an unsafe cause.
+    pub fn unavailable<E>(cause: E) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::new(
+            cause.into(),
+            false,
+            ErrorKind::Unavailable(UnavailableError(())),
+        )
+    }
+
+    /// Creates an error indicating that the server was unable to serve the client's request with a safe cause.
+    pub fn unavailable_safe<E>(cause: E) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::new(
+            cause.into(),
+            true,
+            ErrorKind::Unavailable(UnavailableError(())),
+        )
+    }
+
+    /// A convenience function to construct an internal service error with an unsafe cause.
+    pub fn internal<E>(cause: E) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::service(cause, Internal::new())
+    }
+
+    /// A convenience function to construct an internal service error with a safe cause.
+    pub fn internal_safe<E>(cause: E) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::service_safe(cause, Internal::new())
+    }
+
+    fn new(cause: Box<dyn error::Error + Sync + Send>, cause_safe: bool, kind: ErrorKind) -> Error {
+        let inner = Inner {
+            cause,
+            cause_safe,
+            kind,
+            safe_params: HashMap::new(),
+            unsafe_params: HashMap::new(),
+            backtraces: vec![],
+        };
+        Error(Box::new(inner)).with_backtrace()
+    }
+
+    /// Returns the error's cause.
+    ///
+    /// Use the `cause_safe` method to determine if the error is safe or not.
+    #[inline]
+    pub fn cause(&self) -> &(dyn error::Error + 'static + Sync + Send) {
+        &*self.0.cause
+    }
+
+    /// Returns whether or not the error's cause is considered safe.
+    #[inline]
+    pub fn cause_safe(&self) -> bool {
+        self.0.cause_safe
+    }
+
+    /// Returns kind-specific error information.
+    #[inline]
+    pub fn kind(&self) -> &ErrorKind {
+        &self.0.kind
+    }
+
+    /// Adds a new safe parameter to the error.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value fails to serialize.
+    pub fn with_safe_param<T>(mut self, key: &'static str, value: T) -> Error
+    where
+        T: Serialize,
+    {
+        let value = serde_value::to_value(value).expect("value failed to serialize");
+        self.0.safe_params.insert(Cow::Borrowed(key), value);
+        self
+    }
+
+    /// Adds a new unsafe parameter to the error.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value fails to serialize.
+    pub fn with_unsafe_param<T>(mut self, key: &'static str, value: T) -> Error
+    where
+        T: Serialize,
+    {
+        let value = serde_value::to_value(value).expect("value failed to serialize");
+        self.0.unsafe_params.insert(Cow::Borrowed(key), value);
+        self
+    }
+
+    /// Returns the error's safe parameters.
+    #[inline]
+    pub fn safe_params(&self) -> Params<'_> {
+        Params(&self.0.safe_params)
+    }
+
+    /// Returns the error's unsafe parameters.
+    #[inline]
+    pub fn unsafe_params(&self) -> Params<'_> {
+        Params(&self.0.unsafe_params)
+    }
+
+    /// Adds a new backtrace to the error.
+    ///
+    /// An error always takes a backtrace at the time of its construction, but this method can be used to add extra
+    /// backtraces to it. For example, this might be used when transferring an error from one thread to another.
+    #[inline]
+    pub fn with_backtrace(mut self) -> Error {
+        self.0.backtraces.push(Backtrace::new());
+        self
+    }
+
+    /// Returns the error's backtraces, ordered from oldest to newest.
+    #[inline]
+    pub fn backtraces(&self) -> &[Backtrace] {
+        &self.0.backtraces
+    }
+}
+
+/// A collection of error parameters, either safe or unsafe.
+pub struct Params<'a>(&'a HashMap<Cow<'static, str>, Value>);
+
+impl<'a> Params<'a> {
+    /// Returns an iterator over the key-value parameter pairs.
+    #[inline]
+    pub fn iter(&self) -> ParamsIter<'a> {
+        ParamsIter(self.0.iter())
+    }
+
+    /// Returns the number of parameters.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Determines if there are no parameters.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<'a> Index<&str> for Params<'a> {
+    type Output = Value;
+
+    #[inline]
+    fn index(&self, key: &str) -> &Value {
+        &self.0[key]
+    }
+}
+
+impl<'a> IntoIterator for &Params<'a> {
+    type IntoIter = ParamsIter<'a>;
+    type Item = (&'a str, &'a Value);
+
+    #[inline]
+    fn into_iter(self) -> ParamsIter<'a> {
+        self.iter()
+    }
+}
+
+/// An iterator over the parameters of an error.
+pub struct ParamsIter<'a>(hash_map::Iter<'a, Cow<'static, str>, Value>);
+
+impl<'a> Iterator for ParamsIter<'a> {
+    type Item = (&'a str, &'a Value);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a str, &'a Value)> {
+        self.0.next().map(|(a, b)| (&**a, b))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}

--- a/conjure-error/src/lib.rs
+++ b/conjure-error/src/lib.rs
@@ -17,7 +17,7 @@
 //! Conjure errors are represented by a struct implementing the `ErrorType` trait. The struct's fields are the error's
 //! parameters, and the trait implementation stores the remainder of the error's information.
 #![doc(html_root_url = "https://docs.rs/conjure-error/0.3")]
-#![warn(clippy::all)]
+#![warn(clippy::all, missing_docs)]
 
 extern crate self as conjure_error;
 
@@ -26,11 +26,13 @@ use serde::{Serialize, Serializer};
 
 use crate::ser::ParametersSerializer;
 
-mod ser;
-#[allow(clippy::all)]
-mod types;
-
+pub use crate::error::*;
 pub use crate::types::*;
+
+mod error;
+mod ser;
+#[allow(clippy::all, missing_docs)]
+mod types;
 
 impl ErrorCode {
     /// Returns the HTTP status code associated with the error code.


### PR DESCRIPTION
This is intended to be the standard error passed around in networked
services. It augments a normal Rust error with information about how it
should be reported to a client, extra parameters providing context, and
backtraces.