### PR TITLE
Adjust the definition of the Resource trait

### DIFF
--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1091,14 +1091,16 @@ impl<T> TestServiceResource<T> {
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
 }
-impl<T, B, R> conjure_http::server::Resource<B, R> for TestServiceResource<T>
+impl<T, U> conjure_http::server::Resource<U> for TestServiceResource<T>
 where
-    T: TestService<B::Body>,
-    B: conjure_http::server::RequestBody,
-    R: conjure_http::server::VisitResponse,
+    T: TestService<U>,
 {
     const NAME: &'static str = "TestService";
-    fn endpoints() -> Vec<conjure_http::server::Endpoint<Self, B, R>> {
+    fn endpoints<B, R>() -> Vec<conjure_http::server::Endpoint<Self, B, R>>
+    where
+        B: conjure_http::server::RequestBody<Body = U>,
+        R: conjure_http::server::VisitResponse,
+    {
         vec![
             conjure_http::server::Endpoint::new(
                 "getFileSystems",

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -194,15 +194,17 @@ fn generate_resource(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
             #(#endpoint_fns)*
         }
 
-        impl<T, B, R> conjure_http::server::Resource<B, R> for #name<T>
+        impl<T, U> conjure_http::server::Resource<U> for #name<T>
         where
-            T: #trait_name<B::Body>,
-            B: conjure_http::server::RequestBody,
-            R: conjure_http::server::VisitResponse,
+            T: #trait_name<U>,
         {
             const NAME: &'static str = #name_str;
 
-            fn endpoints() -> #vec<conjure_http::server::Endpoint<Self, B, R>> {
+            fn endpoints<B, R>() -> #vec<conjure_http::server::Endpoint<Self, B, R>>
+            where
+                B: conjure_http::server::RequestBody<Body = U>,
+                R: conjure_http::server::VisitResponse,
+            {
                 vec![
                     #(#endpoints,)*
                 ]

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -201,19 +201,15 @@ where
 /// An HTTP resource.
 ///
 /// The server-half of a Conjure service implements this trait.
-pub trait Resource<B, R>: Sized
-where
-    B: RequestBody,
-    R: VisitResponse,
-{
+pub trait Resource<T>: Sized {
     /// The resource's name.
     const NAME: &'static str;
 
     /// Returns the resource's HTTP endpoints.
     // FIXME ideally this would be a &'static [Endpoint] once const fns become more powerful
-    fn endpoints() -> Vec<Endpoint<Self, B, R>>
+    fn endpoints<B, R>() -> Vec<Endpoint<Self, B, R>>
     where
-        B: RequestBody,
+        B: RequestBody<Body = T>,
         R: VisitResponse;
 }
 

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -15,8 +15,8 @@
 
 use conjure_error::Error;
 use conjure_http::server::{
-    Endpoint, HeaderParameter, Parameter, ParameterType, PathParameter, QueryParameter,
-    RequestBody, Resource, VisitRequestBody, VisitResponse, WriteBody,
+    HeaderParameter, Parameter, ParameterType, PathParameter, QueryParameter, RequestBody,
+    Resource, VisitRequestBody, VisitResponse, WriteBody,
 };
 use conjure_http::{PathParams, QueryParams};
 use conjure_object::{BearerToken, ResourceIdentifier};
@@ -601,8 +601,8 @@ fn cookie_auth() {
 
 #[test]
 fn endpoint() {
-    let endpoint: Endpoint<_, TestBody, TestResponseVisitor> =
-        TestServiceResource::<TestServiceHandler>::endpoints()
+    let endpoint =
+        TestServiceResource::<TestServiceHandler>::endpoints::<TestBody, TestResponseVisitor>()
             .into_iter()
             .find(|e| e.name() == "safeParams")
             .unwrap();


### PR DESCRIPTION
We want to allow service implementations to pick what binary request
body types they support, but don't want to force server implementations
to publicly expose their request body and response visitor types.