### PR TITLE
Pipe a lifetime through RequestBody

### DIFF
--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -56,7 +56,7 @@ pub trait Client {
 /// A trait implemented by request bodies.
 pub trait RequestBody<'a> {
     /// Accepts a visitor, calling the correct method corresponding to this body type.
-    fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
+    fn accept<V>(self, visitor: V) -> V::Output
     where
         V: VisitRequestBody<'a>;
 }
@@ -67,15 +67,15 @@ pub trait VisitRequestBody<'a> {
     type Output;
 
     /// Visits an empty body.
-    fn visit_empty(self) -> Result<Self::Output, Error>;
+    fn visit_empty(self) -> Self::Output;
 
     /// Visits a serializable body.
-    fn visit_serializable<T>(self, body: T) -> Result<Self::Output, Error>
+    fn visit_serializable<T>(self, body: T) -> Self::Output
     where
         T: Serialize + 'a;
 
     /// Visits a streaming, binary body.
-    fn visit_binary<T>(self, body: T) -> Result<Self::Output, Error>
+    fn visit_binary<T>(self, body: T) -> Self::Output
     where
         T: WriteBody + 'a;
 }
@@ -84,7 +84,7 @@ pub trait VisitRequestBody<'a> {
 pub struct EmptyRequestBody;
 
 impl<'a> RequestBody<'a> for EmptyRequestBody {
-    fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
+    fn accept<V>(self, visitor: V) -> V::Output
     where
         V: VisitRequestBody<'a>,
     {
@@ -99,7 +99,7 @@ impl<'a, T> RequestBody<'a> for SerializableRequestBody<T>
 where
     T: Serialize + 'a,
 {
-    fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
+    fn accept<V>(self, visitor: V) -> V::Output
     where
         V: VisitRequestBody<'a>,
     {
@@ -114,7 +114,7 @@ impl<'a, T> RequestBody<'a> for BinaryRequestBody<T>
 where
     T: WriteBody + 'a,
 {
-    fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
+    fn accept<V>(self, visitor: V) -> V::Output
     where
         V: VisitRequestBody<'a>,
     {

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -38,7 +38,7 @@ pub trait Client {
     /// status codes (for example, converting a 5xx response into a service error). The client is also responsible for
     /// decoding the response body if necessary.
     #[allow(clippy::too_many_arguments)]
-    fn request<T, U>(
+    fn request<'a, T, U>(
         &self,
         method: Method,
         path: &'static str,
@@ -49,20 +49,20 @@ pub trait Client {
         response_visitor: U,
     ) -> Result<U::Output, Error>
     where
-        T: RequestBody,
+        T: RequestBody<'a>,
         U: VisitResponse<Self::ResponseBody>;
 }
 
 /// A trait implemented by request bodies.
-pub trait RequestBody {
+pub trait RequestBody<'a> {
     /// Accepts a visitor, calling the correct method corresponding to this body type.
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitRequestBody;
+        V: VisitRequestBody<'a>;
 }
 
 /// A visitor over request body formats.
-pub trait VisitRequestBody {
+pub trait VisitRequestBody<'a> {
     /// The output type returned by visit methods.
     type Output;
 
@@ -72,21 +72,21 @@ pub trait VisitRequestBody {
     /// Visits a serializable body.
     fn visit_serializable<T>(self, body: T) -> Result<Self::Output, Error>
     where
-        T: Serialize;
+        T: Serialize + 'a;
 
     /// Visits a streaming, binary body.
     fn visit_binary<T>(self, body: T) -> Result<Self::Output, Error>
     where
-        T: WriteBody;
+        T: WriteBody + 'a;
 }
 
 /// An empty request body.
 pub struct EmptyRequestBody;
 
-impl RequestBody for EmptyRequestBody {
+impl<'a> RequestBody<'a> for EmptyRequestBody {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitRequestBody,
+        V: VisitRequestBody<'a>,
     {
         visitor.visit_empty()
     }
@@ -95,13 +95,13 @@ impl RequestBody for EmptyRequestBody {
 /// A serializable request body.
 pub struct SerializableRequestBody<T>(pub T);
 
-impl<T> RequestBody for SerializableRequestBody<T>
+impl<'a, T> RequestBody<'a> for SerializableRequestBody<T>
 where
-    T: Serialize,
+    T: Serialize + 'a,
 {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitRequestBody,
+        V: VisitRequestBody<'a>,
     {
         visitor.visit_serializable(self.0)
     }
@@ -110,13 +110,13 @@ where
 /// A streaming binary request body.
 pub struct BinaryRequestBody<T>(pub T);
 
-impl<T> RequestBody for BinaryRequestBody<T>
+impl<'a, T> RequestBody<'a> for BinaryRequestBody<T>
 where
-    T: WriteBody,
+    T: WriteBody + 'a,
 {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitRequestBody,
+        V: VisitRequestBody<'a>,
     {
         visitor.visit_binary(self.0)
     }

--- a/conjure-test/src/test.rs
+++ b/conjure-test/src/test.rs
@@ -312,7 +312,7 @@ impl Client for TestClient {
         assert_eq!(path_params, self.path_params);
         assert_eq!(query_params, self.query_params);
         assert_eq!(headers, self.headers);
-        let body = body.accept(TestBodyVisitor).unwrap();
+        let body = body.accept(TestBodyVisitor);
         assert_eq!(body, self.body);
 
         match &self.response {
@@ -329,25 +329,25 @@ struct TestBodyVisitor;
 impl<'a> VisitRequestBody<'a> for TestBodyVisitor {
     type Output = TestBody;
 
-    fn visit_empty(self) -> Result<TestBody, Error> {
-        Ok(TestBody::Empty)
+    fn visit_empty(self) -> TestBody {
+        TestBody::Empty
     }
 
-    fn visit_serializable<T>(self, body: T) -> Result<TestBody, Error>
+    fn visit_serializable<T>(self, body: T) -> TestBody
     where
         T: Serialize + 'a,
     {
         let body = json::to_string(&body).unwrap();
-        Ok(TestBody::Json(body))
+        TestBody::Json(body)
     }
 
-    fn visit_binary<T>(self, mut body: T) -> Result<TestBody, Error>
+    fn visit_binary<T>(self, mut body: T) -> TestBody
     where
         T: WriteBody + 'a,
     {
         let mut buf = vec![];
         body.write_body(&mut buf).unwrap();
-        Ok(TestBody::Streaming(buf))
+        TestBody::Streaming(buf)
     }
 }
 


### PR DESCRIPTION
Clients need to be able to store the values returned in the visitors.