### PR TITLE
Service client generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,15 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +141,7 @@ name = "conjure-codegen"
 version = "0.3.1"
 dependencies = [
  "conjure-error 0.3.1",
+ "conjure-http 0.3.1",
  "conjure-object 0.3.1",
  "conjure-serde 0.3.1",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -153,9 +163,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "conjure-http"
+version = "0.3.1"
+dependencies = [
+ "conjure-error 0.3.1",
+ "conjure-serde 0.3.1",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "conjure-object"
 version = "0.3.1"
 dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,8 +212,10 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-codegen 0.3.1",
  "conjure-error 0.3.1",
+ "conjure-http 0.3.1",
  "conjure-object 0.3.1",
  "conjure-serde 0.3.1",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -232,6 +255,25 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -312,6 +354,11 @@ dependencies = [
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -758,6 +805,11 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -787,6 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
@@ -797,6 +850,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
@@ -808,6 +863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proptest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27f275a76b824714046ce0b1e00323e06437e027f2d31b2b6272cae30afaf18d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -862,6 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "conjure-codegen",
     "conjure-error",
+    "conjure-http",
     "conjure-object",
     "conjure-rust",
     "conjure-serde",

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 features = ["example-types"]
 
 [features]
-example-types = ["conjure-error"]
+example-types = ["conjure-error", 'conjure-http']
 proc-macro = ["quote/proc-macro", "proc-macro2/proc-macro"]
 
 [dependencies]
@@ -24,3 +24,4 @@ failure = "0.1"
 conjure-object = { version = "0.3.1", path = "../conjure-object" }
 conjure-serde = { version = "0.3.1", path = "../conjure-serde" }
 conjure-error = { version = "0.3.1", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.3.1", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/example-types-ir.json
+++ b/conjure-codegen/example-types-ir.json
@@ -68,6 +68,140 @@
     "unsafeArgs" : [ ]
   } ],
   "types" : [ {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "AliasedString",
+        "package" : "com.palantir.product"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      }
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "CreateDatasetRequest",
+        "package" : "com.palantir.product"
+      },
+      "fields" : [ {
+        "fieldName" : "fileSystemId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "path",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Dataset",
+        "package" : "com.palantir.product.datasets"
+      },
+      "fields" : [ {
+        "fieldName" : "fileSystemId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "rid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "docs" : "Uniquely identifies this dataset."
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "BackingFileSystem",
+        "package" : "com.palantir.product.datasets"
+      },
+      "fields" : [ {
+        "fieldName" : "fileSystemId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "The name by which this file system is identified."
+      }, {
+        "fieldName" : "baseUri",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "configuration",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "AliasedBinary",
+        "package" : "com.palantir.product"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "NestedAliasedBinary",
+        "package" : "com.palantir.product"
+      },
+      "alias" : {
+        "type" : "reference",
+        "reference" : {
+          "name" : "AliasedBinary",
+          "package" : "com.palantir.product"
+        }
+      }
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "IntegerExample",
+        "package" : "com.palantir.product"
+      },
+      "fields" : [ {
+        "fieldName" : "integer",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "INTEGER"
+        }
+      } ]
+    }
+  }, {
     "type" : "object",
     "object" : {
       "typeName" : {
@@ -86,14 +220,14 @@
     "type" : "object",
     "object" : {
       "typeName" : {
-        "name" : "IntegerExample",
+        "name" : "AnyExample",
         "package" : "com.palantir.product"
       },
       "fields" : [ {
-        "fieldName" : "integer",
+        "fieldName" : "any",
         "type" : {
           "type" : "primitive",
-          "primitive" : "INTEGER"
+          "primitive" : "ANY"
         }
       } ]
     }
@@ -117,21 +251,6 @@
           }
         }
       }
-    }
-  }, {
-    "type" : "object",
-    "object" : {
-      "typeName" : {
-        "name" : "AnyExample",
-        "package" : "com.palantir.product"
-      },
-      "fields" : [ {
-        "fieldName" : "any",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "ANY"
-        }
-      } ]
     }
   }, {
     "type" : "object",
@@ -241,6 +360,21 @@
       }
     }
   }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "SafeLongExample",
+        "package" : "com.palantir.product"
+      },
+      "fields" : [ {
+        "fieldName" : "safeLongValue",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "SAFELONG"
+        }
+      } ]
+    }
+  }, {
     "type" : "union",
     "union" : {
       "typeName" : {
@@ -259,14 +393,14 @@
     "type" : "object",
     "object" : {
       "typeName" : {
-        "name" : "SafeLongExample",
+        "name" : "DateTimeExample",
         "package" : "com.palantir.product"
       },
       "fields" : [ {
-        "fieldName" : "safeLongValue",
+        "fieldName" : "datetime",
         "type" : {
           "type" : "primitive",
-          "primitive" : "SAFELONG"
+          "primitive" : "DATETIME"
         }
       } ]
     }
@@ -281,21 +415,6 @@
         "type" : "primitive",
         "primitive" : "BEARERTOKEN"
       }
-    }
-  }, {
-    "type" : "object",
-    "object" : {
-      "typeName" : {
-        "name" : "DateTimeExample",
-        "package" : "com.palantir.product"
-      },
-      "fields" : [ {
-        "fieldName" : "datetime",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "DATETIME"
-        }
-      } ]
     }
   }, {
     "type" : "object",
@@ -354,45 +473,6 @@
     "type" : "object",
     "object" : {
       "typeName" : {
-        "name" : "ReservedKeyExample",
-        "package" : "com.palantir.product"
-      },
-      "fields" : [ {
-        "fieldName" : "package",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "STRING"
-        }
-      }, {
-        "fieldName" : "interface",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "STRING"
-        }
-      }, {
-        "fieldName" : "field-name-with-dashes",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "STRING"
-        }
-      }, {
-        "fieldName" : "primitve-field-name-with-dashes",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "INTEGER"
-        }
-      }, {
-        "fieldName" : "memoizedHashCode",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "INTEGER"
-        }
-      } ]
-    }
-  }, {
-    "type" : "object",
-    "object" : {
-      "typeName" : {
         "name" : "CovariantListExample",
         "package" : "com.palantir.product"
       },
@@ -430,6 +510,45 @@
       } ]
     }
   }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "ReservedKeyExample",
+        "package" : "com.palantir.product"
+      },
+      "fields" : [ {
+        "fieldName" : "package",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "interface",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "field-name-with-dashes",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "primitve-field-name-with-dashes",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "INTEGER"
+        }
+      }, {
+        "fieldName" : "memoizedHashCode",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "INTEGER"
+        }
+      } ]
+    }
+  }, {
     "type" : "alias",
     "alias" : {
       "typeName" : {
@@ -442,18 +561,6 @@
           "name" : "AnyExample",
           "package" : "com.palantir.product"
         }
-      }
-    }
-  }, {
-    "type" : "alias",
-    "alias" : {
-      "typeName" : {
-        "name" : "DateTimeAliasExample",
-        "package" : "com.palantir.product"
-      },
-      "alias" : {
-        "type" : "primitive",
-        "primitive" : "DATETIME"
       }
     }
   }, {
@@ -475,12 +582,12 @@
     "type" : "alias",
     "alias" : {
       "typeName" : {
-        "name" : "BinaryAliasExample",
+        "name" : "DateTimeAliasExample",
         "package" : "com.palantir.product"
       },
       "alias" : {
         "type" : "primitive",
-        "primitive" : "BINARY"
+        "primitive" : "DATETIME"
       }
     }
   }, {
@@ -506,6 +613,33 @@
           }
         }
       } ]
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "BinaryAliasExample",
+        "package" : "com.palantir.product"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "NestedStringAliasExample",
+        "package" : "com.palantir.product"
+      },
+      "alias" : {
+        "type" : "reference",
+        "reference" : {
+          "name" : "StringAliasExample",
+          "package" : "com.palantir.product"
+        }
+      }
     }
   }, {
     "type" : "object",
@@ -598,21 +732,6 @@
         },
         "docs" : "docs for alias field"
       } ]
-    }
-  }, {
-    "type" : "alias",
-    "alias" : {
-      "typeName" : {
-        "name" : "NestedStringAliasExample",
-        "package" : "com.palantir.product"
-      },
-      "alias" : {
-        "type" : "reference",
-        "reference" : {
-          "name" : "StringAliasExample",
-          "package" : "com.palantir.product"
-        }
-      }
     }
   }, {
     "type" : "object",
@@ -771,6 +890,21 @@
       } ]
     }
   }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "BearerTokenExample",
+        "package" : "com.palantir.product"
+      },
+      "fields" : [ {
+        "fieldName" : "bearerTokenValue",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BEARERTOKEN"
+        }
+      } ]
+    }
+  }, {
     "type" : "union",
     "union" : {
       "typeName" : {
@@ -835,33 +969,6 @@
     "type" : "object",
     "object" : {
       "typeName" : {
-        "name" : "BearerTokenExample",
-        "package" : "com.palantir.product"
-      },
-      "fields" : [ {
-        "fieldName" : "bearerTokenValue",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "BEARERTOKEN"
-        }
-      } ]
-    }
-  }, {
-    "type" : "alias",
-    "alias" : {
-      "typeName" : {
-        "name" : "StringAliasExample",
-        "package" : "com.palantir.product"
-      },
-      "alias" : {
-        "type" : "primitive",
-        "primitive" : "STRING"
-      }
-    }
-  }, {
-    "type" : "object",
-    "object" : {
-      "typeName" : {
         "name" : "ListExample",
         "package" : "com.palantir.product"
       },
@@ -904,6 +1011,18 @@
     "type" : "alias",
     "alias" : {
       "typeName" : {
+        "name" : "StringAliasExample",
+        "package" : "com.palantir.product"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
         "name" : "RidAliasExample",
         "package" : "com.palantir.product"
       },
@@ -916,24 +1035,24 @@
     "type" : "alias",
     "alias" : {
       "typeName" : {
-        "name" : "IntegerAliasExample",
-        "package" : "com.palantir.product"
-      },
-      "alias" : {
-        "type" : "primitive",
-        "primitive" : "INTEGER"
-      }
-    }
-  }, {
-    "type" : "alias",
-    "alias" : {
-      "typeName" : {
         "name" : "DoubleAliasExample",
         "package" : "com.palantir.product"
       },
       "alias" : {
         "type" : "primitive",
         "primitive" : "DOUBLE"
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "IntegerAliasExample",
+        "package" : "com.palantir.product"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "INTEGER"
       }
     }
   }, {
@@ -1105,5 +1224,904 @@
       } ]
     }
   } ],
-  "services" : [ ]
+  "services" : [ {
+    "serviceName" : {
+      "name" : "TestService",
+      "package" : "com.palantir.another"
+    },
+    "endpoints" : [ {
+      "endpointName" : "getFileSystems",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/fileSystems",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ ],
+      "returns" : {
+        "type" : "map",
+        "map" : {
+          "keyType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          },
+          "valueType" : {
+            "type" : "reference",
+            "reference" : {
+              "name" : "BackingFileSystem",
+              "package" : "com.palantir.product.datasets"
+            }
+          }
+        }
+      },
+      "docs" : "Returns a mapping from file system id to backing file system configuration.\n",
+      "markers" : [ {
+        "type" : "external",
+        "external" : {
+          "externalReference" : {
+            "name" : "Nonnull",
+            "package" : "javax.annotation"
+          },
+          "fallback" : {
+            "type" : "primitive",
+            "primitive" : "ANY"
+          }
+        }
+      } ]
+    }, {
+      "endpointName" : "createDataset",
+      "httpMethod" : "POST",
+      "httpPath" : "/catalog/datasets",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "request",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "CreateDatasetRequest",
+            "package" : "com.palantir.product"
+          }
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "testHeaderArg",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "header",
+          "header" : {
+            "paramId" : "Test-Header"
+          }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "reference",
+        "reference" : {
+          "name" : "Dataset",
+          "package" : "com.palantir.product.datasets"
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "getDataset",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "reference",
+            "reference" : {
+              "name" : "Dataset",
+              "package" : "com.palantir.product.datasets"
+            }
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "getRawData",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/raw",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "getAliasedRawData",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/raw-aliased",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "reference",
+        "reference" : {
+          "name" : "NestedAliasedBinary",
+          "package" : "com.palantir.product"
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "maybeGetRawData",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/raw-maybe",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        }, {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Nonnull",
+              "package" : "javax.annotation"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "BINARY"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "getAliasedString",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/string-aliased",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "reference",
+        "reference" : {
+          "name" : "AliasedString",
+          "package" : "com.palantir.product"
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "uploadRawData",
+      "httpMethod" : "POST",
+      "httpPath" : "/catalog/datasets/upload-raw",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "input",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BINARY"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "uploadAliasedRawData",
+      "httpMethod" : "POST",
+      "httpPath" : "/catalog/datasets/upload-raw-aliased",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "input",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "NestedAliasedBinary",
+            "package" : "com.palantir.product"
+          }
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "getBranches",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/branches",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "docs" : "A valid dataset resource identifier.\n",
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "set",
+        "set" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "getBranchesDeprecated",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/branchesDeprecated",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "docs" : "A valid dataset resource identifier.\n",
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "set",
+        "set" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "docs" : "Gets all branches of this dataset.\n",
+      "deprecated" : "use getBranches instead",
+      "markers" : [ ]
+    }, {
+      "endpointName" : "resolveBranch",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      }, {
+        "argName" : "branch",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testParam",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/datasets/{datasetRid}/testParam",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "datasetRid",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      } ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testQueryParams",
+      "httpMethod" : "POST",
+      "httpPath" : "/catalog/test-query-params",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "query",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "something",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "different"
+          }
+        },
+        "markers" : [ {
+          "type" : "external",
+          "external" : {
+            "externalReference" : {
+              "name" : "Safe",
+              "package" : "com.palantir.redaction"
+            },
+            "fallback" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        } ]
+      }, {
+        "argName" : "optionalMiddle",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "RID"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "optionalMiddle"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "implicit",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "implicit"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "setEnd",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "setEnd"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "optionalEnd",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "RID"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "optionalEnd"
+          }
+        },
+        "markers" : [ ]
+      } ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "INTEGER"
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testNoResponseQueryParams",
+      "httpMethod" : "POST",
+      "httpPath" : "/catalog/test-no-response-query-params",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "query",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "something",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "different"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "optionalMiddle",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "RID"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "optionalMiddle"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "implicit",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "implicit"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "setEnd",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "setEnd"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "optionalEnd",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "RID"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "optionalEnd"
+          }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testBoolean",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/boolean",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "BOOLEAN"
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testDouble",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/double",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "DOUBLE"
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testInteger",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/integer",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "INTEGER"
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testPostOptional",
+      "httpMethod" : "POST",
+      "httpPath" : "/catalog/optional",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "maybeString",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "testOptionalIntegerAndDouble",
+      "httpMethod" : "GET",
+      "httpPath" : "/catalog/optional-integer-double",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ {
+        "argName" : "maybeInteger",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "maybeInteger"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "maybeDouble",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "DOUBLE"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "maybeDouble"
+          }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    } ],
+    "docs" : "A Markdown description of the service.\n"
+  } ]
 }

--- a/conjure-codegen/example-types/example-service.yml
+++ b/conjure-codegen/example-types/example-service.yml
@@ -1,0 +1,253 @@
+types:
+  imports:
+    Safe:
+      external:
+        java: com.palantir.redaction.Safe
+
+    Nonnull:
+      external:
+        java: javax.annotation.Nonnull
+
+  definitions:
+    default-package: com.palantir.product
+    objects:
+      BackingFileSystem:
+        package: com.palantir.product.datasets
+        fields:
+          fileSystemId:
+            type: string
+            docs: The name by which this file system is identified.
+          baseUri: string
+          configuration: map<string, string>
+
+      Dataset:
+        package: com.palantir.product.datasets
+        fields:
+          fileSystemId: string
+          rid:
+            type: rid
+            docs: Uniquely identifies this dataset.
+
+      CreateDatasetRequest:
+        fields:
+          fileSystemId: string
+          path: string
+
+      AliasedBinary:
+        alias: binary
+
+      NestedAliasedBinary:
+        alias: AliasedBinary
+
+      AliasedString:
+        alias: string
+
+services:
+  TestService:
+    name: Test Service
+    package: com.palantir.another
+    default-auth: header
+    base-path: /catalog
+    docs: |
+      A Markdown description of the service.
+
+    endpoints:
+      getFileSystems:
+        markers:
+          - Nonnull # requires FeatureFlags.DangerousGothamMethodMarkers
+        http: GET /fileSystems
+        returns: map<string, BackingFileSystem>
+        docs: |
+          Returns a mapping from file system id to backing file system configuration.
+
+      createDataset:
+        http: POST /datasets
+        args:
+          request: CreateDatasetRequest
+          testHeaderArg:
+            param-id: Test-Header
+            param-type: header
+            type: string
+            markers:
+              - Safe
+        returns: Dataset
+
+      getDataset:
+        http: GET /datasets/{datasetRid}
+        args:
+          datasetRid:
+            type: rid
+            markers:
+             - Safe
+        returns: optional<Dataset>
+
+      getRawData:
+        http: GET /datasets/{datasetRid}/raw
+        args:
+          datasetRid:
+            type: rid
+            markers:
+             - Safe
+        returns: binary
+
+      getAliasedRawData:
+        http: GET /datasets/{datasetRid}/raw-aliased
+        args:
+          datasetRid:
+            type: rid
+            markers:
+             - Safe
+        returns: NestedAliasedBinary
+
+      maybeGetRawData:
+        http: GET /datasets/{datasetRid}/raw-maybe
+        args:
+          datasetRid:
+            type: rid
+            markers:
+             - Safe
+             - Nonnull
+        returns: optional<binary>
+
+      getAliasedString:
+        http: GET /datasets/{datasetRid}/string-aliased
+        args:
+          datasetRid:
+            type: rid
+            markers:
+             - Safe
+        returns: AliasedString
+
+      uploadRawData:
+        http: POST /datasets/upload-raw
+        args:
+          input:
+            type: binary
+            param-type: body
+            markers:
+              - Safe
+
+      uploadAliasedRawData:
+        http: POST /datasets/upload-raw-aliased
+        args:
+          input:
+            type: NestedAliasedBinary
+            param-type: body
+
+      getBranches:
+        http: GET /datasets/{datasetRid}/branches
+        args:
+          datasetRid:
+            type: rid
+            docs: |
+              A valid dataset resource identifier.
+            markers:
+             - Safe
+        returns: set<string>
+      getBranchesDeprecated:
+        http: GET /datasets/{datasetRid}/branchesDeprecated
+        args:
+          datasetRid:
+            type: rid
+            docs: |
+              A valid dataset resource identifier.
+            markers:
+             - Safe
+        returns: set<string>
+        docs: |
+          Gets all branches of this dataset.
+        deprecated: use getBranches instead
+
+      resolveBranch:
+        http: GET /datasets/{datasetRid}/branches/{branch:.+}/resolve
+        args:
+          datasetRid:
+            type: rid
+            markers:
+             - Safe
+          branch: string
+        returns: optional<string>
+
+      testParam:
+        http: GET /datasets/{datasetRid}/testParam
+        args:
+          datasetRid:
+            type: rid
+            param-id: datasetRid
+            param-type: path
+            markers:
+              - Safe
+        returns: optional<string>
+
+      testQueryParams:
+        http: POST /test-query-params
+        args:
+          query: string
+          something:
+            type: rid
+            param-id: different
+            param-type: query
+            markers:
+              - Safe
+          optionalMiddle:
+            type: optional<rid>
+            param-type: query
+          implicit:
+            type: rid
+            param-type: query
+          setEnd:
+            type: set<string>
+            param-type: query
+          optionalEnd:
+            type: optional<rid>
+            param-type: query
+        returns: integer
+
+      testNoResponseQueryParams:
+        http: POST /test-no-response-query-params
+        args:
+          query: string
+          something:
+            type: rid
+            param-id: different
+            param-type: query
+          optionalMiddle:
+            type: optional<rid>
+            param-type: query
+          implicit:
+            type: rid
+            param-type: query
+          setEnd:
+            type: set<string>
+            param-type: query
+          optionalEnd:
+            type: optional<rid>
+            param-type: query
+
+      testBoolean:
+        http: GET /boolean
+        returns: boolean
+
+      testDouble:
+        http: GET /double
+        returns: double
+
+      testInteger:
+        http: GET /integer
+        returns: integer
+
+      testPostOptional:
+        http: POST /optional
+        args:
+          maybeString: optional<string>
+        returns: optional<string>
+
+      testOptionalIntegerAndDouble:
+        http: GET /optional-integer-double
+        args:
+          maybeInteger:
+            type: optional<integer>
+            param-type: query
+          maybeDouble:
+            type: optional<double>
+            param-type: query

--- a/conjure-codegen/src/aliases.rs
+++ b/conjure-codegen/src/aliases.rs
@@ -49,6 +49,18 @@ pub fn generate(ctx: &Context, def: &AliasDefinition) -> TokenStream {
         quote!()
     };
 
+    let plain = if ctx.is_plain(def.alias()) {
+        quote! {
+            impl conjure_object::Plain for #name {
+                fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    conjure_object::Plain::fmt(&self.0, fmt)
+                }
+            }
+        }
+    } else {
+        quote!()
+    };
+
     quote! {
         use conjure_object::serde::{ser, de};
 
@@ -57,6 +69,8 @@ pub fn generate(ctx: &Context, def: &AliasDefinition) -> TokenStream {
         pub struct #name(pub #alias);
 
         #display
+
+        #plain
 
         impl std::ops::Deref for #name {
             type Target = #alias;

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -182,7 +182,7 @@ fn generate_path(ctx: &Context, endpoint: &EndpointDefinition) -> TokenStream {
 
             let parameter = quote! {
                 conjure_http::private::percent_encode(
-                    conjure_object::ToPlain::to_plain(#name).as_bytes(),
+                    conjure_object::ToPlain::to_plain(&#name).as_bytes(),
                     conjure_http::private::PATH_SEGMENT_ENCODE_SET,
                 )
             };
@@ -241,7 +241,7 @@ fn generate_query(
             #path.push_str(#first_part);
             #path.extend(
                 conjure_http::private::percent_encode(
-                    conjure_object::ToPlain::to_plain(#name).as_bytes(),
+                    conjure_object::ToPlain::to_plain(&#name).as_bytes(),
                     conjure_http::private::QUERY_ENCODE_SET,
                 ),
             );
@@ -425,7 +425,7 @@ fn set_header(
         #request.headers_mut().insert(
             conjure_http::private::http::header::HeaderName::from_static(#header),
             conjure_http::private::http::header::HeaderValue::from_shared(
-                conjure_object::ToPlain::to_plain(#name).into(),
+                conjure_object::ToPlain::to_plain(&#name).into(),
             ).map_err(conjure_http::private::Error::internal_safe)?,
         );
     }

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -370,7 +370,9 @@ fn generate_query(
 
 fn set_auth(request: &TokenStream, endpoint: &EndpointDefinition) -> TokenStream {
     let (header, template) = match endpoint.auth() {
-        Some(AuthType::Cookie(cookie)) => (quote!(COOKIE), format!("{}={{}}", cookie.cookie_name())),
+        Some(AuthType::Cookie(cookie)) => {
+            (quote!(COOKIE), format!("{}={{}}", cookie.cookie_name()))
+        }
         Some(AuthType::Header(_)) => (quote!(AUTHORIZATION), "Bearer {}".to_string()),
         None => return quote!(),
     };

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -1,0 +1,490 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::context::Context;
+use crate::types::{
+    ArgumentDefinition, AuthType, EndpointDefinition, HeaderParameterType, ParameterType,
+    ServiceDefinition, Type,
+};
+
+pub fn generate(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
+    let docs = ctx.docs(def.docs());
+    let name = ctx.type_name(&format!("{}Client", def.service_name().name()));
+
+    let endpoints = def
+        .endpoints()
+        .iter()
+        .map(|e| generate_endpoint(ctx, def, e));
+
+    quote! {
+        #docs
+        #[derive(Clone, Debug)]
+        pub struct #name<T>(T);
+
+        impl<T> #name<T>
+        where
+            T: conjure_http::client::Client
+        {
+            /// Creates a new client.
+            #[inline]
+            pub fn new(client: T) -> #name<T> {
+                #name(client)
+            }
+
+            #(#endpoints)*
+        }
+    }
+}
+
+fn generate_endpoint(
+    ctx: &Context,
+    def: &ServiceDefinition,
+    endpoint: &EndpointDefinition,
+) -> TokenStream {
+    let docs = ctx.docs(endpoint.docs());
+    let deprecated = match endpoint.deprecated() {
+        Some(docs) => {
+            let docs = &**docs;
+            quote! {
+                #[deprecated(note = #docs)]
+            }
+        }
+        None => quote!(),
+    };
+    let name = ctx.field_name(endpoint.endpoint_name());
+
+    let auth_arg = auth_arg(endpoint);
+    let args = endpoint.args().iter().map(|a| {
+        let name = ctx.field_name(a.arg_name());
+        let ty = arg_type(ctx, def, a);
+        quote!(#name: #ty)
+    });
+
+    let ret = return_type(ctx, endpoint);
+    let ret_name = return_type_name(ctx, def, &ret);
+
+    let request = quote!(request_);
+
+    let body_arg = body_arg(endpoint);
+    let body = generate_body(ctx, body_arg);
+
+    let method = endpoint
+        .http_method()
+        .as_str()
+        .parse::<TokenStream>()
+        .unwrap();
+
+    let set_uri = set_uri(ctx, endpoint, &request);
+    let set_auth = set_auth(&request, endpoint);
+    let set_content_type = set_content_type(ctx, &request, body_arg);
+    let set_accept = set_accept(&request, &ret);
+    let set_headers = set_headers(ctx, endpoint, &request);
+    let make_request = make_request(ctx, &ret, &request);
+
+    quote! {
+        #docs
+        #deprecated
+        pub fn #name(&self #auth_arg #(, #args)*) -> Result<#ret_name, conjure_http::private::Error> {
+            let mut #request = conjure_http::private::http::Request::new(#body);
+            *#request.method_mut() = conjure_http::private::http::Method::#method;
+            #set_uri
+            #set_auth
+            #set_content_type
+            #set_accept
+            #set_headers
+            #make_request
+        }
+    }
+}
+
+fn auth_arg(endpoint: &EndpointDefinition) -> TokenStream {
+    match endpoint.auth() {
+        Some(_) => quote!(, auth_: &conjure_object::BearerToken),
+        None => quote!(),
+    }
+}
+
+fn arg_type(ctx: &Context, def: &ServiceDefinition, arg: &ArgumentDefinition) -> TokenStream {
+    if ctx.is_binary(arg.type_()) {
+        quote!(Box<dyn conjure_http::client::WriteBody>)
+    } else {
+        ctx.borrowed_rust_type(def.service_name(), arg.type_())
+    }
+}
+
+fn return_type<'a>(ctx: &Context, endpoint: &'a EndpointDefinition) -> ReturnType<'a> {
+    match endpoint.returns() {
+        Some(ret) => match ctx.is_optional(ret) {
+            Some(inner) if ctx.is_binary(inner) => ReturnType::OptionalBinary,
+            _ if ctx.is_binary(ret) => ReturnType::Binary,
+            _ => ReturnType::Json(ret),
+        },
+        None => ReturnType::None,
+    }
+}
+
+fn return_type_name(ctx: &Context, def: &ServiceDefinition, ty: &ReturnType<'_>) -> TokenStream {
+    match ty {
+        ReturnType::None => quote!(()),
+        ReturnType::Json(ty) => ctx.rust_type(def.service_name(), ty),
+        ReturnType::Binary => quote!(T::ResponseBody),
+        ReturnType::OptionalBinary => quote!(Option<T::ResponseBody>),
+    }
+}
+
+fn set_uri(ctx: &Context, endpoint: &EndpointDefinition, request: &TokenStream) -> TokenStream {
+    let path = quote!(path_);
+    let path_expr = generate_path(ctx, endpoint);
+
+    let build_path = match generate_query(ctx, endpoint, &path) {
+        Some(query) => {
+            quote! {
+                let mut #path = #path_expr;
+                #query
+            }
+        }
+        None => {
+            quote! {
+                let #path = #path_expr;
+            }
+        }
+    };
+
+    quote! {
+        #build_path
+        *#request.uri_mut() = conjure_http::private::http::Uri::from_shared(#path.into())
+            .expect("URI should be valid");
+    }
+}
+
+fn generate_path(ctx: &Context, endpoint: &EndpointDefinition) -> TokenStream {
+    let mut template = String::new();
+    let mut parameters = vec![];
+
+    // skip the empty component before the leading `/`
+    for component in endpoint.http_path().split('/').skip(1) {
+        let component = if component.starts_with('{') && component.ends_with('}') {
+            let name = &component[1..component.len() - 1];
+            let name = ctx.field_name(name);
+
+            let parameter = quote! {
+                conjure_http::private::percent_encode(
+                    conjure_object::ToPlain::to_plain(#name).as_bytes(),
+                    conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+                )
+            };
+            parameters.push(parameter);
+
+            "{}"
+        } else {
+            component
+        };
+        template.push('/');
+        template.push_str(component);
+    }
+
+    quote! {
+        format!(
+            #template,
+            #(#parameters,)*
+        )
+    }
+}
+
+fn generate_query(
+    ctx: &Context,
+    endpoint: &EndpointDefinition,
+    path: &TokenStream,
+) -> Option<TokenStream> {
+    let mut singles = vec![];
+    let mut iters = vec![];
+
+    for argument in endpoint.args() {
+        let query = match argument.param_type() {
+            ParameterType::Query(query) => query,
+            _ => continue,
+        };
+
+        if ctx.is_single_value(argument.type_()) {
+            singles.push((query, argument));
+        } else {
+            iters.push((query, argument));
+        }
+    }
+
+    if singles.is_empty() && iters.is_empty() {
+        return None;
+    }
+
+    let need_first = singles.is_empty();
+
+    let singles = singles.iter().enumerate().map(|(i, (query, argument))| {
+        let prefix = if i == 0 { '?' } else { '&' };
+
+        let name = ctx.field_name(argument.arg_name());
+        let first_part = format!("{}{}=", prefix, query.param_id());
+
+        quote! {
+            #path.push_str(#first_part);
+            #path.extend(
+                conjure_http::private::percent_encode(
+                    conjure_object::ToPlain::to_plain(#name).as_bytes(),
+                    conjure_http::private::QUERY_ENCODE_SET,
+                ),
+            );
+        }
+    });
+
+    let first = quote!(first_);
+
+    let decl_first = if need_first {
+        quote! {
+            let mut #first = true;
+        }
+    } else {
+        quote!()
+    };
+
+    let iters = iters.iter().map(|(query, argument)| {
+        let name = ctx.field_name(argument.arg_name());
+
+        let first_part = if need_first {
+            let first_part = format!("{}=", query.param_id());
+            quote! {
+                let ch = if #first {
+                    #first = false;
+                    '?'
+                } else {
+                    '&'
+                };
+                #path.push(ch);
+                #path.push_str(#first_part);
+            }
+        } else {
+            let first_part = format!("&{}=", query.param_id());
+            quote! {
+                #path.push_str(#first_part);
+            }
+        };
+
+        quote! {
+            for value in #name.iter() {
+                #first_part
+                #path.extend(
+                    conjure_http::private::percent_encode(
+                        conjure_object::ToPlain::to_plain(value).as_bytes(),
+                        conjure_http::private::QUERY_ENCODE_SET,
+                    ),
+                );
+            }
+        }
+    });
+
+    Some(quote! {
+        #(#singles)*
+        #decl_first
+        #(#iters)*
+    })
+}
+
+fn body_arg(endpoint: &EndpointDefinition) -> Option<&ArgumentDefinition> {
+    endpoint.args().iter().find(|a| match a.param_type() {
+        ParameterType::Body(_) => true,
+        _ => false,
+    })
+}
+
+fn generate_body(ctx: &Context, body: Option<&ArgumentDefinition>) -> TokenStream {
+    let body = match body {
+        Some(body) => body,
+        None => return quote!(conjure_http::client::Body::Empty),
+    };
+
+    let name = ctx.field_name(body.arg_name());
+    if ctx.is_binary(body.type_()) {
+        quote! {
+            conjure_http::client::Body::Streaming(#name)
+        }
+    } else {
+        quote! {
+            conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(#name)
+                    .map_err(conjure_http::private::Error::internal)?,
+            )
+        }
+    }
+}
+
+fn set_auth(request: &TokenStream, endpoint: &EndpointDefinition) -> TokenStream {
+    let (header, template) = match endpoint.auth() {
+        Some(AuthType::Cookie(cookie)) => (quote!(COOKIE), format!("{}=", cookie.cookie_name())),
+        Some(AuthType::Header(_)) => (quote!(AUTHORIZATION), "Bearer {}".to_string()),
+        None => return quote!(),
+    };
+
+    quote! {
+        #request.headers_mut().insert(
+            conjure_http::private::http::header::#header,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!(#template, auth_.as_str()).into(),
+            ).expect("bearer tokens are valid headers"),
+        );
+    }
+}
+
+fn set_content_type(
+    ctx: &Context,
+    request: &TokenStream,
+    body: Option<&ArgumentDefinition>,
+) -> TokenStream {
+    let body = match body {
+        Some(body) => body,
+        None => return quote!(),
+    };
+
+    let content_type = if ctx.is_binary(body.type_()) {
+        "application/octet-stream"
+    } else {
+        "application/json"
+    };
+
+    quote! {
+        #request.headers_mut().insert(
+            conjure_http::private::http::header::CONTENT_TYPE,
+            conjure_http::private::http::header::HeaderValue::from_static(#content_type),
+        );
+    }
+}
+
+fn set_accept(request: &TokenStream, ty: &ReturnType<'_>) -> TokenStream {
+    let content_type = match ty {
+        ReturnType::None => return quote!(),
+        ReturnType::Json(_) => "application/json",
+        ReturnType::Binary | ReturnType::OptionalBinary => "application/octet-stream",
+    };
+
+    quote! {
+        #request.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static(#content_type),
+        );
+    }
+}
+
+fn set_headers(ctx: &Context, endpoint: &EndpointDefinition, request: &TokenStream) -> TokenStream {
+    let mut set_headers = vec![];
+
+    for argument in endpoint.args() {
+        let header = match argument.param_type() {
+            ParameterType::Header(header) => header,
+            _ => continue,
+        };
+
+        let mut set_header = set_header(ctx, header, argument, request);
+
+        if !ctx.is_single_value(argument.type_()) {
+            let name = ctx.field_name(argument.arg_name());
+            set_header = quote! {
+                if let Some(#name) = #name {
+                    #set_header
+                }
+            }
+        }
+
+        set_headers.push(set_header);
+    }
+
+    quote! {
+        #(#set_headers)*
+    }
+}
+
+fn set_header(
+    ctx: &Context,
+    header: &HeaderParameterType,
+    argument: &ArgumentDefinition,
+    request: &TokenStream,
+) -> TokenStream {
+    let header = &**header.param_id();
+    let name = ctx.field_name(argument.arg_name());
+
+    quote! {
+        #request.headers_mut().insert(
+            conjure_http::private::http::header::HeaderName::from_static(#header),
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                conjure_object::ToPlain::to_plain(#name).into(),
+            ).map_err(conjure_http::private::Error::internal_safe)?,
+        );
+    }
+}
+
+fn make_request(ctx: &Context, ty: &ReturnType, request: &TokenStream) -> TokenStream {
+    let response = quote! {
+        self.0.request(#request)?
+    };
+
+    match ty {
+        ReturnType::None => {
+            quote! {
+                #response;
+                Ok(())
+            }
+        }
+        ReturnType::Json(ty) => {
+            let mut convert = quote! {
+                conjure_http::private::json::client_from_reader(response.body_mut())
+                    .map_err(conjure_http::private::Error::internal)
+            };
+            if !ctx.is_single_value(ty) {
+                convert = quote! {
+                    if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+                        Ok(Default::default())
+                    } else {
+                        #convert
+                    }
+                };
+            }
+
+            quote! {
+                let mut response = #response;
+                #convert
+            }
+        }
+        ReturnType::Binary => {
+            quote! {
+                let response = #response;
+                Ok(response.into_body())
+            }
+        }
+        ReturnType::OptionalBinary => {
+            quote! {
+                let response = #response;
+                if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+                    Ok(None)
+                } else {
+                    Ok(Some(response.into_body()))
+                }
+            }
+        }
+    }
+}
+
+enum ReturnType<'a> {
+    None,
+    Json(&'a Type),
+    Binary,
+    OptionalBinary,
+}

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -458,7 +458,8 @@ fn set_header(
     argument: &ArgumentDefinition,
     request: &TokenStream,
 ) -> TokenStream {
-    let header = &**header.param_id();
+    // HeaderName::from_static expects http2-style lowercased headers
+    let header = header.param_id().to_lowercase();
     let name = ctx.field_name(argument.arg_name());
 
     quote! {

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -370,7 +370,7 @@ fn generate_query(
 
 fn set_auth(request: &TokenStream, endpoint: &EndpointDefinition) -> TokenStream {
     let (header, template) = match endpoint.auth() {
-        Some(AuthType::Cookie(cookie)) => (quote!(COOKIE), format!("{}=", cookie.cookie_name())),
+        Some(AuthType::Cookie(cookie)) => (quote!(COOKIE), format!("{}={{}}", cookie.cookie_name())),
         Some(AuthType::Header(_)) => (quote!(AUTHORIZATION), "Bearer {}".to_string()),
         None => return quote!(),
     };

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -321,7 +321,7 @@ fn generate_body(ctx: &Context, body: Option<&ArgumentDefinition>) -> TokenStrea
     } else {
         quote! {
             conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(#name)
+                conjure_http::private::json::to_vec(&#name)
                     .map_err(conjure_http::private::Error::internal)?,
             )
         }
@@ -450,7 +450,7 @@ fn make_request(ctx: &Context, ty: &ReturnType, request: &TokenStream) -> TokenS
             };
             if !ctx.is_single_value(ty) {
                 convert = quote! {
-                    if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+                    if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
                         Ok(Default::default())
                     } else {
                         #convert
@@ -472,7 +472,7 @@ fn make_request(ctx: &Context, ty: &ReturnType, request: &TokenStream) -> TokenS
         ReturnType::OptionalBinary => {
             quote! {
                 let response = #response;
-                if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+                if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
                     Ok(None)
                 } else {
                     Ok(Some(response.into_body()))

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -218,10 +218,10 @@ fn generate_query(
             _ => continue,
         };
 
-        if ctx.is_single_value(argument.type_()) {
-            singles.push((query, argument));
-        } else {
+        if ctx.is_iterable(argument.type_()) {
             iters.push((query, argument));
+        } else {
+            singles.push((query, argument));
         }
     }
 
@@ -395,7 +395,7 @@ fn set_headers(ctx: &Context, endpoint: &EndpointDefinition, request: &TokenStre
 
         let mut set_header = set_header(ctx, header, argument, request);
 
-        if !ctx.is_single_value(argument.type_()) {
+        if ctx.is_iterable(argument.type_()) {
             let name = ctx.field_name(argument.arg_name());
             set_header = quote! {
                 if let Some(#name) = #name {
@@ -448,7 +448,7 @@ fn make_request(ctx: &Context, ty: &ReturnType, request: &TokenStream) -> TokenS
                 conjure_http::private::json::client_from_reader(response.body_mut())
                     .map_err(conjure_http::private::Error::internal)
             };
-            if !ctx.is_single_value(ty) {
+            if ctx.is_iterable(ty) {
                 convert = quote! {
                     if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
                         Ok(Default::default())

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -258,11 +258,17 @@ fn generate_path(ctx: &Context, endpoint: &EndpointDefinition) -> TokenStream {
         template.push_str(component);
     }
 
-    quote! {
-        format!(
-            #template,
-            #(#parameters,)*
-        )
+    if parameters.is_empty() {
+        quote! {
+            #template.to_string()
+        }
+    } else {
+        quote! {
+            format!(
+                #template,
+                #(#parameters,)*
+            )
+        }
     }
 }
 

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -670,7 +670,7 @@ impl Context {
             },
             Type::Optional(_) | Type::List(_) | Type::Set(_) | Type::Map(_) => false,
             Type::Reference(def) => self.is_plain_ref(def),
-            Type::External(def) => self.is_binary(def.fallback()),
+            Type::External(def) => self.is_plain(def.fallback()),
         }
     }
 

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -684,21 +684,21 @@ impl Context {
         }
     }
 
-    pub fn is_single_value(&self, def: &Type) -> bool {
+    pub fn is_iterable(&self, def: &Type) -> bool {
         match def {
-            Type::Primitive(_) => true,
-            Type::Optional(_) | Type::List(_) | Type::Set(_) | Type::Map(_) => false,
-            Type::Reference(def) => self.is_single_value_ref(def),
-            Type::External(def) => self.is_single_value(def.fallback()),
+            Type::Primitive(_) => false,
+            Type::Optional(_) | Type::List(_) | Type::Set(_) | Type::Map(_) => true,
+            Type::Reference(def) => self.is_iterable_ref(def),
+            Type::External(def) => self.is_iterable(def.fallback()),
         }
     }
 
-    fn is_single_value_ref(&self, name: &TypeName) -> bool {
+    fn is_iterable_ref(&self, name: &TypeName) -> bool {
         let ctx = &self.types[name];
 
         match &ctx.def {
-            TypeDefinition::Alias(def) => self.is_single_value(def.alias()),
-            TypeDefinition::Enum(_) | TypeDefinition::Object(_) | TypeDefinition::Union(_) => true,
+            TypeDefinition::Alias(def) => self.is_iterable(def.alias()),
+            TypeDefinition::Enum(_) | TypeDefinition::Object(_) | TypeDefinition::Union(_) => false,
         }
     }
 

--- a/conjure-codegen/src/enums.rs
+++ b/conjure-codegen/src/enums.rs
@@ -119,6 +119,12 @@ fn generate_enum(ctx: &Context, def: &EnumDefinition) -> TokenStream {
             }
         }
 
+        impl conjure_object::Plain for #name {
+            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                conjure_object::Plain::fmt(self.as_str(), fmt)
+            }
+        }
+
         impl ser::Serialize for #name {
             fn serialize<S>(&self, s: S) -> #result<S::Ok, S::Error>
             where

--- a/conjure-codegen/src/example_types/another/mod.rs
+++ b/conjure-codegen/src/example_types/another/mod.rs
@@ -1,3 +1,6 @@
 #[doc(inline)]
 pub use self::different_package::DifferentPackage;
+#[doc(inline)]
+pub use self::test_service::TestServiceClient;
 pub mod different_package;
+pub mod test_service;

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -76,7 +76,7 @@ where
         request_.headers_mut().insert(
             conjure_http::private::http::header::HeaderName::from_static("Test-Header"),
             conjure_http::private::http::header::HeaderValue::from_shared(
-                conjure_object::ToPlain::to_plain(test_header_arg).into(),
+                conjure_object::ToPlain::to_plain(&test_header_arg).into(),
             )
             .map_err(conjure_http::private::Error::internal_safe)?,
         );
@@ -96,7 +96,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -132,7 +132,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/raw",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -165,7 +165,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/raw-aliased",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -198,7 +198,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/raw-maybe",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -235,7 +235,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/string-aliased",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -321,7 +321,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/branches",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -359,7 +359,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/branchesDeprecated",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -396,11 +396,11 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/branches/{}/resolve",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(branch).as_bytes(),
+                conjure_object::ToPlain::to_plain(&branch).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -436,7 +436,7 @@ where
         let path_ = format!(
             "/catalog/datasets/{}/testParam",
             conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
                 conjure_http::private::PATH_SEGMENT_ENCODE_SET,
             ),
         );
@@ -480,12 +480,12 @@ where
         let mut path_ = format!("/catalog/test-query-params",);
         path_.push_str("?different=");
         path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(something).as_bytes(),
+            conjure_object::ToPlain::to_plain(&something).as_bytes(),
             conjure_http::private::QUERY_ENCODE_SET,
         ));
         path_.push_str("&implicit=");
         path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(implicit).as_bytes(),
+            conjure_object::ToPlain::to_plain(&implicit).as_bytes(),
             conjure_http::private::QUERY_ENCODE_SET,
         ));
         for value in optional_middle.iter() {
@@ -549,12 +549,12 @@ where
         let mut path_ = format!("/catalog/test-no-response-query-params",);
         path_.push_str("?different=");
         path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(something).as_bytes(),
+            conjure_object::ToPlain::to_plain(&something).as_bytes(),
             conjure_http::private::QUERY_ENCODE_SET,
         ));
         path_.push_str("&implicit=");
         path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(implicit).as_bytes(),
+            conjure_object::ToPlain::to_plain(&implicit).as_bytes(),
             conjure_http::private::QUERY_ENCODE_SET,
         ));
         for value in optional_middle.iter() {

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -256,13 +256,18 @@ where
         conjure_http::private::json::client_from_reader(response.body_mut())
             .map_err(conjure_http::private::Error::internal)
     }
-    pub fn upload_raw_data(
+    pub fn upload_raw_data<U>(
         &self,
         auth_: &conjure_object::BearerToken,
-        input: Box<dyn conjure_http::client::WriteBody>,
-    ) -> Result<(), conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Streaming(input));
+        input: U,
+    ) -> Result<(), conjure_http::private::Error>
+    where
+        U: conjure_http::client::IntoWriteBody,
+    {
+        let mut input = input.into_write_body();
+        let mut request_ = conjure_http::private::http::Request::new(
+            conjure_http::client::Body::Streaming(&mut input),
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let path_ = format!("/catalog/datasets/upload-raw",);
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
@@ -283,13 +288,18 @@ where
         self.0.request(request_)?;
         Ok(())
     }
-    pub fn upload_aliased_raw_data(
+    pub fn upload_aliased_raw_data<U>(
         &self,
         auth_: &conjure_object::BearerToken,
-        input: Box<dyn conjure_http::client::WriteBody>,
-    ) -> Result<(), conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Streaming(input));
+        input: U,
+    ) -> Result<(), conjure_http::private::Error>
+    where
+        U: conjure_http::client::IntoWriteBody,
+    {
+        let mut input = input.into_write_body();
+        let mut request_ = conjure_http::private::http::Request::new(
+            conjure_http::client::Body::Streaming(&mut input),
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let path_ = format!("/catalog/datasets/upload-raw-aliased",);
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -21,7 +21,7 @@ where
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
         *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!("/catalog/fileSystems",);
+        let path_ = "/catalog/fileSystems".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -55,7 +55,7 @@ where
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = format!("/catalog/datasets",);
+        let path_ = "/catalog/datasets".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -269,7 +269,7 @@ where
             conjure_http::client::Body::Streaming(&mut input),
         );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = format!("/catalog/datasets/upload-raw",);
+        let path_ = "/catalog/datasets/upload-raw".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -301,7 +301,7 @@ where
             conjure_http::client::Body::Streaming(&mut input),
         );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = format!("/catalog/datasets/upload-raw-aliased",);
+        let path_ = "/catalog/datasets/upload-raw-aliased".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -487,7 +487,7 @@ where
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let mut path_ = format!("/catalog/test-query-params",);
+        let mut path_ = "/catalog/test-query-params".to_string();
         path_.push_str("?different=");
         path_.extend(conjure_http::private::percent_encode(
             conjure_object::ToPlain::to_plain(&something).as_bytes(),
@@ -556,7 +556,7 @@ where
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let mut path_ = format!("/catalog/test-no-response-query-params",);
+        let mut path_ = "/catalog/test-no-response-query-params".to_string();
         path_.push_str("?different=");
         path_.extend(conjure_http::private::percent_encode(
             conjure_object::ToPlain::to_plain(&something).as_bytes(),
@@ -611,7 +611,7 @@ where
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
         *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!("/catalog/boolean",);
+        let path_ = "/catalog/boolean".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -636,7 +636,7 @@ where
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
         *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!("/catalog/double",);
+        let path_ = "/catalog/double".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -661,7 +661,7 @@ where
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
         *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!("/catalog/integer",);
+        let path_ = "/catalog/integer".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -690,7 +690,7 @@ where
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = format!("/catalog/optional",);
+        let path_ = "/catalog/optional".to_string();
         *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
             .expect("URI should be valid");
         request_.headers_mut().insert(
@@ -725,7 +725,7 @@ where
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
         *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let mut path_ = format!("/catalog/optional-integer-double",);
+        let mut path_ = "/catalog/optional-integer-double".to_string();
         let mut first_ = true;
         for value in maybe_integer.iter() {
             let ch = if first_ {

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -36,7 +36,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         let mut response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
             conjure_http::private::json::client_from_reader(response.body_mut())
@@ -51,7 +51,7 @@ where
     ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error> {
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(request)
+                conjure_http::private::json::to_vec(&request)
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
@@ -114,7 +114,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         let mut response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
             conjure_http::private::json::client_from_reader(response.body_mut())
@@ -218,7 +218,7 @@ where
             ),
         );
         let response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(None)
         } else {
             Ok(Some(response.into_body()))
@@ -339,7 +339,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         let mut response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
             conjure_http::private::json::client_from_reader(response.body_mut())
@@ -377,7 +377,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         let mut response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
             conjure_http::private::json::client_from_reader(response.body_mut())
@@ -418,7 +418,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         let mut response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
             conjure_http::private::json::client_from_reader(response.body_mut())
@@ -454,7 +454,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         let mut response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
             conjure_http::private::json::client_from_reader(response.body_mut())
@@ -473,7 +473,7 @@ where
     ) -> Result<i32, conjure_http::private::Error> {
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(query)
+                conjure_http::private::json::to_vec(&query)
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
@@ -542,7 +542,7 @@ where
     ) -> Result<(), conjure_http::private::Error> {
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(query)
+                conjure_http::private::json::to_vec(&query)
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
@@ -676,7 +676,7 @@ where
     ) -> Result<Option<String>, conjure_http::private::Error> {
         let mut request_ =
             conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(maybe_string)
+                conjure_http::private::json::to_vec(&maybe_string)
                     .map_err(conjure_http::private::Error::internal)?,
             ));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
@@ -699,7 +699,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         let mut response = self.0.request(request_)?;
-        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
             conjure_http::private::json::client_from_reader(response.body_mut())

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -74,7 +74,7 @@ where
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
         request_.headers_mut().insert(
-            conjure_http::private::http::header::HeaderName::from_static("Test-Header"),
+            conjure_http::private::http::header::HeaderName::from_static("test-header"),
             conjure_http::private::http::header::HeaderValue::from_shared(
                 conjure_object::ToPlain::to_plain(&test_header_arg).into(),
             )

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1,0 +1,760 @@
+#[doc = "A Markdown description of the service."]
+#[derive(Clone, Debug)]
+pub struct TestServiceClient<T>(T);
+impl<T> TestServiceClient<T>
+where
+    T: conjure_http::client::Client,
+{
+    #[doc = r" Creates a new client."]
+    #[inline]
+    pub fn new(client: T) -> TestServiceClient<T> {
+        TestServiceClient(client)
+    }
+    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    pub fn get_file_systems(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<
+        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
+        conjure_http::private::Error,
+    > {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!("/catalog/fileSystems",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(Default::default())
+        } else {
+            conjure_http::private::json::client_from_reader(response.body_mut())
+                .map_err(conjure_http::private::Error::internal)
+        }
+    }
+    pub fn create_dataset(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        request: &super::super::product::CreateDatasetRequest,
+        test_header_arg: &str,
+    ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(request)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ));
+        *request_.method_mut() = conjure_http::private::http::Method::POST;
+        let path_ = format!("/catalog/datasets",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::CONTENT_TYPE,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::HeaderName::from_static("Test-Header"),
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                conjure_object::ToPlain::to_plain(test_header_arg).into(),
+            )
+            .map_err(conjure_http::private::Error::internal_safe)?,
+        );
+        let mut response = self.0.request(request_)?;
+        conjure_http::private::json::client_from_reader(response.body_mut())
+            .map_err(conjure_http::private::Error::internal)
+    }
+    pub fn get_dataset(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
+    {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(Default::default())
+        } else {
+            conjure_http::private::json::client_from_reader(response.body_mut())
+                .map_err(conjure_http::private::Error::internal)
+        }
+    }
+    pub fn get_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<T::ResponseBody, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/raw",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static(
+                "application/octet-stream",
+            ),
+        );
+        let response = self.0.request(request_)?;
+        Ok(response.into_body())
+    }
+    pub fn get_aliased_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<T::ResponseBody, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/raw-aliased",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static(
+                "application/octet-stream",
+            ),
+        );
+        let response = self.0.request(request_)?;
+        Ok(response.into_body())
+    }
+    pub fn maybe_get_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<T::ResponseBody>, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/raw-maybe",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static(
+                "application/octet-stream",
+            ),
+        );
+        let response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(None)
+        } else {
+            Ok(Some(response.into_body()))
+        }
+    }
+    pub fn get_aliased_string(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<super::super::product::AliasedString, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/string-aliased",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        conjure_http::private::json::client_from_reader(response.body_mut())
+            .map_err(conjure_http::private::Error::internal)
+    }
+    pub fn upload_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        input: Box<dyn conjure_http::client::WriteBody>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Streaming(input));
+        *request_.method_mut() = conjure_http::private::http::Method::POST;
+        let path_ = format!("/catalog/datasets/upload-raw",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::CONTENT_TYPE,
+            conjure_http::private::http::header::HeaderValue::from_static(
+                "application/octet-stream",
+            ),
+        );
+        self.0.request(request_)?;
+        Ok(())
+    }
+    pub fn upload_aliased_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        input: Box<dyn conjure_http::client::WriteBody>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Streaming(input));
+        *request_.method_mut() = conjure_http::private::http::Method::POST;
+        let path_ = format!("/catalog/datasets/upload-raw-aliased",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::CONTENT_TYPE,
+            conjure_http::private::http::header::HeaderValue::from_static(
+                "application/octet-stream",
+            ),
+        );
+        self.0.request(request_)?;
+        Ok(())
+    }
+    pub fn get_branches(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/branches",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(Default::default())
+        } else {
+            conjure_http::private::json::client_from_reader(response.body_mut())
+                .map_err(conjure_http::private::Error::internal)
+        }
+    }
+    #[doc = "Gets all branches of this dataset."]
+    #[deprecated(note = "use getBranches instead")]
+    pub fn get_branches_deprecated(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/branchesDeprecated",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(Default::default())
+        } else {
+            conjure_http::private::json::client_from_reader(response.body_mut())
+                .map_err(conjure_http::private::Error::internal)
+        }
+    }
+    pub fn resolve_branch(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+        branch: &str,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/branches/{}/resolve",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(branch).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(Default::default())
+        } else {
+            conjure_http::private::json::client_from_reader(response.body_mut())
+                .map_err(conjure_http::private::Error::internal)
+        }
+    }
+    pub fn test_param(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!(
+            "/catalog/datasets/{}/testParam",
+            conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(dataset_rid).as_bytes(),
+                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
+            ),
+        );
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(Default::default())
+        } else {
+            conjure_http::private::json::client_from_reader(response.body_mut())
+                .map_err(conjure_http::private::Error::internal)
+        }
+    }
+    pub fn test_query_params(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        query: &str,
+        something: &conjure_object::ResourceIdentifier,
+        optional_middle: Option<&conjure_object::ResourceIdentifier>,
+        implicit: &conjure_object::ResourceIdentifier,
+        set_end: &std::collections::BTreeSet<String>,
+        optional_end: Option<&conjure_object::ResourceIdentifier>,
+    ) -> Result<i32, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(query)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ));
+        *request_.method_mut() = conjure_http::private::http::Method::POST;
+        let mut path_ = format!("/catalog/test-query-params",);
+        path_.push_str("?different=");
+        path_.extend(conjure_http::private::percent_encode(
+            conjure_object::ToPlain::to_plain(something).as_bytes(),
+            conjure_http::private::QUERY_ENCODE_SET,
+        ));
+        path_.push_str("&implicit=");
+        path_.extend(conjure_http::private::percent_encode(
+            conjure_object::ToPlain::to_plain(implicit).as_bytes(),
+            conjure_http::private::QUERY_ENCODE_SET,
+        ));
+        for value in optional_middle.iter() {
+            path_.push_str("&optionalMiddle=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        for value in set_end.iter() {
+            path_.push_str("&setEnd=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        for value in optional_end.iter() {
+            path_.push_str("&optionalEnd=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::CONTENT_TYPE,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        conjure_http::private::json::client_from_reader(response.body_mut())
+            .map_err(conjure_http::private::Error::internal)
+    }
+    pub fn test_no_response_query_params(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        query: &str,
+        something: &conjure_object::ResourceIdentifier,
+        optional_middle: Option<&conjure_object::ResourceIdentifier>,
+        implicit: &conjure_object::ResourceIdentifier,
+        set_end: &std::collections::BTreeSet<String>,
+        optional_end: Option<&conjure_object::ResourceIdentifier>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(query)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ));
+        *request_.method_mut() = conjure_http::private::http::Method::POST;
+        let mut path_ = format!("/catalog/test-no-response-query-params",);
+        path_.push_str("?different=");
+        path_.extend(conjure_http::private::percent_encode(
+            conjure_object::ToPlain::to_plain(something).as_bytes(),
+            conjure_http::private::QUERY_ENCODE_SET,
+        ));
+        path_.push_str("&implicit=");
+        path_.extend(conjure_http::private::percent_encode(
+            conjure_object::ToPlain::to_plain(implicit).as_bytes(),
+            conjure_http::private::QUERY_ENCODE_SET,
+        ));
+        for value in optional_middle.iter() {
+            path_.push_str("&optionalMiddle=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        for value in set_end.iter() {
+            path_.push_str("&setEnd=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        for value in optional_end.iter() {
+            path_.push_str("&optionalEnd=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::CONTENT_TYPE,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        self.0.request(request_)?;
+        Ok(())
+    }
+    pub fn test_boolean(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<bool, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!("/catalog/boolean",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        conjure_http::private::json::client_from_reader(response.body_mut())
+            .map_err(conjure_http::private::Error::internal)
+    }
+    pub fn test_double(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<f64, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!("/catalog/double",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        conjure_http::private::json::client_from_reader(response.body_mut())
+            .map_err(conjure_http::private::Error::internal)
+    }
+    pub fn test_integer(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<i32, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let path_ = format!("/catalog/integer",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        conjure_http::private::json::client_from_reader(response.body_mut())
+            .map_err(conjure_http::private::Error::internal)
+    }
+    pub fn test_post_optional(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        maybe_string: Option<&str>,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(maybe_string)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ));
+        *request_.method_mut() = conjure_http::private::http::Method::POST;
+        let path_ = format!("/catalog/optional",);
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::CONTENT_TYPE,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::ACCEPT,
+            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
+        );
+        let mut response = self.0.request(request_)?;
+        if response.status() == &conjure_http::private::http::StatusCode::NO_CONTENT {
+            Ok(Default::default())
+        } else {
+            conjure_http::private::json::client_from_reader(response.body_mut())
+                .map_err(conjure_http::private::Error::internal)
+        }
+    }
+    pub fn test_optional_integer_and_double(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        maybe_integer: Option<i32>,
+        maybe_double: Option<f64>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let mut request_ =
+            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
+        *request_.method_mut() = conjure_http::private::http::Method::GET;
+        let mut path_ = format!("/catalog/optional-integer-double",);
+        let mut first_ = true;
+        for value in maybe_integer.iter() {
+            let ch = if first_ {
+                first_ = false;
+                '?'
+            } else {
+                '&'
+            };
+            path_.push(ch);
+            path_.push_str("maybeInteger=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        for value in maybe_double.iter() {
+            let ch = if first_ {
+                first_ = false;
+                '?'
+            } else {
+                '&'
+            };
+            path_.push(ch);
+            path_.push_str("maybeDouble=");
+            path_.extend(conjure_http::private::percent_encode(
+                conjure_object::ToPlain::to_plain(value).as_bytes(),
+                conjure_http::private::QUERY_ENCODE_SET,
+            ));
+        }
+        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
+            .expect("URI should be valid");
+        request_.headers_mut().insert(
+            conjure_http::private::http::header::AUTHORIZATION,
+            conjure_http::private::http::header::HeaderValue::from_shared(
+                format!("Bearer {}", auth_.as_str()).into(),
+            )
+            .expect("bearer tokens are valid headers"),
+        );
+        self.0.request(request_)?;
+        Ok(())
+    }
+}

--- a/conjure-codegen/src/example_types/product/aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/aliased_binary.rs
@@ -1,25 +1,25 @@
 use conjure_object::serde::{de, ser};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
-pub struct BinaryAliasExample(pub conjure_object::ByteBuf);
-impl conjure_object::Plain for BinaryAliasExample {
+pub struct AliasedBinary(pub conjure_object::ByteBuf);
+impl conjure_object::Plain for AliasedBinary {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         conjure_object::Plain::fmt(&self.0, fmt)
     }
 }
-impl std::ops::Deref for BinaryAliasExample {
+impl std::ops::Deref for AliasedBinary {
     type Target = conjure_object::ByteBuf;
     #[inline]
     fn deref(&self) -> &conjure_object::ByteBuf {
         &self.0
     }
 }
-impl std::ops::DerefMut for BinaryAliasExample {
+impl std::ops::DerefMut for AliasedBinary {
     #[inline]
     fn deref_mut(&mut self) -> &mut conjure_object::ByteBuf {
         &mut self.0
     }
 }
-impl ser::Serialize for BinaryAliasExample {
+impl ser::Serialize for AliasedBinary {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -27,11 +27,11 @@ impl ser::Serialize for BinaryAliasExample {
         self.0.serialize(s)
     }
 }
-impl<'de> de::Deserialize<'de> for BinaryAliasExample {
-    fn deserialize<D>(d: D) -> Result<BinaryAliasExample, D::Error>
+impl<'de> de::Deserialize<'de> for AliasedBinary {
+    fn deserialize<D>(d: D) -> Result<AliasedBinary, D::Error>
     where
         D: de::Deserializer<'de>,
     {
-        de::Deserialize::deserialize(d).map(BinaryAliasExample)
+        de::Deserialize::deserialize(d).map(AliasedBinary)
     }
 }

--- a/conjure-codegen/src/example_types/product/aliased_string.rs
+++ b/conjure-codegen/src/example_types/product/aliased_string.rs
@@ -1,30 +1,30 @@
 use conjure_object::serde::{de, ser};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
-pub struct ErrorNamespace(pub String);
-impl std::fmt::Display for ErrorNamespace {
+pub struct AliasedString(pub String);
+impl std::fmt::Display for AliasedString {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
-impl conjure_object::Plain for ErrorNamespace {
+impl conjure_object::Plain for AliasedString {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         conjure_object::Plain::fmt(&self.0, fmt)
     }
 }
-impl std::ops::Deref for ErrorNamespace {
+impl std::ops::Deref for AliasedString {
     type Target = String;
     #[inline]
     fn deref(&self) -> &String {
         &self.0
     }
 }
-impl std::ops::DerefMut for ErrorNamespace {
+impl std::ops::DerefMut for AliasedString {
     #[inline]
     fn deref_mut(&mut self) -> &mut String {
         &mut self.0
     }
 }
-impl ser::Serialize for ErrorNamespace {
+impl ser::Serialize for AliasedString {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -32,11 +32,11 @@ impl ser::Serialize for ErrorNamespace {
         self.0.serialize(s)
     }
 }
-impl<'de> de::Deserialize<'de> for ErrorNamespace {
-    fn deserialize<D>(d: D) -> Result<ErrorNamespace, D::Error>
+impl<'de> de::Deserialize<'de> for AliasedString {
+    fn deserialize<D>(d: D) -> Result<AliasedString, D::Error>
     where
         D: de::Deserializer<'de>,
     {
-        de::Deserialize::deserialize(d).map(ErrorNamespace)
+        de::Deserialize::deserialize(d).map(AliasedString)
     }
 }

--- a/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
@@ -1,6 +1,11 @@
 use conjure_object::serde::{de, ser};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BearerTokenAliasExample(pub conjure_object::BearerToken);
+impl conjure_object::Plain for BearerTokenAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for BearerTokenAliasExample {
     type Target = conjure_object::BearerToken;
     #[inline]

--- a/conjure-codegen/src/example_types/product/boolean_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/boolean_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for BooleanAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for BooleanAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for BooleanAliasExample {
     type Target = bool;
     #[inline]

--- a/conjure-codegen/src/example_types/product/create_dataset_request.rs
+++ b/conjure-codegen/src/example_types/product/create_dataset_request.rs
@@ -1,0 +1,171 @@
+use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
+use conjure_object::serde::{de, ser};
+use std::fmt;
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct CreateDatasetRequest {
+    file_system_id: String,
+    path: String,
+}
+impl CreateDatasetRequest {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T, U>(file_system_id: T, path: U) -> CreateDatasetRequest
+    where
+        T: Into<String>,
+        U: Into<String>,
+    {
+        CreateDatasetRequest {
+            file_system_id: file_system_id.into(),
+            path: path.into(),
+        }
+    }
+    #[doc = r" Returns a new builder."]
+    #[inline]
+    pub fn builder() -> Builder {
+        Default::default()
+    }
+    #[inline]
+    pub fn file_system_id(&self) -> &str {
+        &*self.file_system_id
+    }
+    #[inline]
+    pub fn path(&self) -> &str {
+        &*self.path
+    }
+}
+#[doc = "A builder for the `CreateDatasetRequest` type."]
+#[derive(Debug, Clone, Default)]
+pub struct Builder {
+    file_system_id: Option<String>,
+    path: Option<String>,
+}
+impl Builder {
+    #[doc = r""]
+    #[doc = r" Required."]
+    pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.file_system_id = Some(file_system_id.into());
+        self
+    }
+    #[doc = r""]
+    #[doc = r" Required."]
+    pub fn path<T>(&mut self, path: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.path = Some(path.into());
+        self
+    }
+    #[doc = r" Constructs a new instance of the type."]
+    #[doc = r""]
+    #[doc = r" # Panics"]
+    #[doc = r""]
+    #[doc = r" Panics if a required field was not set."]
+    #[inline]
+    pub fn build(&self) -> CreateDatasetRequest {
+        CreateDatasetRequest {
+            file_system_id: self
+                .file_system_id
+                .clone()
+                .expect("field file_system_id was not set"),
+            path: self.path.clone().expect("field path was not set"),
+        }
+    }
+}
+impl From<CreateDatasetRequest> for Builder {
+    #[inline]
+    fn from(_v: CreateDatasetRequest) -> Builder {
+        Builder {
+            file_system_id: Some(_v.file_system_id),
+            path: Some(_v.path),
+        }
+    }
+}
+impl ser::Serialize for CreateDatasetRequest {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let size = 2usize;
+        let mut s = s.serialize_struct("CreateDatasetRequest", size)?;
+        s.serialize_field("fileSystemId", &self.file_system_id)?;
+        s.serialize_field("path", &self.path)?;
+        s.end()
+    }
+}
+impl<'de> de::Deserialize<'de> for CreateDatasetRequest {
+    fn deserialize<D>(d: D) -> Result<CreateDatasetRequest, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_struct("CreateDatasetRequest", &["fileSystemId", "path"], Visitor_)
+    }
+}
+struct Visitor_;
+impl<'de> de::Visitor<'de> for Visitor_ {
+    type Value = CreateDatasetRequest;
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("map")
+    }
+    fn visit_map<A>(self, mut map_: A) -> Result<CreateDatasetRequest, A::Error>
+    where
+        A: de::MapAccess<'de>,
+    {
+        let mut file_system_id = None;
+        let mut path = None;
+        while let Some(field_) = map_.next_key()? {
+            match field_ {
+                Field_::FileSystemId => file_system_id = Some(map_.next_value()?),
+                Field_::Path => path = Some(map_.next_value()?),
+                Field_::Unknown_ => {
+                    map_.next_value::<de::IgnoredAny>()?;
+                }
+            }
+        }
+        let file_system_id = match file_system_id {
+            Some(v) => v,
+            None => return Err(de::Error::missing_field("fileSystemId")),
+        };
+        let path = match path {
+            Some(v) => v,
+            None => return Err(de::Error::missing_field("path")),
+        };
+        Ok(CreateDatasetRequest {
+            file_system_id,
+            path,
+        })
+    }
+}
+enum Field_ {
+    FileSystemId,
+    Path,
+    Unknown_,
+}
+impl<'de> de::Deserialize<'de> for Field_ {
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_str(FieldVisitor_)
+    }
+}
+struct FieldVisitor_;
+impl<'de> de::Visitor<'de> for FieldVisitor_ {
+    type Value = Field_;
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("string")
+    }
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
+    where
+        E: de::Error,
+    {
+        let v = match value {
+            "fileSystemId" => Field_::FileSystemId,
+            "path" => Field_::Path,
+            _ => Field_::Unknown_,
+        };
+        Ok(v)
+    }
+}

--- a/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
+++ b/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
@@ -1,0 +1,227 @@
+use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
+use conjure_object::serde::{de, ser};
+use std::fmt;
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct BackingFileSystem {
+    file_system_id: String,
+    base_uri: String,
+    configuration: std::collections::BTreeMap<String, String>,
+}
+impl BackingFileSystem {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T, U, V>(file_system_id: T, base_uri: U, configuration: V) -> BackingFileSystem
+    where
+        T: Into<String>,
+        U: Into<String>,
+        V: IntoIterator<Item = (String, String)>,
+    {
+        BackingFileSystem {
+            file_system_id: file_system_id.into(),
+            base_uri: base_uri.into(),
+            configuration: configuration.into_iter().collect(),
+        }
+    }
+    #[doc = r" Returns a new builder."]
+    #[inline]
+    pub fn builder() -> Builder {
+        Default::default()
+    }
+    #[doc = "The name by which this file system is identified."]
+    #[inline]
+    pub fn file_system_id(&self) -> &str {
+        &*self.file_system_id
+    }
+    #[inline]
+    pub fn base_uri(&self) -> &str {
+        &*self.base_uri
+    }
+    #[inline]
+    pub fn configuration(&self) -> &std::collections::BTreeMap<String, String> {
+        &self.configuration
+    }
+}
+#[doc = "A builder for the `BackingFileSystem` type."]
+#[derive(Debug, Clone, Default)]
+pub struct Builder {
+    file_system_id: Option<String>,
+    base_uri: Option<String>,
+    configuration: std::collections::BTreeMap<String, String>,
+}
+impl Builder {
+    #[doc = "The name by which this file system is identified."]
+    #[doc = r""]
+    #[doc = r" Required."]
+    pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.file_system_id = Some(file_system_id.into());
+        self
+    }
+    #[doc = r""]
+    #[doc = r" Required."]
+    pub fn base_uri<T>(&mut self, base_uri: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.base_uri = Some(base_uri.into());
+        self
+    }
+    pub fn configuration<T>(&mut self, configuration: T) -> &mut Self
+    where
+        T: IntoIterator<Item = (String, String)>,
+    {
+        self.configuration = configuration.into_iter().collect();
+        self
+    }
+    pub fn extend_configuration<T>(&mut self, configuration: T) -> &mut Self
+    where
+        T: IntoIterator<Item = (String, String)>,
+    {
+        self.configuration.extend(configuration);
+        self
+    }
+    pub fn insert_configuration<K, V>(&mut self, key: K, value: V) -> &mut Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.configuration.insert(key.into(), value.into());
+        self
+    }
+    #[doc = r" Constructs a new instance of the type."]
+    #[doc = r""]
+    #[doc = r" # Panics"]
+    #[doc = r""]
+    #[doc = r" Panics if a required field was not set."]
+    #[inline]
+    pub fn build(&self) -> BackingFileSystem {
+        BackingFileSystem {
+            file_system_id: self
+                .file_system_id
+                .clone()
+                .expect("field file_system_id was not set"),
+            base_uri: self.base_uri.clone().expect("field base_uri was not set"),
+            configuration: self.configuration.clone(),
+        }
+    }
+}
+impl From<BackingFileSystem> for Builder {
+    #[inline]
+    fn from(_v: BackingFileSystem) -> Builder {
+        Builder {
+            file_system_id: Some(_v.file_system_id),
+            base_uri: Some(_v.base_uri),
+            configuration: _v.configuration,
+        }
+    }
+}
+impl ser::Serialize for BackingFileSystem {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let mut size = 2usize;
+        let skip_configuration = self.configuration.is_empty();
+        if !skip_configuration {
+            size += 1;
+        }
+        let mut s = s.serialize_struct("BackingFileSystem", size)?;
+        s.serialize_field("fileSystemId", &self.file_system_id)?;
+        s.serialize_field("baseUri", &self.base_uri)?;
+        if skip_configuration {
+            s.skip_field("configuration")?;
+        } else {
+            s.serialize_field("configuration", &self.configuration)?;
+        }
+        s.end()
+    }
+}
+impl<'de> de::Deserialize<'de> for BackingFileSystem {
+    fn deserialize<D>(d: D) -> Result<BackingFileSystem, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_struct(
+            "BackingFileSystem",
+            &["fileSystemId", "baseUri", "configuration"],
+            Visitor_,
+        )
+    }
+}
+struct Visitor_;
+impl<'de> de::Visitor<'de> for Visitor_ {
+    type Value = BackingFileSystem;
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("map")
+    }
+    fn visit_map<A>(self, mut map_: A) -> Result<BackingFileSystem, A::Error>
+    where
+        A: de::MapAccess<'de>,
+    {
+        let mut file_system_id = None;
+        let mut base_uri = None;
+        let mut configuration = None;
+        while let Some(field_) = map_.next_key()? {
+            match field_ {
+                Field_::FileSystemId => file_system_id = Some(map_.next_value()?),
+                Field_::BaseUri => base_uri = Some(map_.next_value()?),
+                Field_::Configuration => configuration = Some(map_.next_value()?),
+                Field_::Unknown_ => {
+                    map_.next_value::<de::IgnoredAny>()?;
+                }
+            }
+        }
+        let file_system_id = match file_system_id {
+            Some(v) => v,
+            None => return Err(de::Error::missing_field("fileSystemId")),
+        };
+        let base_uri = match base_uri {
+            Some(v) => v,
+            None => return Err(de::Error::missing_field("baseUri")),
+        };
+        let configuration = match configuration {
+            Some(v) => v,
+            None => Default::default(),
+        };
+        Ok(BackingFileSystem {
+            file_system_id,
+            base_uri,
+            configuration,
+        })
+    }
+}
+enum Field_ {
+    FileSystemId,
+    BaseUri,
+    Configuration,
+    Unknown_,
+}
+impl<'de> de::Deserialize<'de> for Field_ {
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_str(FieldVisitor_)
+    }
+}
+struct FieldVisitor_;
+impl<'de> de::Visitor<'de> for FieldVisitor_ {
+    type Value = Field_;
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("string")
+    }
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
+    where
+        E: de::Error,
+    {
+        let v = match value {
+            "fileSystemId" => Field_::FileSystemId,
+            "baseUri" => Field_::BaseUri,
+            "configuration" => Field_::Configuration,
+            _ => Field_::Unknown_,
+        };
+        Ok(v)
+    }
+}

--- a/conjure-codegen/src/example_types/product/datasets/dataset.rs
+++ b/conjure-codegen/src/example_types/product/datasets/dataset.rs
@@ -1,0 +1,170 @@
+use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
+use conjure_object::serde::{de, ser};
+use std::fmt;
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct Dataset {
+    file_system_id: String,
+    rid: conjure_object::ResourceIdentifier,
+}
+impl Dataset {
+    #[doc = r" Constructs a new instance of the type."]
+    #[inline]
+    pub fn new<T>(file_system_id: T, rid: conjure_object::ResourceIdentifier) -> Dataset
+    where
+        T: Into<String>,
+    {
+        Dataset {
+            file_system_id: file_system_id.into(),
+            rid: rid,
+        }
+    }
+    #[doc = r" Returns a new builder."]
+    #[inline]
+    pub fn builder() -> Builder {
+        Default::default()
+    }
+    #[inline]
+    pub fn file_system_id(&self) -> &str {
+        &*self.file_system_id
+    }
+    #[doc = "Uniquely identifies this dataset."]
+    #[inline]
+    pub fn rid(&self) -> &conjure_object::ResourceIdentifier {
+        &self.rid
+    }
+}
+#[doc = "A builder for the `Dataset` type."]
+#[derive(Debug, Clone, Default)]
+pub struct Builder {
+    file_system_id: Option<String>,
+    rid: Option<conjure_object::ResourceIdentifier>,
+}
+impl Builder {
+    #[doc = r""]
+    #[doc = r" Required."]
+    pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.file_system_id = Some(file_system_id.into());
+        self
+    }
+    #[doc = "Uniquely identifies this dataset."]
+    #[doc = r""]
+    #[doc = r" Required."]
+    #[inline]
+    pub fn rid(&mut self, rid: conjure_object::ResourceIdentifier) -> &mut Self {
+        self.rid = Some(rid);
+        self
+    }
+    #[doc = r" Constructs a new instance of the type."]
+    #[doc = r""]
+    #[doc = r" # Panics"]
+    #[doc = r""]
+    #[doc = r" Panics if a required field was not set."]
+    #[inline]
+    pub fn build(&self) -> Dataset {
+        Dataset {
+            file_system_id: self
+                .file_system_id
+                .clone()
+                .expect("field file_system_id was not set"),
+            rid: self.rid.clone().expect("field rid was not set"),
+        }
+    }
+}
+impl From<Dataset> for Builder {
+    #[inline]
+    fn from(_v: Dataset) -> Builder {
+        Builder {
+            file_system_id: Some(_v.file_system_id),
+            rid: Some(_v.rid),
+        }
+    }
+}
+impl ser::Serialize for Dataset {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let size = 2usize;
+        let mut s = s.serialize_struct("Dataset", size)?;
+        s.serialize_field("fileSystemId", &self.file_system_id)?;
+        s.serialize_field("rid", &self.rid)?;
+        s.end()
+    }
+}
+impl<'de> de::Deserialize<'de> for Dataset {
+    fn deserialize<D>(d: D) -> Result<Dataset, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_struct("Dataset", &["fileSystemId", "rid"], Visitor_)
+    }
+}
+struct Visitor_;
+impl<'de> de::Visitor<'de> for Visitor_ {
+    type Value = Dataset;
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("map")
+    }
+    fn visit_map<A>(self, mut map_: A) -> Result<Dataset, A::Error>
+    where
+        A: de::MapAccess<'de>,
+    {
+        let mut file_system_id = None;
+        let mut rid = None;
+        while let Some(field_) = map_.next_key()? {
+            match field_ {
+                Field_::FileSystemId => file_system_id = Some(map_.next_value()?),
+                Field_::Rid => rid = Some(map_.next_value()?),
+                Field_::Unknown_ => {
+                    map_.next_value::<de::IgnoredAny>()?;
+                }
+            }
+        }
+        let file_system_id = match file_system_id {
+            Some(v) => v,
+            None => return Err(de::Error::missing_field("fileSystemId")),
+        };
+        let rid = match rid {
+            Some(v) => v,
+            None => return Err(de::Error::missing_field("rid")),
+        };
+        Ok(Dataset {
+            file_system_id,
+            rid,
+        })
+    }
+}
+enum Field_ {
+    FileSystemId,
+    Rid,
+    Unknown_,
+}
+impl<'de> de::Deserialize<'de> for Field_ {
+    fn deserialize<D>(d: D) -> Result<Field_, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_str(FieldVisitor_)
+    }
+}
+struct FieldVisitor_;
+impl<'de> de::Visitor<'de> for FieldVisitor_ {
+    type Value = Field_;
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("string")
+    }
+    fn visit_str<E>(self, value: &str) -> Result<Field_, E>
+    where
+        E: de::Error,
+    {
+        let v = match value {
+            "fileSystemId" => Field_::FileSystemId,
+            "rid" => Field_::Rid,
+            _ => Field_::Unknown_,
+        };
+        Ok(v)
+    }
+}

--- a/conjure-codegen/src/example_types/product/datasets/mod.rs
+++ b/conjure-codegen/src/example_types/product/datasets/mod.rs
@@ -1,0 +1,6 @@
+#[doc(inline)]
+pub use self::backing_file_system::BackingFileSystem;
+#[doc(inline)]
+pub use self::dataset::Dataset;
+pub mod backing_file_system;
+pub mod dataset;

--- a/conjure-codegen/src/example_types/product/date_time_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/date_time_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for DateTimeAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for DateTimeAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for DateTimeAliasExample {
     type Target = conjure_object::DateTime<conjure_object::Utc>;
     #[inline]

--- a/conjure-codegen/src/example_types/product/double_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/double_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for DoubleAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for DoubleAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for DoubleAliasExample {
     type Target = f64;
     #[inline]

--- a/conjure-codegen/src/example_types/product/enum_example.rs
+++ b/conjure-codegen/src/example_types/product/enum_example.rs
@@ -24,6 +24,11 @@ impl fmt::Display for EnumExample {
         fmt::Display::fmt(self.as_str(), fmt)
     }
 }
+impl conjure_object::Plain for EnumExample {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        conjure_object::Plain::fmt(self.as_str(), fmt)
+    }
+}
 impl ser::Serialize for EnumExample {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/conjure-codegen/src/example_types/product/integer_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/integer_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for IntegerAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for IntegerAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for IntegerAliasExample {
     type Target = i32;
     #[inline]

--- a/conjure-codegen/src/example_types/product/mod.rs
+++ b/conjure-codegen/src/example_types/product/mod.rs
@@ -1,6 +1,10 @@
 #[doc(inline)]
 pub use self::alias_as_map_key_example::AliasAsMapKeyExample;
 #[doc(inline)]
+pub use self::aliased_binary::AliasedBinary;
+#[doc(inline)]
+pub use self::aliased_string::AliasedString;
+#[doc(inline)]
 pub use self::any_example::AnyExample;
 #[doc(inline)]
 pub use self::any_map_example::AnyMapExample;
@@ -20,6 +24,8 @@ pub use self::boolean_example::BooleanExample;
 pub use self::covariant_list_example::CovariantListExample;
 #[doc(inline)]
 pub use self::covariant_optional_example::CovariantOptionalExample;
+#[doc(inline)]
+pub use self::create_dataset_request::CreateDatasetRequest;
 #[doc(inline)]
 pub use self::date_time_alias_example::DateTimeAliasExample;
 #[doc(inline)]
@@ -52,6 +58,8 @@ pub use self::many_field_example::ManyFieldExample;
 pub use self::map_alias_example::MapAliasExample;
 #[doc(inline)]
 pub use self::map_example::MapExample;
+#[doc(inline)]
+pub use self::nested_aliased_binary::NestedAliasedBinary;
 #[doc(inline)]
 pub use self::nested_string_alias_example::NestedStringAliasExample;
 #[doc(inline)]
@@ -87,6 +95,8 @@ pub use self::uuid_alias_example::UuidAliasExample;
 #[doc(inline)]
 pub use self::uuid_example::UuidExample;
 pub mod alias_as_map_key_example;
+pub mod aliased_binary;
+pub mod aliased_string;
 pub mod any_example;
 pub mod any_map_example;
 pub mod bearer_token_alias_example;
@@ -97,6 +107,8 @@ pub mod boolean_alias_example;
 pub mod boolean_example;
 pub mod covariant_list_example;
 pub mod covariant_optional_example;
+pub mod create_dataset_request;
+pub mod datasets;
 pub mod date_time_alias_example;
 pub mod date_time_example;
 pub mod double_alias_example;
@@ -113,6 +125,7 @@ pub mod list_example;
 pub mod many_field_example;
 pub mod map_alias_example;
 pub mod map_example;
+pub mod nested_aliased_binary;
 pub mod nested_string_alias_example;
 pub mod optional_example;
 pub mod primitive_optionals_example;

--- a/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
@@ -1,0 +1,37 @@
+use conjure_object::serde::{de, ser};
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+pub struct NestedAliasedBinary(pub super::AliasedBinary);
+impl conjure_object::Plain for NestedAliasedBinary {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
+impl std::ops::Deref for NestedAliasedBinary {
+    type Target = super::AliasedBinary;
+    #[inline]
+    fn deref(&self) -> &super::AliasedBinary {
+        &self.0
+    }
+}
+impl std::ops::DerefMut for NestedAliasedBinary {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut super::AliasedBinary {
+        &mut self.0
+    }
+}
+impl ser::Serialize for NestedAliasedBinary {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        self.0.serialize(s)
+    }
+}
+impl<'de> de::Deserialize<'de> for NestedAliasedBinary {
+    fn deserialize<D>(d: D) -> Result<NestedAliasedBinary, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        de::Deserialize::deserialize(d).map(NestedAliasedBinary)
+    }
+}

--- a/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for NestedStringAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for NestedStringAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for NestedStringAliasExample {
     type Target = super::StringAliasExample;
     #[inline]

--- a/conjure-codegen/src/example_types/product/rid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/rid_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for RidAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for RidAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for RidAliasExample {
     type Target = conjure_object::ResourceIdentifier;
     #[inline]

--- a/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for SafeLongAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for SafeLongAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for SafeLongAliasExample {
     type Target = conjure_object::SafeLong;
     #[inline]

--- a/conjure-codegen/src/example_types/product/string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/string_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for StringAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for StringAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for StringAliasExample {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/example_types/product/uuid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/uuid_alias_example.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for UuidAliasExample {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for UuidAliasExample {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for UuidAliasExample {
     type Target = conjure_object::Uuid;
     #[inline]

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -199,6 +199,7 @@ use crate::context::Context;
 use crate::types::{ConjureDefinition, TypeDefinition};
 
 mod aliases;
+mod clients;
 mod context;
 mod enums;
 mod errors;
@@ -352,6 +353,17 @@ impl Config {
                 contents: errors::generate(&context, def),
             };
             root.insert(&context.module_path(def.error_name()), type_);
+        }
+
+        for def in defs.services() {
+            let type_ = Type {
+                module_name: context.module_name(def.service_name()),
+                type_name: context
+                    .type_name(&format!("{}Client", def.service_name().name()))
+                    .to_string(),
+                contents: clients::generate(&context, def),
+            };
+            root.insert(&context.module_path(def.service_name()), type_);
         }
 
         root

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -181,6 +181,16 @@
 //! assert_eq!(error.code(), ErrorCode::InvalidArgument);
 //! assert_eq!(error.name(), "Conjure:InvalidServiceDefinition");
 //! ```
+//!
+//! ## Services
+//!
+//! Conjure services turn into a client object, which wraps a raw HTTP client and provides methods to interact with the
+//! service's endpoints:
+//!
+//! ```ignore
+//! let client = TestServiceClient::new(http_client);
+//! let file_systems = client.get_file_systems(auth_token)?;
+//! ```
 #![warn(clippy::all, missing_docs)]
 #![doc(html_root_url = "https://docs.rs/conjure-codegen/0.3")]
 #![recursion_limit = "256"]

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -187,9 +187,14 @@
 //! Conjure services turn into a client object, which wraps a raw HTTP client and provides methods to interact with the
 //! service's endpoints:
 //!
-//! ```ignore
+//! ```
+//! # use conjure_codegen::example_types::another::TestServiceClient;
+//! # fn foo<T: conjure_http::client::Client>(http_client: T) -> Result<(), conjure_error::Error> {
+//! # let auth_token = "foobar".parse().unwrap();
 //! let client = TestServiceClient::new(http_client);
-//! let file_systems = client.get_file_systems(auth_token)?;
+//! let file_systems = client.get_file_systems(&auth_token)?;
+//! # Ok(())
+//! # }
 //! ```
 #![warn(clippy::all, missing_docs)]
 #![doc(html_root_url = "https://docs.rs/conjure-codegen/0.3")]

--- a/conjure-codegen/src/types/argument_name.rs
+++ b/conjure-codegen/src/types/argument_name.rs
@@ -7,6 +7,11 @@ impl std::fmt::Display for ArgumentName {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for ArgumentName {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for ArgumentName {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/documentation.rs
+++ b/conjure-codegen/src/types/documentation.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for Documentation {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for Documentation {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for Documentation {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/endpoint_name.rs
+++ b/conjure-codegen/src/types/endpoint_name.rs
@@ -7,6 +7,11 @@ impl std::fmt::Display for EndpointName {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for EndpointName {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for EndpointName {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/error_code.rs
+++ b/conjure-codegen/src/types/error_code.rs
@@ -36,6 +36,11 @@ impl fmt::Display for ErrorCode {
         fmt::Display::fmt(self.as_str(), fmt)
     }
 }
+impl conjure_object::Plain for ErrorCode {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        conjure_object::Plain::fmt(self.as_str(), fmt)
+    }
+}
 impl ser::Serialize for ErrorCode {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/conjure-codegen/src/types/field_name.rs
+++ b/conjure-codegen/src/types/field_name.rs
@@ -7,6 +7,11 @@ impl std::fmt::Display for FieldName {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for FieldName {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for FieldName {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/http_method.rs
+++ b/conjure-codegen/src/types/http_method.rs
@@ -24,6 +24,11 @@ impl fmt::Display for HttpMethod {
         fmt::Display::fmt(self.as_str(), fmt)
     }
 }
+impl conjure_object::Plain for HttpMethod {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        conjure_object::Plain::fmt(self.as_str(), fmt)
+    }
+}
 impl ser::Serialize for HttpMethod {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/conjure-codegen/src/types/http_path.rs
+++ b/conjure-codegen/src/types/http_path.rs
@@ -6,6 +6,11 @@ impl std::fmt::Display for HttpPath {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for HttpPath {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for HttpPath {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/parameter_id.rs
+++ b/conjure-codegen/src/types/parameter_id.rs
@@ -7,6 +7,11 @@ impl std::fmt::Display for ParameterId {
         std::fmt::Display::fmt(&self.0, fmt)
     }
 }
+impl conjure_object::Plain for ParameterId {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        conjure_object::Plain::fmt(&self.0, fmt)
+    }
+}
 impl std::ops::Deref for ParameterId {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/primitive_type.rs
+++ b/conjure-codegen/src/types/primitive_type.rs
@@ -38,6 +38,11 @@ impl fmt::Display for PrimitiveType {
         fmt::Display::fmt(self.as_str(), fmt)
     }
 }
+impl conjure_object::Plain for PrimitiveType {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        conjure_object::Plain::fmt(self.as_str(), fmt)
+    }
+}
 impl ser::Serialize for PrimitiveType {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/conjure-error/src/types/error_code.rs
+++ b/conjure-error/src/types/error_code.rs
@@ -39,6 +39,11 @@ impl fmt::Display for ErrorCode {
         fmt::Display::fmt(self.as_str(), fmt)
     }
 }
+impl conjure_object::Plain for ErrorCode {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        conjure_object::Plain::fmt(self.as_str(), fmt)
+    }
+}
 impl ser::Serialize for ErrorCode {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "conjure-http"
+version = "0.3.1"
+authors = ["Steven Fackler <sfackler@palantir.com>"]
+edition = "2018"
+
+[dependencies]
+http = "0.1"
+percent-encoding = "1.0"
+
+conjure-error = { version = "0.3.1", path = "../conjure-error" }
+conjure-serde = { version = "0.3.1", path = "../conjure-serde" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -3,6 +3,10 @@ name = "conjure-http"
 version = "0.3.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
+license = "Apache-2.0"
+description = "HTTP interfaces for generated Conjure services"
+repository = "https://github.com/palantir/conjure-rust"
+readme = "../README.md"
 
 [dependencies]
 http = "0.1"

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -1,0 +1,52 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use conjure_error::Error;
+use http::{Request, Response};
+use std::io::{Cursor, Read, Write};
+
+pub trait Client {
+    type ResponseBody: Read;
+
+    fn request(&self, req: Request<Body>) -> Result<Response<Self::ResponseBody>, Error>;
+}
+
+pub enum Body {
+    Empty,
+    Fixed(Vec<u8>),
+    Streaming(Box<dyn WriteBody>),
+}
+
+pub trait WriteBody {
+    fn write(&mut self, w: &mut dyn Write) -> Result<(), Error>;
+
+    fn reset(&mut self) -> bool;
+}
+
+impl<T> WriteBody for Cursor<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn write(&mut self, w: &mut dyn Write) -> Result<(), Error> {
+        let buf = &self.get_ref().as_ref()[self.position() as usize..];
+        w.write_all(buf).map_err(Error::internal_safe)?;
+        self.set_position(self.get_ref().as_ref().len() as u64);
+        Ok(())
+    }
+
+    fn reset(&mut self) -> bool {
+        self.set_position(0);
+        true
+    }
+}

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -48,6 +48,8 @@ pub enum Body {
 /// A trait implemented by streaming bodies.
 pub trait WriteBody {
     /// Writes the body out, in its entirety.
+    ///
+    /// Behavior is unspecified if this method is called twice without a successful call to `reset` in between.
     fn write_body(&mut self, w: &mut dyn Write) -> Result<(), Error>;
 
     /// Attempts to reset the body so that it can be written out again.

--- a/conjure-http/src/lib.rs
+++ b/conjure-http/src/lib.rs
@@ -17,6 +17,7 @@
 //! Conjure services generate code that interacts with the types and traits in this crate, so that consumers are not
 //! tightly bound to specific client and server implementations.
 #![warn(missing_docs)]
+#![doc(html_root_url = "https://docs.rs/conjure-http/0.3")]
 
 pub mod client;
 

--- a/conjure-http/src/lib.rs
+++ b/conjure-http/src/lib.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Interfaces for Conjure HTTP clients and servers.
+//!
+//! Conjure services generate code that interacts with the types and traits in this crate, so that consumers are not
+//! tightly bound to specific client and server implementations.
+#![warn(missing_docs)]
+
 pub mod client;
 
 #[doc(hidden)]

--- a/conjure-http/src/lib.rs
+++ b/conjure-http/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod client;
+
+#[doc(hidden)]
+pub mod private;

--- a/conjure-http/src/private.rs
+++ b/conjure-http/src/private.rs
@@ -1,0 +1,18 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use conjure_error::Error;
+pub use conjure_serde::json;
+pub use http;
+pub use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET};

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/palantir/conjure-rust"
 readme = "../README.md"
 
 [dependencies]
+base64 = "0.10"
 serde = "1.0"
 serde_bytes = "0.10"
 serde-value = "0.5"

--- a/conjure-object/src/lib.rs
+++ b/conjure-object/src/lib.rs
@@ -28,12 +28,14 @@ pub use uuid::{self, Uuid};
 
 #[doc(inline)]
 pub use crate::bearer_token::BearerToken;
+pub use crate::plain::*;
 #[doc(inline)]
 pub use crate::resource_identifier::ResourceIdentifier;
 #[doc(inline)]
 pub use crate::safe_long::SafeLong;
 
 pub mod bearer_token;
+mod plain;
 pub mod resource_identifier;
 pub mod safe_long;
 

--- a/conjure-object/src/plain.rs
+++ b/conjure-object/src/plain.rs
@@ -1,0 +1,131 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use base64::display::Base64Display;
+use chrono::format::{Fixed, Item};
+use chrono::{DateTime, Utc};
+use serde_bytes::ByteBuf;
+use std::f64;
+use std::fmt;
+use std::iter;
+use uuid::Uuid;
+
+use crate::{BearerToken, ResourceIdentifier, SafeLong};
+
+/// Format trait for the Conjure PLAIN format.
+pub trait Plain {
+    /// Formats this value in its Conjure PLAIN format.
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;
+}
+
+impl<T> Plain for &T
+where
+    T: ?Sized + Plain,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Plain::fmt(&**self, fmt)
+    }
+}
+
+macro_rules! as_display {
+    ($t:ty) => {
+        impl Plain for $t {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Display::fmt(self, fmt)
+            }
+        }
+    };
+}
+
+as_display!(bool);
+as_display!(i32);
+as_display!(ResourceIdentifier);
+as_display!(SafeLong);
+as_display!(str);
+as_display!(String);
+as_display!(Uuid);
+
+impl Plain for BearerToken {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), fmt)
+    }
+}
+
+impl Plain for DateTime<Utc> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(
+            &self.format_with_items(iter::once(Item::Fixed(Fixed::RFC3339))),
+            fmt,
+        )
+    }
+}
+
+impl Plain for f64 {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_nan() {
+            fmt::Display::fmt("NaN", fmt)
+        } else if *self == f64::INFINITY {
+            fmt::Display::fmt("Infinity", fmt)
+        } else if *self == f64::NEG_INFINITY {
+            fmt::Display::fmt("-Infinity", fmt)
+        } else {
+            fmt::Display::fmt(self, fmt)
+        }
+    }
+}
+
+impl Plain for [u8] {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&Base64Display::with_config(self, base64::STANDARD), fmt)
+    }
+}
+
+impl Plain for Vec<u8> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Plain::fmt(&**self, fmt)
+    }
+}
+
+impl Plain for ByteBuf {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Plain::fmt(&**self, fmt)
+    }
+}
+
+/// A trait for converting a value to its Conjure PLAIN string representation.
+///
+/// This is implemented for all types that implement the `Plain` trait.
+pub trait ToPlain {
+    /// Returns the conjure PLAIN string representation of this value.
+    fn to_plain(&self) -> String;
+}
+
+impl<T> ToPlain for T
+where
+    T: ?Sized + Plain,
+{
+    fn to_plain(&self) -> String {
+        struct Adaptor<T>(T);
+
+        impl<T> fmt::Display for Adaptor<T>
+        where
+            T: Plain,
+        {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                Plain::fmt(&self.0, fmt)
+            }
+        }
+
+        Adaptor(self).to_string()
+    }
+}

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -10,10 +10,12 @@ doctest = false
 [dependencies]
 conjure-object = { path = "../conjure-object" }
 conjure-error = { path = "../conjure-error" }
+conjure-http = { path = "../conjure-http" }
 
 [dev-dependencies]
 serde_json = "1.0"
 base64 = "0.10"
+http = "0.1"
 
 conjure-serde = { path = "../conjure-serde" }
 

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -421,7 +421,7 @@ fn json_request() {
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
         assert_eq!(req.headers(), &headers);
         match req.body() {
-            Body::Fixed(buf) => assert_eq!(&buf[..], r#""hello world""#.as_bytes()),
+            Body::Fixed(buf) => assert_eq!(&buf[..], &br#""hello world""#[..]),
             _ => panic!("wrong body type"),
         }
         Ok(Response::builder()
@@ -440,7 +440,7 @@ fn optional_json_request() {
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
         assert_eq!(req.headers(), &headers);
         match req.body() {
-            Body::Fixed(buf) => assert_eq!(&buf[..], r#""hello world""#.as_bytes()),
+            Body::Fixed(buf) => assert_eq!(&buf[..], &br#""hello world""#[..]),
             _ => panic!("wrong body type"),
         }
         Ok(Response::builder()
@@ -456,7 +456,7 @@ fn optional_json_request() {
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
         assert_eq!(req.headers(), &headers);
         match req.body() {
-            Body::Fixed(buf) => assert_eq!(&buf[..], "null".as_bytes()),
+            Body::Fixed(buf) => assert_eq!(&buf[..], &b"null"[..]),
             _ => panic!("wrong body type"),
         }
         Ok(Response::builder()
@@ -525,7 +525,7 @@ fn json_response() {
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
             .header("Content-Type", "application/json")
-            .body(r#""hello world""#.as_bytes())
+            .body(&br#""hello world""#[..])
             .unwrap())
     }));
 
@@ -538,7 +538,7 @@ fn optional_json_response() {
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
             .header("Content-Type", "application/json")
-            .body(r#""hello world""#.as_bytes())
+            .body(&br#""hello world""#[..])
             .unwrap())
     }));
 
@@ -569,7 +569,7 @@ fn list_json_response() {
     assert_eq!(s, Vec::<String>::new());
 
     let client = TestServiceClient::new(TestClient::new(|_| {
-        Ok(Response::builder().body(r#"["hello"]"#.as_bytes()).unwrap())
+        Ok(Response::builder().body(&br#"["hello"]"#[..]).unwrap())
     }));
 
     let s = client.list_json_response().unwrap();
@@ -589,7 +589,7 @@ fn set_json_response() {
     assert_eq!(s, BTreeSet::new());
 
     let client = TestServiceClient::new(TestClient::new(|_| {
-        Ok(Response::builder().body(r#"["hello"]"#.as_bytes()).unwrap())
+        Ok(Response::builder().body(&br#"["hello"]"#[..]).unwrap())
     }));
 
     let s = client.set_json_response().unwrap();
@@ -612,7 +612,7 @@ fn map_json_response() {
 
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
-            .body(r#"{"hello": "world"}"#.as_bytes())
+            .body(&br#"{"hello": "world"}"#[..])
             .unwrap())
     }));
 
@@ -627,12 +627,12 @@ fn streaming_response() {
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
             .header("Content-Type", "application/octet-stream")
-            .body("foobar".as_bytes())
+            .body(&b"foobar"[..])
             .unwrap())
     }));
 
     let r = client.streaming_response().unwrap();
-    assert_eq!(r, "foobar".as_bytes());
+    assert_eq!(r, &b"foobar"[..]);
 }
 
 #[test]
@@ -640,12 +640,12 @@ fn optional_streaming_response() {
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
             .header("Content-Type", "application/octet-stream")
-            .body("foobar".as_bytes())
+            .body(&b"foobar"[..])
             .unwrap())
     }));
 
     let r = client.optional_streaming_response().unwrap();
-    assert_eq!(r, Some("foobar".as_bytes()));
+    assert_eq!(r, Some(&b"foobar"[..]));
 
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
@@ -663,12 +663,12 @@ fn streaming_alias_response() {
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
             .header("Content-Type", "application/octet-stream")
-            .body("foobar".as_bytes())
+            .body(&b"foobar"[..])
             .unwrap())
     }));
 
     let r = client.streaming_alias_response().unwrap();
-    assert_eq!(r, "foobar".as_bytes());
+    assert_eq!(r, &b"foobar"[..]);
 }
 
 #[test]
@@ -676,12 +676,12 @@ fn optional_streaming_alias_response() {
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()
             .header("Content-Type", "application/octet-stream")
-            .body("foobar".as_bytes())
+            .body(&b"foobar"[..])
             .unwrap())
     }));
 
     let r = client.optional_streaming_alias_response().unwrap();
-    assert_eq!(r, Some("foobar".as_bytes()));
+    assert_eq!(r, Some(&b"foobar"[..]));
 
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -15,6 +15,7 @@ use conjure_error::{Error, ErrorCode, ErrorType};
 use conjure_http::client::{Body, Client};
 use conjure_object::serde::de::DeserializeOwned;
 use conjure_object::serde::Serialize;
+use conjure_object::ResourceIdentifier;
 use http::{Request, Response, StatusCode};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
@@ -298,7 +299,10 @@ fn partially_optional_query_params() {
     client.partially_optional_query_params(None, "hi").unwrap();
 
     let client = TestServiceClient::new(TestClient::new(|req| {
-        assert_eq!(req.uri(), "/test/partiallyOptionalQueryParams?bar=hi&foo=2");
+        assert_eq!(
+            req.uri(),
+            "/test/partiallyOptionalQueryParams?bar=hello%20world&foo=2"
+        );
         Ok(Response::builder()
             .status(StatusCode::NO_CONTENT)
             .body(&[][..])
@@ -306,6 +310,28 @@ fn partially_optional_query_params() {
     }));
 
     client
-        .partially_optional_query_params(Some(2), "hi")
+        .partially_optional_query_params(Some(2), "hello world")
+        .unwrap();
+}
+
+#[test]
+fn path_params() {
+    let client = TestServiceClient::new(TestClient::new(|req| {
+        assert_eq!(
+            req.uri(),
+            "/test/pathParams/hello%20world/false/raw/ri.conjure.main.test.foo"
+        );
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    client
+        .path_params(
+            "hello world",
+            false,
+            &ResourceIdentifier::new("ri.conjure.main.test.foo").unwrap(),
+        )
         .unwrap();
 }

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -421,7 +421,7 @@ fn json_request() {
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
         assert_eq!(req.headers(), &headers);
         match req.body() {
-            Body::Fixed(buf) => assert_eq!(&buf[..], &br#""hello world""#[..]),
+            Body::Fixed(buf) => assert_eq!(&buf[..], r#""hello world""#.as_bytes()),
             _ => panic!("wrong body type"),
         }
         Ok(Response::builder()
@@ -440,7 +440,7 @@ fn optional_json_request() {
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
         assert_eq!(req.headers(), &headers);
         match req.body() {
-            Body::Fixed(buf) => assert_eq!(&buf[..], &br#""hello world""#[..]),
+            Body::Fixed(buf) => assert_eq!(&buf[..], r#""hello world""#.as_bytes()),
             _ => panic!("wrong body type"),
         }
         Ok(Response::builder()
@@ -456,7 +456,7 @@ fn optional_json_request() {
         headers.insert("Content-Type", HeaderValue::from_static("application/json"));
         assert_eq!(req.headers(), &headers);
         match req.body() {
-            Body::Fixed(buf) => assert_eq!(&buf[..], &b"null"[..]),
+            Body::Fixed(buf) => assert_eq!(&buf[..], "null".as_bytes()),
             _ => panic!("wrong body type"),
         }
         Ok(Response::builder()
@@ -491,7 +491,7 @@ fn streaming_request() {
             .unwrap())
     }));
 
-    client.streaming_request(&[0, 1, 2, 3][..]).unwrap()
+    client.streaming_request(&[0, 1, 2, 3][..]).unwrap();
 }
 
 #[test]
@@ -517,5 +517,113 @@ fn streaming_alias_request() {
             .unwrap())
     }));
 
-    client.streaming_alias_request(&[0, 1, 2, 3][..]).unwrap()
+    client.streaming_alias_request(&[0, 1, 2, 3][..]).unwrap();
+}
+
+#[test]
+fn json_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .header("Content-Type", "application/json")
+            .body(r#""hello world""#.as_bytes())
+            .unwrap())
+    }));
+
+    let s = client.json_response().unwrap();
+    assert_eq!(s, "hello world");
+}
+
+#[test]
+fn optional_json_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .header("Content-Type", "application/json")
+            .body(r#""hello world""#.as_bytes())
+            .unwrap())
+    }));
+
+    let s = client.optional_json_response().unwrap();
+    assert_eq!(s, Some("hello world".to_string()));
+
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    let s = client.optional_json_response().unwrap();
+    assert_eq!(s, None);
+}
+
+#[test]
+fn streaming_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .header("Content-Type", "application/octet-stream")
+            .body("foobar".as_bytes())
+            .unwrap())
+    }));
+
+    let r = client.streaming_response().unwrap();
+    assert_eq!(r, "foobar".as_bytes());
+}
+
+#[test]
+fn optional_streaming_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .header("Content-Type", "application/octet-stream")
+            .body("foobar".as_bytes())
+            .unwrap())
+    }));
+
+    let r = client.optional_streaming_response().unwrap();
+    assert_eq!(r, Some("foobar".as_bytes()));
+
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    let r = client.optional_streaming_response().unwrap();
+    assert_eq!(r, None);
+}
+
+#[test]
+fn streaming_alias_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .header("Content-Type", "application/octet-stream")
+            .body("foobar".as_bytes())
+            .unwrap())
+    }));
+
+    let r = client.streaming_alias_response().unwrap();
+    assert_eq!(r, "foobar".as_bytes());
+}
+
+#[test]
+fn optional_streaming_alias_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .header("Content-Type", "application/octet-stream")
+            .body("foobar".as_bytes())
+            .unwrap())
+    }));
+
+    let r = client.optional_streaming_alias_response().unwrap();
+    assert_eq!(r, Some("foobar".as_bytes()));
+
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    let r = client.optional_streaming_alias_response().unwrap();
+    assert_eq!(r, None);
 }

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -15,7 +15,7 @@ use conjure_error::{Error, ErrorCode, ErrorType};
 use conjure_http::client::{Body, Client};
 use conjure_object::serde::de::DeserializeOwned;
 use conjure_object::serde::Serialize;
-use conjure_object::ResourceIdentifier;
+use conjure_object::{BearerToken, ResourceIdentifier};
 use http::header::{HeaderMap, HeaderValue};
 use http::{Request, Response, StatusCode};
 use std::collections::{BTreeMap, BTreeSet};
@@ -626,4 +626,40 @@ fn optional_streaming_alias_response() {
 
     let r = client.optional_streaming_alias_response().unwrap();
     assert_eq!(r, None);
+}
+
+#[test]
+fn header_auth() {
+    let client = TestServiceClient::new(TestClient::new(|req| {
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", HeaderValue::from_static("Bearer fizzbuzz"));
+        assert_eq!(req.headers(), &headers);
+
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    client
+        .header_auth(&BearerToken::new("fizzbuzz").unwrap())
+        .unwrap();
+}
+
+#[test]
+fn cookie_auth() {
+    let client = TestServiceClient::new(TestClient::new(|req| {
+        let mut headers = HeaderMap::new();
+        headers.insert("Cookie", HeaderValue::from_static("foobar=fizzbuzz"));
+        assert_eq!(req.headers(), &headers);
+
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    client
+        .cookie_auth(&BearerToken::new("fizzbuzz").unwrap())
+        .unwrap();
 }

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -557,6 +557,72 @@ fn optional_json_response() {
 }
 
 #[test]
+fn list_json_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    let s = client.list_json_response().unwrap();
+    assert_eq!(s, Vec::<String>::new());
+
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder().body(r#"["hello"]"#.as_bytes()).unwrap())
+    }));
+
+    let s = client.list_json_response().unwrap();
+    assert_eq!(s, vec!["hello".to_string()]);
+}
+
+#[test]
+fn set_json_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    let s = client.set_json_response().unwrap();
+    assert_eq!(s, BTreeSet::new());
+
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder().body(r#"["hello"]"#.as_bytes()).unwrap())
+    }));
+
+    let s = client.set_json_response().unwrap();
+    let mut set = BTreeSet::new();
+    set.insert("hello".to_string());
+    assert_eq!(s, set);
+}
+
+#[test]
+fn map_json_response() {
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(&[][..])
+            .unwrap())
+    }));
+
+    let s = client.map_json_response().unwrap();
+    assert_eq!(s, BTreeMap::new());
+
+    let client = TestServiceClient::new(TestClient::new(|_| {
+        Ok(Response::builder()
+            .body(r#"{"hello": "world"}"#.as_bytes())
+            .unwrap())
+    }));
+
+    let s = client.map_json_response().unwrap();
+    let mut map = BTreeMap::new();
+    map.insert("hello".to_string(), "world".to_string());
+    assert_eq!(s, map);
+}
+
+#[test]
 fn streaming_response() {
     let client = TestServiceClient::new(TestClient::new(|_| {
         Ok(Response::builder()

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -532,14 +532,14 @@
           "optional" : {
             "itemType" : {
               "type" : "primitive",
-              "primitive" : "UUID"
+              "primitive" : "BOOLEAN"
             }
           }
         },
         "paramType" : {
           "type" : "query",
           "query" : {
-            "paramId" : "foo"
+            "paramId" : "foo2"
           }
         },
         "markers" : [ ]
@@ -599,7 +599,7 @@
         "paramType" : {
           "type" : "query",
           "query" : {
-            "paramId" : "foo"
+            "paramId" : "foo2"
           }
         },
         "markers" : [ ]
@@ -653,6 +653,43 @@
         "paramType" : {
           "type" : "path",
           "path" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "headers",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/headers",
+      "args" : [ {
+        "argName" : "foo",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "header",
+          "header" : {
+            "paramId" : "Some-Custom-Header"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "bar",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "header",
+          "header" : {
+            "paramId" : "Some-Optional-Header"
+          }
         },
         "markers" : [ ]
       } ],

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -869,6 +869,28 @@
         }
       },
       "markers" : [ ]
+    }, {
+      "endpointName" : "headerAuth",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/headerAuth",
+      "auth" : {
+        "type" : "header",
+        "header" : { }
+      },
+      "args" : [ ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "cookieAuth",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/cookieAuth",
+      "auth" : {
+        "type" : "cookie",
+        "cookie" : {
+          "cookieName" : "foobar"
+        }
+      },
+      "args" : [ ],
+      "markers" : [ ]
     } ]
   } ]
 }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -516,5 +516,108 @@
       }
     }
   } ],
-  "services" : [ ]
+  "services" : [ {
+    "serviceName" : {
+      "name" : "TestService",
+      "package" : "com.palantir.conjure"
+    },
+    "endpoints" : [ {
+      "endpointName" : "allOptionalQueryParams",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/allOptionalQueryParams",
+      "args" : [ {
+        "argName" : "foo",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "UUID"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "foo"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "bar",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "bar"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "baz",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "baz"
+          }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "partiallyOptionalQueryParams",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/partiallyOptionalQueryParams",
+      "args" : [ {
+        "argName" : "foo",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "foo"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "bar",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "bar"
+          }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    } ]
+  } ]
 }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -788,6 +788,87 @@
         "markers" : [ ]
       } ],
       "markers" : [ ]
+    }, {
+      "endpointName" : "jsonResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/jsonResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "optionalJsonResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/optionalJsonResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "streamingResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/streamingResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "optionalStreamingResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/optionalStreamingResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "BINARY"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "streamingAliasResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/streamingAliasResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "reference",
+        "reference" : {
+          "name" : "BinaryAlias",
+          "package" : "com.palantir.conjure"
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "optionalStreamingAliasResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/optionalStreamingAliasResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "optional",
+        "optional" : {
+          "itemType" : {
+            "type" : "reference",
+            "reference" : {
+              "name" : "BinaryAlias",
+              "package" : "com.palantir.conjure"
+            }
+          }
+        }
+      },
+      "markers" : [ ]
     } ]
   } ]
 }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -507,6 +507,18 @@
     "type" : "alias",
     "alias" : {
       "typeName" : {
+        "name" : "BinaryAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
         "name" : "IntegerAlias",
         "package" : "com.palantir.conjure"
       },
@@ -690,6 +702,88 @@
           "header" : {
             "paramId" : "Some-Optional-Header"
           }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "emptyRequest",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/emptyRequest",
+      "args" : [ ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "jsonRequest",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/jsonRequest",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "optionalJsonRequest",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/optionalJsonRequest",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "streamingRequest",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/streamingRequest",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BINARY"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
+    }, {
+      "endpointName" : "streamingAliasRequest",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/streamingAliasRequest",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "BinaryAlias",
+            "package" : "com.palantir.conjure"
+          }
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
         },
         "markers" : [ ]
       } ],

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -618,6 +618,45 @@
         "markers" : [ ]
       } ],
       "markers" : [ ]
+    }, {
+      "endpointName" : "pathParams",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/pathParams/{foo}/{bar}/raw/{baz}",
+      "args" : [ {
+        "argName" : "foo",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "bar",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BOOLEAN"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "baz",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "RID"
+        },
+        "paramType" : {
+          "type" : "path",
+          "path" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "markers" : [ ]
     } ]
   } ]
 }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -814,6 +814,55 @@
       },
       "markers" : [ ]
     }, {
+      "endpointName" : "listJsonResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/listJsonResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "list",
+        "list" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "setJsonResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/setJsonResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "set",
+        "set" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
+      "endpointName" : "mapJsonResponse",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/mapJsonResponse",
+      "args" : [ ],
+      "returns" : {
+        "type" : "map",
+        "map" : {
+          "keyType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          },
+          "valueType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      },
+      "markers" : [ ]
+    }, {
       "endpointName" : "streamingResponse",
       "httpMethod" : "GET",
       "httpPath" : "/test/streamingResponse",

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -76,3 +76,31 @@ types:
           bar: integer
         unsafe-args:
           unsafeFoo: boolean
+
+services:
+  TestService:
+    name: Test Service
+    package: com.palantir.conjure
+    base-path: /test
+    endpoints:
+      allOptionalQueryParams:
+        http: GET /allOptionalQueryParams
+        args:
+          foo:
+            type: optional<uuid>
+            param-type: query
+          bar:
+            type: list<string>
+            param-type: query
+          baz:
+            type: set<integer>
+            param-type: query
+      partiallyOptionalQueryParams:
+        http: GET /partiallyOptionalQueryParams
+        args:
+          foo:
+            type: optional<integer>
+            param-type: query
+          bar:
+            type: string
+            param-type: query

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -104,3 +104,9 @@ services:
           bar:
             type: string
             param-type: query
+      pathParams:
+        http: GET /pathParams/{foo}/{bar}/raw/{baz}
+        args:
+          foo: string
+          bar: boolean
+          baz: rid

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -161,3 +161,9 @@ services:
       optionalStreamingAliasResponse:
         http: GET /optionalStreamingAliasResponse
         returns: optional<BinaryAlias>
+      headerAuth:
+        http: GET /headerAuth
+        auth: header
+      cookieAuth:
+        http: GET /cookieAuth
+        auth: cookie:foobar

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -87,8 +87,9 @@ services:
         http: GET /allOptionalQueryParams
         args:
           foo:
-            type: optional<uuid>
+            type: optional<boolean>
             param-type: query
+            param-id: foo2
           bar:
             type: list<string>
             param-type: query
@@ -101,6 +102,7 @@ services:
           foo:
             type: optional<integer>
             param-type: query
+            param-id: foo2
           bar:
             type: string
             param-type: query
@@ -110,3 +112,14 @@ services:
           foo: string
           bar: boolean
           baz: rid
+      headers:
+        http: GET /headers
+        args:
+          foo:
+            type: string
+            param-type: header
+            param-id: Some-Custom-Header
+          bar:
+            type: optional<integer>
+            param-type: header
+            param-id: Some-Optional-Header

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -149,6 +149,15 @@ services:
       optionalJsonResponse:
         http: GET /optionalJsonResponse
         returns: optional<string>
+      listJsonResponse:
+        http: GET /listJsonResponse
+        returns: list<string>
+      setJsonResponse:
+        http: GET /setJsonResponse
+        returns: set<string>
+      mapJsonResponse:
+        http: GET /mapJsonResponse
+        returns: map<string, string>
       streamingResponse:
         http: GET /streamingResponse
         returns: binary

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -143,3 +143,21 @@ services:
         http: POST /streamingAliasRequest
         args:
           body: BinaryAlias
+      jsonResponse:
+        http: GET /jsonResponse
+        returns: string
+      optionalJsonResponse:
+        http: GET /optionalJsonResponse
+        returns: optional<string>
+      streamingResponse:
+        http: GET /streamingResponse
+        returns: binary
+      optionalStreamingResponse:
+        http: GET /optionalStreamingResponse
+        returns: optional<binary>
+      streamingAliasResponse:
+        http: GET /streamingAliasResponse
+        returns: BinaryAlias
+      optionalStreamingAliasResponse:
+        http: GET /optionalStreamingAliasResponse
+        returns: optional<BinaryAlias>

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -36,6 +36,8 @@ types:
         alias: TestUnion
       OptionalObjectAlias:
         alias: optional<TestObject>
+      BinaryAlias:
+        alias: binary
       TransparentAliases:
         fields:
           optionalOfAlias: optional<IntegerAlias>
@@ -123,3 +125,21 @@ services:
             type: optional<integer>
             param-type: header
             param-id: Some-Optional-Header
+      emptyRequest:
+        http: POST /emptyRequest
+      jsonRequest:
+        http: POST /jsonRequest
+        args:
+          body: string
+      optionalJsonRequest:
+        http: POST /optionalJsonRequest
+        args:
+          body: optional<string>
+      streamingRequest:
+        http: POST /streamingRequest
+        args:
+          body: binary
+      streamingAliasRequest:
+        http: POST /streamingAliasRequest
+        args:
+          body: BinaryAlias


### PR DESCRIPTION
We want to enable code generation to evolve separately from the HTTP
client/server logic, so the conjure-http crate just contains a tiny shim
interface that we generate code targetting and the real clients/servers
work with generically.

In the case of clients, we generate a struct which wraps a generic
`Client` implementation and has methods per endpoint that handle the
serialization and deserialization logic.