### PR TITLE
Push body deserialization to the client.

### DIFF
--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -28,25 +28,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::DefaultSerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/fileSystems",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(Default::default())
-        } else {
-            conjure_http::private::json::client_from_reader(response.body_mut())
-                .map_err(conjure_http::private::Error::internal)
-        }
+            response_visitor_,
+        )
     }
     pub fn create_dataset(
         &self,
@@ -65,10 +57,6 @@ where
             .expect("bearer tokens are valid headers"),
         );
         headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
-        headers_.insert(
             conjure_http::private::http::header::HeaderName::from_static("test-header"),
             conjure_http::private::http::header::HeaderValue::from_shared(
                 conjure_object::ToPlain::to_plain(&test_header_arg).into(),
@@ -76,16 +64,16 @@ where
             .map_err(conjure_http::private::Error::internal_safe)?,
         );
         let body_ = conjure_http::client::SerializableRequestBody(request);
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::SerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::POST,
             "/catalog/datasets",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        conjure_http::private::json::client_from_reader(response.body_mut())
-            .map_err(conjure_http::private::Error::internal)
+            response_visitor_,
+        )
     }
     pub fn get_dataset(
         &self,
@@ -107,25 +95,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::DefaultSerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(Default::default())
-        } else {
-            conjure_http::private::json::client_from_reader(response.body_mut())
-                .map_err(conjure_http::private::Error::internal)
-        }
+            response_visitor_,
+        )
     }
     pub fn get_raw_data(
         &self,
@@ -146,22 +126,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static(
-                "application/octet-stream",
-            ),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let response = self.0.request(
+        let response_visitor_ = conjure_http::client::BinaryResponseVisitor;
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/raw",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        Ok(response.into_body())
+            response_visitor_,
+        )
     }
     pub fn get_aliased_raw_data(
         &self,
@@ -182,22 +157,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static(
-                "application/octet-stream",
-            ),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let response = self.0.request(
+        let response_visitor_ = conjure_http::client::BinaryResponseVisitor;
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/raw-aliased",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        Ok(response.into_body())
+            response_visitor_,
+        )
     }
     pub fn maybe_get_raw_data(
         &self,
@@ -218,26 +188,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static(
-                "application/octet-stream",
-            ),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let response = self.0.request(
+        let response_visitor_ = conjure_http::client::OptionalBinaryResponseVisitor;
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/raw-maybe",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(None)
-        } else {
-            Ok(Some(response.into_body()))
-        }
+            response_visitor_,
+        )
     }
     pub fn get_aliased_string(
         &self,
@@ -258,21 +219,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::SerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/string-aliased",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        conjure_http::private::json::client_from_reader(response.body_mut())
-            .map_err(conjure_http::private::Error::internal)
+            response_visitor_,
+        )
     }
     pub fn upload_raw_data<U>(
         &self,
@@ -293,6 +250,7 @@ where
             .expect("bearer tokens are valid headers"),
         );
         let body_ = conjure_http::client::BinaryRequestBody(input);
+        let response_visitor_ = conjure_http::client::EmptyResponseVisitor;
         self.0.request(
             conjure_http::private::http::Method::POST,
             "/catalog/datasets/upload-raw",
@@ -300,8 +258,8 @@ where
             query_params_,
             headers_,
             body_,
-        )?;
-        Ok(())
+            response_visitor_,
+        )
     }
     pub fn upload_aliased_raw_data<U>(
         &self,
@@ -322,6 +280,7 @@ where
             .expect("bearer tokens are valid headers"),
         );
         let body_ = conjure_http::client::BinaryRequestBody(input);
+        let response_visitor_ = conjure_http::client::EmptyResponseVisitor;
         self.0.request(
             conjure_http::private::http::Method::POST,
             "/catalog/datasets/upload-raw-aliased",
@@ -329,8 +288,8 @@ where
             query_params_,
             headers_,
             body_,
-        )?;
-        Ok(())
+            response_visitor_,
+        )
     }
     pub fn get_branches(
         &self,
@@ -351,25 +310,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::DefaultSerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/branches",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(Default::default())
-        } else {
-            conjure_http::private::json::client_from_reader(response.body_mut())
-                .map_err(conjure_http::private::Error::internal)
-        }
+            response_visitor_,
+        )
     }
     #[doc = "Gets all branches of this dataset."]
     #[deprecated(note = "use getBranches instead")]
@@ -392,25 +343,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::DefaultSerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/branchesDeprecated",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(Default::default())
-        } else {
-            conjure_http::private::json::client_from_reader(response.body_mut())
-                .map_err(conjure_http::private::Error::internal)
-        }
+            response_visitor_,
+        )
     }
     pub fn resolve_branch(
         &self,
@@ -433,25 +376,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::DefaultSerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(Default::default())
-        } else {
-            conjure_http::private::json::client_from_reader(response.body_mut())
-                .map_err(conjure_http::private::Error::internal)
-        }
+            response_visitor_,
+        )
     }
     pub fn test_param(
         &self,
@@ -472,25 +407,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::DefaultSerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/datasets/{datasetRid}/testParam",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(Default::default())
-        } else {
-            conjure_http::private::json::client_from_reader(response.body_mut())
-                .map_err(conjure_http::private::Error::internal)
-        }
+            response_visitor_,
+        )
     }
     pub fn test_query_params(
         &self,
@@ -528,21 +455,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::SerializableRequestBody(query);
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::SerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::POST,
             "/catalog/test-query-params",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        conjure_http::private::json::client_from_reader(response.body_mut())
-            .map_err(conjure_http::private::Error::internal)
+            response_visitor_,
+        )
     }
     pub fn test_no_response_query_params(
         &self,
@@ -581,6 +504,7 @@ where
             .expect("bearer tokens are valid headers"),
         );
         let body_ = conjure_http::client::SerializableRequestBody(query);
+        let response_visitor_ = conjure_http::client::EmptyResponseVisitor;
         self.0.request(
             conjure_http::private::http::Method::POST,
             "/catalog/test-no-response-query-params",
@@ -588,8 +512,8 @@ where
             query_params_,
             headers_,
             body_,
-        )?;
-        Ok(())
+            response_visitor_,
+        )
     }
     pub fn test_boolean(
         &self,
@@ -605,21 +529,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::SerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/boolean",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        conjure_http::private::json::client_from_reader(response.body_mut())
-            .map_err(conjure_http::private::Error::internal)
+            response_visitor_,
+        )
     }
     pub fn test_double(
         &self,
@@ -635,21 +555,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::SerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/double",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        conjure_http::private::json::client_from_reader(response.body_mut())
-            .map_err(conjure_http::private::Error::internal)
+            response_visitor_,
+        )
     }
     pub fn test_integer(
         &self,
@@ -665,21 +581,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::EmptyRequestBody;
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::SerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/integer",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        conjure_http::private::json::client_from_reader(response.body_mut())
-            .map_err(conjure_http::private::Error::internal)
+            response_visitor_,
+        )
     }
     pub fn test_post_optional(
         &self,
@@ -696,25 +608,17 @@ where
             )
             .expect("bearer tokens are valid headers"),
         );
-        headers_.insert(
-            conjure_http::private::http::header::ACCEPT,
-            conjure_http::private::http::header::HeaderValue::from_static("application/json"),
-        );
         let body_ = conjure_http::client::SerializableRequestBody(maybe_string);
-        let mut response = self.0.request(
+        let response_visitor_ = conjure_http::client::DefaultSerializableResponseVisitor::new();
+        self.0.request(
             conjure_http::private::http::Method::POST,
             "/catalog/optional",
             path_params_,
             query_params_,
             headers_,
             body_,
-        )?;
-        if response.status() == conjure_http::private::http::StatusCode::NO_CONTENT {
-            Ok(Default::default())
-        } else {
-            conjure_http::private::json::client_from_reader(response.body_mut())
-                .map_err(conjure_http::private::Error::internal)
-        }
+            response_visitor_,
+        )
     }
     pub fn test_optional_integer_and_double(
         &self,
@@ -741,6 +645,7 @@ where
             .expect("bearer tokens are valid headers"),
         );
         let body_ = conjure_http::client::EmptyRequestBody;
+        let response_visitor_ = conjure_http::client::EmptyResponseVisitor;
         self.0.request(
             conjure_http::private::http::Method::GET,
             "/catalog/optional-integer-double",
@@ -748,7 +653,7 @@ where
             query_params_,
             headers_,
             body_,
-        )?;
-        Ok(())
+            response_visitor_,
+        )
     }
 }

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -15,16 +15,19 @@
 //! The Conjure HTTP client API.
 
 use conjure_error::Error;
-use http::{HeaderMap, Method, Response};
-use serde::Serialize;
-use std::io::{Read, Write};
+use http::{HeaderMap, Method};
+use serde::de::DeserializeOwned;
+use serde::{Deserializer, Serialize};
+use std::error;
+use std::io::Write;
+use std::marker::PhantomData;
 
 use crate::{PathParams, QueryParams};
 
 /// A trait implemented by HTTP client implementations.
 pub trait Client {
     /// The client's response body type.
-    type ResponseBody: Read;
+    type ResponseBody;
 
     /// Makes an HTTP request.
     ///
@@ -34,7 +37,8 @@ pub trait Client {
     /// A response must only be returned if it has a 2xx status code. The client is responsible for handling all other
     /// status codes (for example, converting a 5xx response into a service error). The client is also responsible for
     /// decoding the response body if necessary.
-    fn request<T>(
+    #[allow(clippy::too_many_arguments)]
+    fn request<T, U>(
         &self,
         method: Method,
         path: &'static str,
@@ -42,9 +46,11 @@ pub trait Client {
         query_params: QueryParams,
         headers: HeaderMap,
         body: T,
-    ) -> Result<Response<Self::ResponseBody>, Error>
+        response_visitor: U,
+    ) -> Result<U::Output, Error>
     where
-        T: RequestBody;
+        T: RequestBody,
+        U: VisitResponse<Self::ResponseBody>;
 }
 
 /// A trait implemented by request bodies.
@@ -113,6 +119,168 @@ where
         V: VisitRequestBody,
     {
         visitor.visit_binary(self.0)
+    }
+}
+
+/// A visitor over HTTP responses.
+pub trait VisitResponse<T>: Sized {
+    /// The type produced by the visitor.
+    type Output;
+
+    /// Returns the type of response the visitor accepts.
+    ///
+    /// This is used to create the HTTP `Accept` header.
+    fn accept(&self) -> Accept;
+
+    /// Visits an empty response.
+    fn visit_empty(self) -> Result<Self::Output, Error> {
+        Err(Error::internal_safe("unexpected empty response"))
+    }
+
+    /// Visits a serializable response.
+    fn visit_serializable<'de, D>(self, deserializer: D) -> Result<Self::Output, Error>
+    where
+        D: Deserializer<'de>,
+        D::Error: Into<Box<error::Error + Sync + Send>>,
+    {
+        let _ = deserializer;
+        Err(Error::internal_safe("unexpected serializable response"))
+    }
+
+    /// Visits a streaming binary response.
+    fn visit_binary(self, body: T) -> Result<Self::Output, Error> {
+        let _ = body;
+        Err(Error::internal_safe("unexpected binary response"))
+    }
+}
+
+/// The type of response expected by a visitor.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Accept {
+    /// An empty response.
+    Empty,
+    /// A serializable response.
+    Serializable,
+    /// A binary response.
+    Binary,
+}
+
+/// A visitor expecting an empty response.
+pub struct EmptyResponseVisitor;
+
+impl<T> VisitResponse<T> for EmptyResponseVisitor {
+    type Output = ();
+
+    fn accept(&self) -> Accept {
+        Accept::Empty
+    }
+
+    fn visit_empty(self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// A visitor expecting a serializable response.
+#[derive(Default)]
+pub struct SerializableResponseVisitor<T>(PhantomData<T>);
+
+impl<T> SerializableResponseVisitor<T>
+where
+    T: DeserializeOwned,
+{
+    /// Creates a new visitor.
+    pub fn new() -> SerializableResponseVisitor<T> {
+        SerializableResponseVisitor(PhantomData)
+    }
+}
+
+impl<T, U> VisitResponse<U> for SerializableResponseVisitor<T>
+where
+    T: DeserializeOwned,
+{
+    type Output = T;
+
+    fn accept(&self) -> Accept {
+        Accept::Serializable
+    }
+
+    fn visit_serializable<'de, D>(self, deserializer: D) -> Result<T, Error>
+    where
+        D: Deserializer<'de>,
+        D::Error: Into<Box<error::Error + Sync + Send>>,
+    {
+        T::deserialize(deserializer).map_err(Error::internal)
+    }
+}
+
+/// A visitor expecting either an empty or serializable response.
+#[derive(Default)]
+pub struct DefaultSerializableResponseVisitor<T>(PhantomData<T>);
+
+impl<T> DefaultSerializableResponseVisitor<T>
+where
+    T: Default + DeserializeOwned,
+{
+    /// Creates a new visitor.
+    pub fn new() -> DefaultSerializableResponseVisitor<T> {
+        DefaultSerializableResponseVisitor(PhantomData)
+    }
+}
+
+impl<T, U> VisitResponse<U> for DefaultSerializableResponseVisitor<T>
+where
+    T: Default + DeserializeOwned,
+{
+    type Output = T;
+
+    fn accept(&self) -> Accept {
+        Accept::Serializable
+    }
+
+    fn visit_empty(self) -> Result<T, Error> {
+        Ok(T::default())
+    }
+
+    fn visit_serializable<'de, D>(self, deserializer: D) -> Result<T, Error>
+    where
+        D: Deserializer<'de>,
+        D::Error: Into<Box<error::Error + Sync + Send>>,
+    {
+        T::deserialize(deserializer).map_err(Error::internal)
+    }
+}
+
+/// A visitor expecting a binary response.
+pub struct BinaryResponseVisitor;
+
+impl<T> VisitResponse<T> for BinaryResponseVisitor {
+    type Output = T;
+
+    fn accept(&self) -> Accept {
+        Accept::Binary
+    }
+
+    fn visit_binary(self, body: T) -> Result<T, Error> {
+        Ok(body)
+    }
+}
+
+/// A builder expecting an empty or binary response.
+pub struct OptionalBinaryResponseVisitor;
+
+impl<T> VisitResponse<T> for OptionalBinaryResponseVisitor {
+    type Output = Option<T>;
+
+    fn accept(&self) -> Accept {
+        Accept::Binary
+    }
+
+    fn visit_empty(self) -> Result<Option<T>, Error> {
+        Ok(None)
+    }
+
+    fn visit_binary(self, body: T) -> Result<Option<T>, Error> {
+        Ok(Some(body))
     }
 }
 

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -32,7 +32,7 @@ pub trait Client {
     /// Makes an HTTP request.
     ///
     /// The client is responsible for assembling the request URI. It is provided with the path template, unencoded path
-    /// parameters, unencoded query parameters, and the request body.
+    /// parameters, unencoded query parameters, header parameters, and request body.
     ///
     /// A response must only be returned if it has a 2xx status code. The client is responsible for handling all other
     /// status codes (for example, converting a 5xx response into a service error). The client is also responsible for

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use conjure_error::{Error, ErrorCode, ErrorType};
-use conjure_http::client::{Client, RequestBody, VisitRequestBody, WriteBody};
+use conjure_http::client::{Client, RequestBody, VisitRequestBody, VisitResponse, WriteBody};
 use conjure_http::{PathParams, QueryParams};
 use conjure_object::serde::de::DeserializeOwned;
 use conjure_object::serde::Serialize;
 use conjure_object::{BearerToken, ResourceIdentifier};
 use conjure_serde::json;
-use http::{HeaderMap, Method, Response, StatusCode};
-use std::cell::Cell;
+use http::{HeaderMap, Method};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
 
@@ -249,7 +248,7 @@ struct TestClient {
     query_params: QueryParams,
     headers: HeaderMap,
     body: TestBody,
-    response: Cell<Option<Response<&'static [u8]>>>,
+    response: TestBody,
 }
 
 impl TestClient {
@@ -261,7 +260,7 @@ impl TestClient {
             query_params: QueryParams::new(),
             headers: HeaderMap::new(),
             body: TestBody::Empty,
-            response: Cell::new(Some(Response::new(&[]))),
+            response: TestBody::Empty,
         }
     }
 
@@ -285,16 +284,16 @@ impl TestClient {
         self
     }
 
-    fn response(self, response: Response<&'static [u8]>) -> TestClient {
-        self.response.set(Some(response));
+    fn response(mut self, response: TestBody) -> TestClient {
+        self.response = response;
         self
     }
 }
 
 impl Client for TestClient {
-    type ResponseBody = &'static [u8];
+    type ResponseBody = Vec<u8>;
 
-    fn request<T>(
+    fn request<T, U>(
         &self,
         method: Method,
         path: &'static str,
@@ -302,9 +301,11 @@ impl Client for TestClient {
         query_params: QueryParams,
         headers: HeaderMap,
         body: T,
-    ) -> Result<Response<&'static [u8]>, Error>
+        response_visitor: U,
+    ) -> Result<U::Output, Error>
     where
         T: RequestBody,
+        U: VisitResponse<Vec<u8>>,
     {
         assert_eq!(method, self.method);
         assert_eq!(path, self.path);
@@ -314,7 +315,12 @@ impl Client for TestClient {
         let body = body.accept(TestBodyVisitor).unwrap();
         assert_eq!(body, self.body);
 
-        Ok(self.response.replace(None).unwrap())
+        match &self.response {
+            TestBody::Empty => response_visitor.visit_empty(),
+            TestBody::Json(json) => response_visitor
+                .visit_serializable(&mut json::ClientDeserializer::from_slice(json.as_bytes())),
+            TestBody::Streaming(buf) => response_visitor.visit_binary(buf.clone()),
+        }
     }
 }
 
@@ -457,13 +463,7 @@ fn streaming_alias_request() {
 #[test]
 fn json_response() {
     let client = TestClient::new(Method::GET, "/test/jsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/json")
-                .body(&br#""hello world""#[..])
-                .unwrap(),
-        );
+        .response(TestBody::Json(r#""hello world""#.to_string()));
 
     let s = TestServiceClient::new(client).json_response().unwrap();
     assert_eq!(s, "hello world");
@@ -472,27 +472,14 @@ fn json_response() {
 #[test]
 fn optional_json_response() {
     let client = TestClient::new(Method::GET, "/test/optionalJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/json")
-                .body(&br#""hello world""#[..])
-                .unwrap(),
-        );
+        .response(TestBody::Json(r#""hello world""#.to_string()));
 
     let s = TestServiceClient::new(client)
         .optional_json_response()
         .unwrap();
     assert_eq!(s, Some("hello world".to_string()));
 
-    let client = TestClient::new(Method::GET, "/test/optionalJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(&[][..])
-                .unwrap(),
-        );
+    let client = TestClient::new(Method::GET, "/test/optionalJsonResponse");
 
     let s = TestServiceClient::new(client)
         .optional_json_response()
@@ -502,26 +489,14 @@ fn optional_json_response() {
 
 #[test]
 fn list_json_response() {
-    let client = TestClient::new(Method::GET, "/test/listJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(&[][..])
-                .unwrap(),
-        );
+    let client =
+        TestClient::new(Method::GET, "/test/listJsonResponse");
 
     let s = TestServiceClient::new(client).list_json_response().unwrap();
     assert_eq!(s, Vec::<String>::new());
 
     let client = TestClient::new(Method::GET, "/test/listJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/json")
-                .body(&br#"["hello"]"#[..])
-                .unwrap(),
-        );
+        .response(TestBody::Json(r#"["hello"]"#.to_string()));
 
     let s = TestServiceClient::new(client).list_json_response().unwrap();
     assert_eq!(s, vec!["hello".to_string()]);
@@ -529,26 +504,14 @@ fn list_json_response() {
 
 #[test]
 fn set_json_response() {
-    let client = TestClient::new(Method::GET, "/test/setJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(&[][..])
-                .unwrap(),
-        );
+    let client =
+        TestClient::new(Method::GET, "/test/setJsonResponse");
 
     let s = TestServiceClient::new(client).set_json_response().unwrap();
     assert_eq!(s, BTreeSet::new());
 
     let client = TestClient::new(Method::GET, "/test/setJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/json")
-                .body(&br#"["hello"]"#[..])
-                .unwrap(),
-        );
+        .response(TestBody::Json(r#"["hello"]"#.to_string()));
 
     let s = TestServiceClient::new(client).set_json_response().unwrap();
     let mut set = BTreeSet::new();
@@ -558,26 +521,14 @@ fn set_json_response() {
 
 #[test]
 fn map_json_response() {
-    let client = TestClient::new(Method::GET, "/test/mapJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(&[][..])
-                .unwrap(),
-        );
+    let client =
+        TestClient::new(Method::GET, "/test/mapJsonResponse");
 
     let s = TestServiceClient::new(client).map_json_response().unwrap();
     assert_eq!(s, BTreeMap::new());
 
     let client = TestClient::new(Method::GET, "/test/mapJsonResponse")
-        .header("Accept", "application/json")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/json")
-                .body(&br#"{"hello": "world"}"#[..])
-                .unwrap(),
-        );
+        .response(TestBody::Json(r#"{"hello": "world"}"#.to_string()));
 
     let s = TestServiceClient::new(client).map_json_response().unwrap();
     let mut map = BTreeMap::new();
@@ -588,42 +539,23 @@ fn map_json_response() {
 #[test]
 fn streaming_response() {
     let client = TestClient::new(Method::GET, "/test/streamingResponse")
-        .header("Accept", "application/octet-stream")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/octet-stream")
-                .body(&b"foobar"[..])
-                .unwrap(),
-        );
+        .response(TestBody::Streaming(b"foobar".to_vec()));
 
     let r = TestServiceClient::new(client).streaming_response().unwrap();
-    assert_eq!(r, &b"foobar"[..]);
+    assert_eq!(r, b"foobar".to_vec());
 }
 
 #[test]
 fn optional_streaming_response() {
     let client = TestClient::new(Method::GET, "/test/optionalStreamingResponse")
-        .header("Accept", "application/octet-stream")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/octet-stream")
-                .body(&b"foobar"[..])
-                .unwrap(),
-        );
+        .response(TestBody::Streaming(b"foobar".to_vec()));
 
     let r = TestServiceClient::new(client)
         .optional_streaming_response()
         .unwrap();
-    assert_eq!(r, Some(&b"foobar"[..]));
+    assert_eq!(r, Some(b"foobar".to_vec()));
 
-    let client = TestClient::new(Method::GET, "/test/optionalStreamingResponse")
-        .header("Accept", "application/octet-stream")
-        .response(
-            Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(&[][..])
-                .unwrap(),
-        );
+    let client = TestClient::new(Method::GET, "/test/optionalStreamingResponse");
 
     let r = TestServiceClient::new(client)
         .optional_streaming_response()
@@ -634,44 +566,25 @@ fn optional_streaming_response() {
 #[test]
 fn streaming_alias_response() {
     let client = TestClient::new(Method::GET, "/test/streamingAliasResponse")
-        .header("Accept", "application/octet-stream")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/octet-stream")
-                .body(&b"foobar"[..])
-                .unwrap(),
-        );
+        .response(TestBody::Streaming(b"foobar".to_vec()));
 
     let r = TestServiceClient::new(client)
         .streaming_alias_response()
         .unwrap();
-    assert_eq!(r, &b"foobar"[..]);
+    assert_eq!(r, b"foobar".to_vec());
 }
 
 #[test]
 fn optional_streaming_alias_response() {
     let client = TestClient::new(Method::GET, "/test/optionalStreamingAliasResponse")
-        .header("Accept", "application/octet-stream")
-        .response(
-            Response::builder()
-                .header("Content-Type", "application/octet-stream")
-                .body(&b"foobar"[..])
-                .unwrap(),
-        );
+        .response(TestBody::Streaming(b"foobar".to_vec()));
 
     let r = TestServiceClient::new(client)
         .optional_streaming_alias_response()
         .unwrap();
-    assert_eq!(r, Some(&b"foobar"[..]));
+    assert_eq!(r, Some(b"foobar".to_vec()));
 
-    let client = TestClient::new(Method::GET, "/test/optionalStreamingAliasResponse")
-        .header("Accept", "application/octet-stream")
-        .response(
-            Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(&[][..])
-                .unwrap(),
-        );
+    let client = TestClient::new(Method::GET, "/test/optionalStreamingAliasResponse");
 
     let r = TestServiceClient::new(client)
         .optional_streaming_alias_response()

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -489,8 +489,7 @@ fn optional_json_response() {
 
 #[test]
 fn list_json_response() {
-    let client =
-        TestClient::new(Method::GET, "/test/listJsonResponse");
+    let client = TestClient::new(Method::GET, "/test/listJsonResponse");
 
     let s = TestServiceClient::new(client).list_json_response().unwrap();
     assert_eq!(s, Vec::<String>::new());
@@ -504,8 +503,7 @@ fn list_json_response() {
 
 #[test]
 fn set_json_response() {
-    let client =
-        TestClient::new(Method::GET, "/test/setJsonResponse");
+    let client = TestClient::new(Method::GET, "/test/setJsonResponse");
 
     let s = TestServiceClient::new(client).set_json_response().unwrap();
     assert_eq!(s, BTreeSet::new());
@@ -521,8 +519,7 @@ fn set_json_response() {
 
 #[test]
 fn map_json_response() {
-    let client =
-        TestClient::new(Method::GET, "/test/mapJsonResponse");
+    let client = TestClient::new(Method::GET, "/test/mapJsonResponse");
 
     let s = TestServiceClient::new(client).map_json_response().unwrap();
     assert_eq!(s, BTreeMap::new());


### PR DESCRIPTION
This allows the client to control how e.g. serializable responses are
decoded.