### PR TITLE
Make server::WriteBody take self by value

### DIFF
--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -300,11 +300,11 @@ pub trait VisitResponse {
 /// A trait implemented by streaming bodies.
 pub trait WriteBody {
     /// Writes the body out, in its entirety.
-    fn write_body(&mut self, w: &mut dyn Write) -> Result<(), Error>;
+    fn write_body(self, w: &mut dyn Write) -> Result<(), Error>;
 }
 
 impl WriteBody for Vec<u8> {
-    fn write_body(&mut self, w: &mut dyn Write) -> Result<(), Error> {
-        w.write_all(self).map_err(Error::internal_safe)
+    fn write_body(self, w: &mut dyn Write) -> Result<(), Error> {
+        w.write_all(&self).map_err(Error::internal_safe)
     }
 }

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -247,7 +247,7 @@ impl VisitResponse for TestResponseVisitor {
         Ok(TestBody::Json(body))
     }
 
-    fn visit_binary<T>(self, mut body: T) -> Result<TestBody, Error>
+    fn visit_binary<T>(self, body: T) -> Result<TestBody, Error>
     where
         T: WriteBody + 'static,
     {


### PR DESCRIPTION
We're only going to write the body out once, so this can make
implementations a bit less weird in some cases.