### PR TITLE
Push path construction into clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "conjure-error 0.3.1",
  "conjure-serde 0.3.1",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -354,11 +354,6 @@ dependencies = [
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -863,7 +858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
-"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum proptest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27f275a76b824714046ce0b1e00323e06437e027f2d31b2b6272cae30afaf18d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -18,24 +18,28 @@ where
         std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
         conjure_http::private::Error,
     > {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = "/catalog/fileSystems".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/fileSystems",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
@@ -49,38 +53,42 @@ where
         request: &super::super::product::CreateDatasetRequest,
         test_header_arg: &str,
     ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(&request)
-                    .map_err(conjure_http::private::Error::internal)?,
-            ));
-        *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = "/catalog/datasets".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::CONTENT_TYPE,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::HeaderName::from_static("test-header"),
             conjure_http::private::http::header::HeaderValue::from_shared(
                 conjure_object::ToPlain::to_plain(&test_header_arg).into(),
             )
             .map_err(conjure_http::private::Error::internal_safe)?,
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::POST,
+            "/catalog/datasets",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(&request)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ),
+        )?;
         conjure_http::private::json::client_from_reader(response.body_mut())
             .map_err(conjure_http::private::Error::internal)
     }
@@ -90,30 +98,32 @@ where
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
     {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
@@ -126,32 +136,34 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<T::ResponseBody, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/raw",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static(
                 "application/octet-stream",
             ),
         );
-        let response = self.0.request(request_)?;
+        let response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/raw",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         Ok(response.into_body())
     }
     pub fn get_aliased_raw_data(
@@ -159,32 +171,34 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<T::ResponseBody, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/raw-aliased",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static(
                 "application/octet-stream",
             ),
         );
-        let response = self.0.request(request_)?;
+        let response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/raw-aliased",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         Ok(response.into_body())
     }
     pub fn maybe_get_raw_data(
@@ -192,32 +206,34 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<Option<T::ResponseBody>, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/raw-maybe",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static(
                 "application/octet-stream",
             ),
         );
-        let response = self.0.request(request_)?;
+        let response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/raw-maybe",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(None)
         } else {
@@ -229,30 +245,32 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<super::super::product::AliasedString, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/string-aliased",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/string-aliased",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         conjure_http::private::json::client_from_reader(response.body_mut())
             .map_err(conjure_http::private::Error::internal)
     }
@@ -265,27 +283,30 @@ where
         U: conjure_http::client::IntoWriteBody,
     {
         let mut input = input.into_write_body();
-        let mut request_ = conjure_http::private::http::Request::new(
-            conjure_http::client::Body::Streaming(&mut input),
-        );
-        *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = "/catalog/datasets/upload-raw".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::CONTENT_TYPE,
             conjure_http::private::http::header::HeaderValue::from_static(
                 "application/octet-stream",
             ),
         );
-        self.0.request(request_)?;
+        self.0.request(
+            conjure_http::private::http::Method::POST,
+            "/catalog/datasets/upload-raw",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Streaming(&mut input),
+        )?;
         Ok(())
     }
     pub fn upload_aliased_raw_data<U>(
@@ -297,27 +318,30 @@ where
         U: conjure_http::client::IntoWriteBody,
     {
         let mut input = input.into_write_body();
-        let mut request_ = conjure_http::private::http::Request::new(
-            conjure_http::client::Body::Streaming(&mut input),
-        );
-        *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = "/catalog/datasets/upload-raw-aliased".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::CONTENT_TYPE,
             conjure_http::private::http::header::HeaderValue::from_static(
                 "application/octet-stream",
             ),
         );
-        self.0.request(request_)?;
+        self.0.request(
+            conjure_http::private::http::Method::POST,
+            "/catalog/datasets/upload-raw-aliased",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Streaming(&mut input),
+        )?;
         Ok(())
     }
     pub fn get_branches(
@@ -325,30 +349,32 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/branches",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/branches",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
@@ -363,30 +389,32 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/branchesDeprecated",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/branchesDeprecated",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
@@ -400,34 +428,33 @@ where
         dataset_rid: &conjure_object::ResourceIdentifier,
         branch: &str,
     ) -> Result<Option<String>, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/branches/{}/resolve",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&branch).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        path_params_.insert("branch", conjure_object::ToPlain::to_plain(&branch));
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
@@ -440,30 +467,32 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<Option<String>, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = format!(
-            "/catalog/datasets/{}/testParam",
-            conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(&dataset_rid).as_bytes(),
-                conjure_http::private::PATH_SEGMENT_ENCODE_SET,
-            ),
+        let mut path_params_ = conjure_http::PathParams::new();
+        path_params_.insert(
+            "datasetRid",
+            conjure_object::ToPlain::to_plain(&dataset_rid),
         );
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/datasets/{datasetRid}/testParam",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
@@ -481,62 +510,51 @@ where
         set_end: &std::collections::BTreeSet<String>,
         optional_end: Option<&conjure_object::ResourceIdentifier>,
     ) -> Result<i32, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(&query)
-                    .map_err(conjure_http::private::Error::internal)?,
-            ));
-        *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let mut path_ = "/catalog/test-query-params".to_string();
-        path_.push_str("?different=");
-        path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(&something).as_bytes(),
-            conjure_http::private::QUERY_ENCODE_SET,
-        ));
-        path_.push_str("&implicit=");
-        path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(&implicit).as_bytes(),
-            conjure_http::private::QUERY_ENCODE_SET,
-        ));
-        for value in optional_middle.iter() {
-            path_.push_str("&optionalMiddle=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        for value in set_end.iter() {
-            path_.push_str("&setEnd=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        for value in optional_end.iter() {
-            path_.push_str("&optionalEnd=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        query_params_.insert("different", conjure_object::ToPlain::to_plain(&something));
+        query_params_.insert_all(
+            "optionalMiddle",
+            optional_middle
+                .iter()
+                .map(conjure_object::ToPlain::to_plain),
+        );
+        query_params_.insert("implicit", conjure_object::ToPlain::to_plain(&implicit));
+        query_params_.insert_all(
+            "setEnd",
+            set_end.iter().map(conjure_object::ToPlain::to_plain),
+        );
+        query_params_.insert_all(
+            "optionalEnd",
+            optional_end.iter().map(conjure_object::ToPlain::to_plain),
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::CONTENT_TYPE,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::POST,
+            "/catalog/test-query-params",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(&query)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ),
+        )?;
         conjure_http::private::json::client_from_reader(response.body_mut())
             .map_err(conjure_http::private::Error::internal)
     }
@@ -550,82 +568,75 @@ where
         set_end: &std::collections::BTreeSet<String>,
         optional_end: Option<&conjure_object::ResourceIdentifier>,
     ) -> Result<(), conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(&query)
-                    .map_err(conjure_http::private::Error::internal)?,
-            ));
-        *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let mut path_ = "/catalog/test-no-response-query-params".to_string();
-        path_.push_str("?different=");
-        path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(&something).as_bytes(),
-            conjure_http::private::QUERY_ENCODE_SET,
-        ));
-        path_.push_str("&implicit=");
-        path_.extend(conjure_http::private::percent_encode(
-            conjure_object::ToPlain::to_plain(&implicit).as_bytes(),
-            conjure_http::private::QUERY_ENCODE_SET,
-        ));
-        for value in optional_middle.iter() {
-            path_.push_str("&optionalMiddle=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        for value in set_end.iter() {
-            path_.push_str("&setEnd=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        for value in optional_end.iter() {
-            path_.push_str("&optionalEnd=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        query_params_.insert("different", conjure_object::ToPlain::to_plain(&something));
+        query_params_.insert_all(
+            "optionalMiddle",
+            optional_middle
+                .iter()
+                .map(conjure_object::ToPlain::to_plain),
+        );
+        query_params_.insert("implicit", conjure_object::ToPlain::to_plain(&implicit));
+        query_params_.insert_all(
+            "setEnd",
+            set_end.iter().map(conjure_object::ToPlain::to_plain),
+        );
+        query_params_.insert_all(
+            "optionalEnd",
+            optional_end.iter().map(conjure_object::ToPlain::to_plain),
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::CONTENT_TYPE,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        self.0.request(request_)?;
+        self.0.request(
+            conjure_http::private::http::Method::POST,
+            "/catalog/test-no-response-query-params",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(&query)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ),
+        )?;
         Ok(())
     }
     pub fn test_boolean(
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<bool, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = "/catalog/boolean".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/boolean",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         conjure_http::private::json::client_from_reader(response.body_mut())
             .map_err(conjure_http::private::Error::internal)
     }
@@ -633,24 +644,28 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<f64, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = "/catalog/double".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/double",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         conjure_http::private::json::client_from_reader(response.body_mut())
             .map_err(conjure_http::private::Error::internal)
     }
@@ -658,24 +673,28 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<i32, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let path_ = "/catalog/integer".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/integer",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         conjure_http::private::json::client_from_reader(response.body_mut())
             .map_err(conjure_http::private::Error::internal)
     }
@@ -684,31 +703,35 @@ where
         auth_: &conjure_object::BearerToken,
         maybe_string: Option<&str>,
     ) -> Result<Option<String>, conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Fixed(
-                conjure_http::private::json::to_vec(&maybe_string)
-                    .map_err(conjure_http::private::Error::internal)?,
-            ));
-        *request_.method_mut() = conjure_http::private::http::Method::POST;
-        let path_ = "/catalog/optional".to_string();
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::CONTENT_TYPE,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        request_.headers_mut().insert(
+        headers_.insert(
             conjure_http::private::http::header::ACCEPT,
             conjure_http::private::http::header::HeaderValue::from_static("application/json"),
         );
-        let mut response = self.0.request(request_)?;
+        let mut response = self.0.request(
+            conjure_http::private::http::Method::POST,
+            "/catalog/optional",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Fixed(
+                conjure_http::private::json::to_vec(&maybe_string)
+                    .map_err(conjure_http::private::Error::internal)?,
+            ),
+        )?;
         if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
             Ok(Default::default())
         } else {
@@ -722,49 +745,32 @@ where
         maybe_integer: Option<i32>,
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error> {
-        let mut request_ =
-            conjure_http::private::http::Request::new(conjure_http::client::Body::Empty);
-        *request_.method_mut() = conjure_http::private::http::Method::GET;
-        let mut path_ = "/catalog/optional-integer-double".to_string();
-        let mut first_ = true;
-        for value in maybe_integer.iter() {
-            let ch = if first_ {
-                first_ = false;
-                '?'
-            } else {
-                '&'
-            };
-            path_.push(ch);
-            path_.push_str("maybeInteger=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        for value in maybe_double.iter() {
-            let ch = if first_ {
-                first_ = false;
-                '?'
-            } else {
-                '&'
-            };
-            path_.push(ch);
-            path_.push_str("maybeDouble=");
-            path_.extend(conjure_http::private::percent_encode(
-                conjure_object::ToPlain::to_plain(value).as_bytes(),
-                conjure_http::private::QUERY_ENCODE_SET,
-            ));
-        }
-        *request_.uri_mut() = conjure_http::private::http::Uri::from_shared(path_.into())
-            .expect("URI should be valid");
-        request_.headers_mut().insert(
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        query_params_.insert_all(
+            "maybeInteger",
+            maybe_integer.iter().map(conjure_object::ToPlain::to_plain),
+        );
+        query_params_.insert_all(
+            "maybeDouble",
+            maybe_double.iter().map(conjure_object::ToPlain::to_plain),
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        headers_.insert(
             conjure_http::private::http::header::AUTHORIZATION,
             conjure_http::private::http::header::HeaderValue::from_shared(
                 format!("Bearer {}", auth_.as_str()).into(),
             )
             .expect("bearer tokens are valid headers"),
         );
-        self.0.request(request_)?;
+        self.0.request(
+            conjure_http::private::http::Method::GET,
+            "/catalog/optional-integer-double",
+            path_params_,
+            query_params_,
+            headers_,
+            conjure_http::client::Body::Empty,
+        )?;
         Ok(())
     }
 }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 
 [dependencies]
 http = "0.1"
-percent-encoding = "1.0"
+lazy_static = "1.0"
 
 conjure-error = { version = "0.3.1", path = "../conjure-error" }
 conjure-serde = { version = "0.3.1", path = "../conjure-serde" }

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -15,7 +15,7 @@
 //! The Conjure HTTP client API.
 
 use conjure_error::Error;
-use http::{HeaderMap, Response, Method};
+use http::{HeaderMap, Method, Response};
 use std::io::{Read, Write};
 
 use crate::{PathParams, QueryParams};

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -15,8 +15,10 @@
 //! The Conjure HTTP client API.
 
 use conjure_error::Error;
-use http::{Request, Response};
+use http::{HeaderMap, Response, Method};
 use std::io::{Read, Write};
+
+use crate::{PathParams, QueryParams};
 
 /// A trait implemented by HTTP client implementations.
 pub trait Client {
@@ -25,14 +27,22 @@ pub trait Client {
 
     /// Makes an HTTP request.
     ///
-    /// The request's URI will be absolute-form, and it is the responsibility of the client to add the authority and
-    /// any extra context path required. The request body will be unencoded, and the request will not include a
-    /// `Content-Length` header.
+    /// The client is responsible for assembling the request URI. It is provided with the path template, unencoded path
+    /// parameters, and unencoded query parameters. The request body is also unencoded, and the header map will not
+    /// include a `Content-Length` header.
     ///
     /// A response must only be returned if it has a 2xx status code. The client is responsible for handling all other
     /// status codes (for example, converting a 5xx response into a service error). The client is also responsible for
     /// decoding the response body if necessary.
-    fn request(&self, req: Request<Body<'_>>) -> Result<Response<Self::ResponseBody>, Error>;
+    fn request(
+        &self,
+        method: Method,
+        path: &'static str,
+        path_params: PathParams,
+        query_params: QueryParams,
+        headers: HeaderMap,
+        body: Body<'_>,
+    ) -> Result<Response<Self::ResponseBody>, Error>;
 }
 
 /// The body type used by a request.

--- a/conjure-http/src/lib.rs
+++ b/conjure-http/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! Conjure services generate code that interacts with the types and traits in this crate, so that consumers are not
 //! tightly bound to specific client and server implementations.
-#![warn(missing_docs)]
+#![warn(missing_docs, clippy::all)]
 #![doc(html_root_url = "https://docs.rs/conjure-http/0.3")]
 
 #[doc(inline)]

--- a/conjure-http/src/lib.rs
+++ b/conjure-http/src/lib.rs
@@ -19,7 +19,15 @@
 #![warn(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/conjure-http/0.3")]
 
+#[doc(inline)]
+pub use crate::path_params::PathParams;
+
+#[doc(inline)]
+pub use crate::query_params::QueryParams;
+
 pub mod client;
+pub mod path_params;
+pub mod query_params;
 
 #[doc(hidden)]
 pub mod private;

--- a/conjure-http/src/path_params.rs
+++ b/conjure-http/src/path_params.rs
@@ -1,0 +1,89 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Path parameters.
+
+use std::collections::hash_map::{self, HashMap};
+use std::ops::Index;
+
+/// A data structure storing the path parameters of the request.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PathParams(HashMap<String, String>);
+
+impl PathParams {
+    /// Creates a new, empty `PathParams`.
+    #[inline]
+    pub fn new() -> PathParams {
+        PathParams::default()
+    }
+
+    /// Inserts a parameter.
+    #[inline]
+    pub fn insert<T, U>(&mut self, key: T, value: U)
+    where
+        T: Into<String>,
+        U: Into<String>,
+    {
+        self.0.insert(key.into(), value.into());
+    }
+
+    /// Returns an iterator over the parameters.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_> {
+        Iter(self.0.iter())
+    }
+}
+
+impl<'a> IntoIterator for &'a PathParams {
+    type IntoIter = Iter<'a>;
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+impl<'a> Index<&'a str> for PathParams {
+    type Output = str;
+
+    #[inline]
+    fn index(&self, key: &'a str) -> &str {
+        &self.0[key]
+    }
+}
+
+/// An iterator over path parameters.
+pub struct Iter<'a>(hash_map::Iter<'a, String, String>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a str, &'a str)> {
+        self.0.next().map(|v| (&**v.0, &**v.1))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/conjure-http/src/private.rs
+++ b/conjure-http/src/private.rs
@@ -15,4 +15,3 @@
 pub use conjure_error::Error;
 pub use conjure_serde::json;
 pub use http;
-pub use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET, QUERY_ENCODE_SET};

--- a/conjure-http/src/query_params/mod.rs
+++ b/conjure-http/src/query_params/mod.rs
@@ -1,0 +1,118 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Query parameters.
+use std::collections::hash_map::{self, Entry, HashMap};
+use std::ops::Index;
+
+#[doc(inline)]
+pub use crate::query_params::values::Values;
+
+pub mod values;
+
+/// A data structure storing the query parameters of a request.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct QueryParams(HashMap<String, Values>);
+
+impl QueryParams {
+    /// Creates a new, empty `QueryParams`.
+    #[inline]
+    pub fn new() -> QueryParams {
+        QueryParams::default()
+    }
+
+    /// Inserts a parameter.
+    ///
+    /// If the key already exists, the new value will be added to the existing values.
+    pub fn insert<T, U>(&mut self, key: T, value: U)
+    where
+        T: Into<String>,
+        U: Into<String>,
+    {
+        self.0
+            .entry(key.into())
+            .or_insert_with(Values::new)
+            .push(value)
+    }
+
+    /// Inserts multiple parameters.
+    ///
+    /// If the key already exists, the new values will be added to the existing values.
+    pub fn insert_all<T, U, I>(&mut self, key: T, values: I)
+    where
+        T: Into<String>,
+        U: Into<String>,
+        I: IntoIterator<Item = U>,
+    {
+        match self.0.entry(key.into()) {
+            Entry::Occupied(mut e) => e.get_mut().extend(values),
+            Entry::Vacant(e) => {
+                let mut new = Values::new();
+                new.extend(values);
+                if !new.is_empty() {
+                    e.insert(new);
+                }
+            }
+        }
+    }
+
+    /// Returns an iterator over the parameters.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_> {
+        Iter(self.0.iter())
+    }
+}
+
+impl<'a> IntoIterator for &'a QueryParams {
+    type IntoIter = Iter<'a>;
+    type Item = (&'a str, &'a Values);
+
+    #[inline]
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+impl<'a> Index<&'a str> for QueryParams {
+    type Output = Values;
+
+    #[inline]
+    fn index(&self, key: &'a str) -> &Values {
+        self.0.get(key).unwrap_or_else(|| &*values::EMPTY)
+    }
+}
+
+/// An iterator over query parameters.
+pub struct Iter<'a>(hash_map::Iter<'a, String, Values>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a str, &'a Values);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a str, &'a Values)> {
+        self.0.next().map(|v| (&**v.0, v.1))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/conjure-http/src/query_params/values.rs
+++ b/conjure-http/src/query_params/values.rs
@@ -1,0 +1,103 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Query parameter values.
+
+use lazy_static::lazy_static;
+use std::slice;
+
+// FIXME replace with const fn Values::new once Vec::new is const
+lazy_static! {
+    pub(crate) static ref EMPTY: Values = Values::new();
+}
+
+/// A data structure storing the values for a specific query parameter.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Values(Vec<String>);
+
+impl Values {
+    #[inline]
+    pub(crate) fn new() -> Values {
+        Values(vec![])
+    }
+
+    #[inline]
+    pub(crate) fn push<T>(&mut self, value: T)
+    where
+        T: Into<String>,
+    {
+        self.0.push(value.into());
+    }
+
+    #[inline]
+    pub(crate) fn extend<T, I>(&mut self, values: I)
+    where
+        T: Into<String>,
+        I: IntoIterator<Item = T>,
+    {
+        self.0.extend(values.into_iter().map(|s| s.into()));
+    }
+
+    /// Returns `true` if there are no values corresponding to the key.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the number of values.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns an iterator over the values.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_> {
+        Iter(self.0.iter())
+    }
+}
+
+impl<'a> IntoIterator for &'a Values {
+    type IntoIter = Iter<'a>;
+    type Item = &'a str;
+
+    #[inline]
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+
+/// An iterator over query parameter values.
+pub struct Iter<'a>(slice::Iter<'a, String>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a str;
+
+    #[inline]
+    fn next(&mut self) -> Option<&'a str> {
+        self.0.next().map(|v| &**v)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a> ExactSizeIterator for Iter<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/conjure-http/src/query_params/values.rs
+++ b/conjure-http/src/query_params/values.rs
@@ -46,7 +46,7 @@ impl Values {
         T: Into<String>,
         I: IntoIterator<Item = T>,
     {
-        self.0.extend(values.into_iter().map(|s| s.into()));
+        self.0.extend(values.into_iter().map(Into::into));
     }
 
     /// Returns `true` if there are no values corresponding to the key.

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -94,19 +94,6 @@
       } ]
     }
   }, {
-    "type" : "enum",
-    "enum" : {
-      "typeName" : {
-        "name" : "TestEnum",
-        "package" : "com.palantir.conjure"
-      },
-      "values" : [ {
-        "value" : "ONE"
-      }, {
-        "value" : "TWO"
-      } ]
-    }
-  }, {
     "type" : "alias",
     "alias" : {
       "typeName" : {
@@ -122,6 +109,19 @@
           }
         }
       }
+    }
+  }, {
+    "type" : "enum",
+    "enum" : {
+      "typeName" : {
+        "name" : "TestEnum",
+        "package" : "com.palantir.conjure"
+      },
+      "values" : [ {
+        "value" : "ONE"
+      }, {
+        "value" : "TWO"
+      } ]
     }
   }, {
     "type" : "alias",
@@ -255,21 +255,6 @@
     "type" : "object",
     "object" : {
       "typeName" : {
-        "name" : "TestObject",
-        "package" : "com.palantir.conjure"
-      },
-      "fields" : [ {
-        "fieldName" : "foo",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "INTEGER"
-        }
-      } ]
-    }
-  }, {
-    "type" : "object",
-    "object" : {
-      "typeName" : {
         "name" : "OtherSubpackageObject",
         "package" : "com.palantir.conjure.bar.baz"
       },
@@ -281,6 +266,21 @@
             "name" : "SubpackageObject",
             "package" : "com.palantir.conjure.foo"
           }
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "TestObject",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "foo",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "INTEGER"
         }
       } ]
     }
@@ -432,6 +432,21 @@
       }
     }
   }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "UnionAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "reference",
+        "reference" : {
+          "name" : "TestUnion",
+          "package" : "com.palantir.conjure"
+        }
+      }
+    }
+  }, {
     "type" : "object",
     "object" : {
       "typeName" : {
@@ -492,21 +507,6 @@
     "type" : "alias",
     "alias" : {
       "typeName" : {
-        "name" : "UnionAlias",
-        "package" : "com.palantir.conjure"
-      },
-      "alias" : {
-        "type" : "reference",
-        "reference" : {
-          "name" : "TestUnion",
-          "package" : "com.palantir.conjure"
-        }
-      }
-    }
-  }, {
-    "type" : "alias",
-    "alias" : {
-      "typeName" : {
         "name" : "BinaryAlias",
         "package" : "com.palantir.conjure"
       },
@@ -534,14 +534,63 @@
       "package" : "com.palantir.conjure"
     },
     "endpoints" : [ {
-      "endpointName" : "allOptionalQueryParams",
+      "endpointName" : "queryParams",
       "httpMethod" : "GET",
-      "httpPath" : "/test/allOptionalQueryParams",
+      "httpPath" : "/test/queryParams",
       "args" : [ {
-        "argName" : "foo",
+        "argName" : "normal",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "normal"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "optional",
         "type" : {
           "type" : "optional",
           "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "custom"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "list",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "list"
+          }
+        },
+        "markers" : [ ]
+      }, {
+        "argName" : "set",
+        "type" : {
+          "type" : "set",
+          "set" : {
             "itemType" : {
               "type" : "primitive",
               "primitive" : "BOOLEAN"
@@ -551,80 +600,7 @@
         "paramType" : {
           "type" : "query",
           "query" : {
-            "paramId" : "foo2"
-          }
-        },
-        "markers" : [ ]
-      }, {
-        "argName" : "bar",
-        "type" : {
-          "type" : "list",
-          "list" : {
-            "itemType" : {
-              "type" : "primitive",
-              "primitive" : "STRING"
-            }
-          }
-        },
-        "paramType" : {
-          "type" : "query",
-          "query" : {
-            "paramId" : "bar"
-          }
-        },
-        "markers" : [ ]
-      }, {
-        "argName" : "baz",
-        "type" : {
-          "type" : "set",
-          "set" : {
-            "itemType" : {
-              "type" : "primitive",
-              "primitive" : "INTEGER"
-            }
-          }
-        },
-        "paramType" : {
-          "type" : "query",
-          "query" : {
-            "paramId" : "baz"
-          }
-        },
-        "markers" : [ ]
-      } ],
-      "markers" : [ ]
-    }, {
-      "endpointName" : "partiallyOptionalQueryParams",
-      "httpMethod" : "GET",
-      "httpPath" : "/test/partiallyOptionalQueryParams",
-      "args" : [ {
-        "argName" : "foo",
-        "type" : {
-          "type" : "optional",
-          "optional" : {
-            "itemType" : {
-              "type" : "primitive",
-              "primitive" : "INTEGER"
-            }
-          }
-        },
-        "paramType" : {
-          "type" : "query",
-          "query" : {
-            "paramId" : "foo2"
-          }
-        },
-        "markers" : [ ]
-      }, {
-        "argName" : "bar",
-        "type" : {
-          "type" : "primitive",
-          "primitive" : "STRING"
-        },
-        "paramType" : {
-          "type" : "query",
-          "query" : {
-            "paramId" : "bar"
+            "paramId" : "set"
           }
         },
         "markers" : [ ]

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -85,28 +85,21 @@ services:
     package: com.palantir.conjure
     base-path: /test
     endpoints:
-      allOptionalQueryParams:
-        http: GET /allOptionalQueryParams
+      queryParams:
+        http: GET /queryParams
         args:
-          foo:
-            type: optional<boolean>
+          normal:
+            type: string
             param-type: query
-            param-id: foo2
-          bar:
-            type: list<string>
-            param-type: query
-          baz:
-            type: set<integer>
-            param-type: query
-      partiallyOptionalQueryParams:
-        http: GET /partiallyOptionalQueryParams
-        args:
-          foo:
+          optional:
             type: optional<integer>
             param-type: query
-            param-id: foo2
-          bar:
-            type: string
+            param-id: custom
+          list:
+            type: list<integer>
+            param-type: query
+          set:
+            type: set<boolean>
             param-type: query
       pathParams:
         http: GET /pathParams/{foo}/{bar}/raw/{baz}


### PR DESCRIPTION
It's generally preferable to move complexity out of generated code and into the
http client. This is the first step, which just handles path construction.
Request and response handling is a follow-up.