### PR TITLE
Parameterize binary body writers

### DIFF
--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -145,7 +145,9 @@ fn params(ctx: &Context, body_arg: Option<&ArgumentDefinition>) -> TokenStream {
 
 fn where_(ctx: &Context, body_arg: Option<&ArgumentDefinition>) -> TokenStream {
     match body_arg {
-        Some(a) if ctx.is_binary(a.type_()) => quote!(where U: conjure_http::client::WriteBody<T::RequestWriter>),
+        Some(a) if ctx.is_binary(a.type_()) => {
+            quote!(where U: conjure_http::client::WriteBody<T::BinaryWriter>)
+        }
         _ => quote!(),
     }
 }
@@ -180,10 +182,10 @@ fn return_type_name(ctx: &Context, def: &ServiceDefinition, ty: &ReturnType<'_>)
     match ty {
         ReturnType::None => quote!(()),
         ReturnType::Json(ty) => ctx.rust_type(def.service_name(), ty),
-        ReturnType::Binary => quote!(T::ResponseBody),
+        ReturnType::Binary => quote!(T::BinaryBody),
         ReturnType::OptionalBinary => {
             let option = ctx.option_ident(def.service_name());
-            quote!(#option<T::ResponseBody>)
+            quote!(#option<T::BinaryBody>)
         }
     }
 }

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -145,7 +145,7 @@ fn params(ctx: &Context, body_arg: Option<&ArgumentDefinition>) -> TokenStream {
 
 fn where_(ctx: &Context, body_arg: Option<&ArgumentDefinition>) -> TokenStream {
     match body_arg {
-        Some(a) if ctx.is_binary(a.type_()) => quote!(where U: conjure_http::client::WriteBody),
+        Some(a) if ctx.is_binary(a.type_()) => quote!(where U: conjure_http::client::WriteBody<T::RequestWriter>),
         _ => quote!(),
     }
 }

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -179,7 +179,7 @@ where
         input: U,
     ) -> Result<(), conjure_http::private::Error>
     where
-        U: conjure_http::client::WriteBody,
+        U: conjure_http::client::WriteBody<T::RequestWriter>,
     {
         let path_params_ = conjure_http::PathParams::new();
         let query_params_ = conjure_http::QueryParams::new();
@@ -203,7 +203,7 @@ where
         input: U,
     ) -> Result<(), conjure_http::private::Error>
     where
-        U: conjure_http::client::WriteBody,
+        U: conjure_http::client::WriteBody<T::RequestWriter>,
     {
         let path_params_ = conjure_http::PathParams::new();
         let query_params_ = conjure_http::QueryParams::new();
@@ -507,13 +507,13 @@ where
 }
 use conjure_http::server::Response as _;
 #[doc = "A Markdown description of the service."]
-pub trait TestService<T> {
+pub trait TestService<I, O> {
     #[doc = "The body type returned by the `get_raw_data` method."]
-    type GetRawDataBody: conjure_http::server::WriteBody + 'static;
+    type GetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     #[doc = "The body type returned by the `get_aliased_raw_data` method."]
-    type GetAliasedRawDataBody: conjure_http::server::WriteBody + 'static;
+    type GetAliasedRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     #[doc = "The body type returned by the `maybe_get_raw_data` method."]
-    type MaybeGetRawDataBody: conjure_http::server::WriteBody + 'static;
+    type MaybeGetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     #[doc = "Returns a mapping from file system id to backing file system configuration."]
     fn get_file_systems(
         &self,
@@ -556,12 +556,12 @@ pub trait TestService<T> {
     fn upload_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
-        input: T,
+        input: I,
     ) -> Result<(), conjure_http::private::Error>;
     fn upload_aliased_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
-        input: T,
+        input: I,
     ) -> Result<(), conjure_http::private::Error>;
     fn get_branches(
         &self,
@@ -646,7 +646,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -664,7 +664,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -684,7 +684,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -703,7 +703,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -722,7 +722,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -741,7 +741,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -760,7 +760,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -779,7 +779,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -797,7 +797,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -815,7 +815,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -834,7 +834,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -853,7 +853,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -873,7 +873,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -892,7 +892,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -943,7 +943,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -994,7 +994,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1012,7 +1012,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1030,7 +1030,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1048,7 +1048,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1067,7 +1067,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body>,
+        T: TestService<B::Body, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1091,15 +1091,15 @@ impl<T> TestServiceResource<T> {
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
 }
-impl<T, U> conjure_http::server::Resource<U> for TestServiceResource<T>
+impl<T, I, O> conjure_http::server::Resource<I, O> for TestServiceResource<T>
 where
-    T: TestService<U>,
+    T: TestService<I, O>,
 {
     const NAME: &'static str = "TestService";
     fn endpoints<B, R>() -> Vec<conjure_http::server::Endpoint<Self, B, R>>
     where
-        B: conjure_http::server::RequestBody<Body = U>,
-        R: conjure_http::server::VisitResponse,
+        B: conjure_http::server::RequestBody<Body = I>,
+        R: conjure_http::server::VisitResponse<BinaryWriter = O>,
     {
         vec![
             conjure_http::server::Endpoint::new(

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -89,7 +89,7 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
-    ) -> Result<T::ResponseBody, conjure_http::private::Error> {
+    ) -> Result<T::BinaryBody, conjure_http::private::Error> {
         let mut path_params_ = conjure_http::PathParams::new();
         conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
         let query_params_ = conjure_http::QueryParams::new();
@@ -111,7 +111,7 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
-    ) -> Result<T::ResponseBody, conjure_http::private::Error> {
+    ) -> Result<T::BinaryBody, conjure_http::private::Error> {
         let mut path_params_ = conjure_http::PathParams::new();
         conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
         let query_params_ = conjure_http::QueryParams::new();
@@ -133,7 +133,7 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
-    ) -> Result<Option<T::ResponseBody>, conjure_http::private::Error> {
+    ) -> Result<Option<T::BinaryBody>, conjure_http::private::Error> {
         let mut path_params_ = conjure_http::PathParams::new();
         conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
         let query_params_ = conjure_http::QueryParams::new();
@@ -179,7 +179,7 @@ where
         input: U,
     ) -> Result<(), conjure_http::private::Error>
     where
-        U: conjure_http::client::WriteBody<T::RequestWriter>,
+        U: conjure_http::client::WriteBody<T::BinaryWriter>,
     {
         let path_params_ = conjure_http::PathParams::new();
         let query_params_ = conjure_http::QueryParams::new();
@@ -203,7 +203,7 @@ where
         input: U,
     ) -> Result<(), conjure_http::private::Error>
     where
-        U: conjure_http::client::WriteBody<T::RequestWriter>,
+        U: conjure_http::client::WriteBody<T::BinaryWriter>,
     {
         let path_params_ = conjure_http::PathParams::new();
         let query_params_ = conjure_http::QueryParams::new();
@@ -646,7 +646,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -664,7 +664,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -684,7 +684,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -703,7 +703,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -722,7 +722,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -741,7 +741,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -760,7 +760,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -779,7 +779,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -797,7 +797,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -815,7 +815,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -834,7 +834,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -853,7 +853,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -873,7 +873,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -892,7 +892,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -943,7 +943,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -994,7 +994,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1012,7 +1012,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1030,7 +1030,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1048,7 +1048,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1067,7 +1067,7 @@ impl<T> TestServiceResource<T> {
         response_visitor_: R,
     ) -> Result<R::Output, conjure_http::private::Error>
     where
-        T: TestService<B::Body, R::BinaryWriter>,
+        T: TestService<B::BinaryBody, R::BinaryWriter>,
         B: conjure_http::server::RequestBody,
         R: conjure_http::server::VisitResponse,
     {
@@ -1098,7 +1098,7 @@ where
     const NAME: &'static str = "TestService";
     fn endpoints<B, R>() -> Vec<conjure_http::server::Endpoint<Self, B, R>>
     where
-        B: conjure_http::server::RequestBody<Body = I>,
+        B: conjure_http::server::RequestBody<BinaryBody = I>,
         R: conjure_http::server::VisitResponse<BinaryWriter = O>,
     {
         vec![

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -224,7 +224,7 @@ fn generate_resource(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
 
             fn endpoints<B, R>() -> #vec<conjure_http::server::Endpoint<Self, B, R>>
             where
-                B: conjure_http::server::RequestBody<Body = I>,
+                B: conjure_http::server::RequestBody<BinaryBody = I>,
                 R: conjure_http::server::VisitResponse<BinaryWriter = O>,
             {
                 vec![
@@ -238,7 +238,7 @@ fn generate_resource(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
 fn endpoint_fn_trait_params(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
     let mut params = vec![];
     if service_has_binary_request_body(ctx, def) {
-        params.push(quote!(B::Body));
+        params.push(quote!(B::BinaryBody));
     }
     if service_has_binary_response_body(ctx, def) {
         params.push(quote!(R::BinaryWriter));

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -24,10 +24,10 @@ use crate::{PathParams, QueryParams};
 
 /// A trait implemented by HTTP client implementations.
 pub trait Client {
-    /// The client's request body writer type.
-    type RequestWriter;
-    /// The client's response body type.
-    type ResponseBody;
+    /// The client's binary request body writer type.
+    type BinaryWriter;
+    /// The client's binary response body type.
+    type BinaryBody;
 
     /// Makes an HTTP request.
     ///
@@ -49,8 +49,8 @@ pub trait Client {
         response_visitor: U,
     ) -> Result<U::Output, Error>
     where
-        T: RequestBody<'a, Self::RequestWriter>,
-        U: VisitResponse<Self::ResponseBody>;
+        T: RequestBody<'a, Self::BinaryWriter>,
+        U: VisitResponse<Self::BinaryBody>;
 }
 
 /// A trait implemented by request bodies.

--- a/conjure-http/src/private/client.rs
+++ b/conjure-http/src/private/client.rs
@@ -108,10 +108,10 @@ fn encode_auth(headers: &mut HeaderMap, header: HeaderName, prefix: &str, value:
 
 pub struct EmptyRequestBody;
 
-impl<'a> RequestBody<'a> for EmptyRequestBody {
+impl<'a, W> RequestBody<'a, W> for EmptyRequestBody {
     fn accept<V>(self, visitor: V) -> V::Output
     where
-        V: VisitRequestBody<'a>,
+        V: VisitRequestBody<'a, W>,
     {
         visitor.visit_empty()
     }
@@ -119,13 +119,13 @@ impl<'a> RequestBody<'a> for EmptyRequestBody {
 
 pub struct SerializableRequestBody<T>(pub T);
 
-impl<'a, T> RequestBody<'a> for SerializableRequestBody<T>
+impl<'a, T, W> RequestBody<'a, W> for SerializableRequestBody<T>
 where
     T: Serialize + 'a,
 {
     fn accept<V>(self, visitor: V) -> V::Output
     where
-        V: VisitRequestBody<'a>,
+        V: VisitRequestBody<'a, W>,
     {
         visitor.visit_serializable(self.0)
     }
@@ -133,13 +133,13 @@ where
 
 pub struct BinaryRequestBody<T>(pub T);
 
-impl<'a, T> RequestBody<'a> for BinaryRequestBody<T>
+impl<'a, T, W> RequestBody<'a, W> for BinaryRequestBody<T>
 where
-    T: WriteBody + 'a,
+    T: WriteBody<W> + 'a,
 {
     fn accept<V>(self, visitor: V) -> V::Output
     where
-        V: VisitRequestBody<'a>,
+        V: VisitRequestBody<'a, W>,
     {
         visitor.visit_binary(self.0)
     }

--- a/conjure-http/src/private/server.rs
+++ b/conjure-http/src/private/server.rs
@@ -280,10 +280,10 @@ impl<T> VisitRequestBody<T> for BinaryRequestBodyVisitor {
 
 pub struct EmptyResponse;
 
-impl Response for EmptyResponse {
+impl<W> Response<W> for EmptyResponse {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitResponse,
+        V: VisitResponse<BinaryWriter = W>,
     {
         visitor.visit_empty()
     }
@@ -291,13 +291,13 @@ impl Response for EmptyResponse {
 
 pub struct SerializableResponse<T>(pub T);
 
-impl<T> Response for SerializableResponse<T>
+impl<T, W> Response<W> for SerializableResponse<T>
 where
     T: Serialize + 'static,
 {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitResponse,
+        V: VisitResponse<BinaryWriter = W>,
     {
         visitor.visit_serializable(self.0)
     }
@@ -305,13 +305,13 @@ where
 
 pub struct DefaultSerializableResponse<T>(pub T);
 
-impl<T> Response for DefaultSerializableResponse<T>
+impl<T, W> Response<W> for DefaultSerializableResponse<T>
 where
     T: PartialEq + Default + Serialize + 'static,
 {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitResponse,
+        V: VisitResponse<BinaryWriter = W>,
     {
         if self.0 == T::default() {
             visitor.visit_empty()
@@ -323,13 +323,13 @@ where
 
 pub struct BinaryResponse<T>(pub T);
 
-impl<T> Response for BinaryResponse<T>
+impl<T, W> Response<W> for BinaryResponse<T>
 where
-    T: WriteBody + 'static,
+    T: WriteBody<W> + 'static,
 {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitResponse,
+        V: VisitResponse<BinaryWriter = W>,
     {
         visitor.visit_binary(self.0)
     }
@@ -337,13 +337,13 @@ where
 
 pub struct OptionalBinaryResponse<T>(pub Option<T>);
 
-impl<T> Response for OptionalBinaryResponse<T>
+impl<T, W> Response<W> for OptionalBinaryResponse<T>
 where
-    T: WriteBody + 'static,
+    T: WriteBody<W> + 'static,
 {
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitResponse,
+        V: VisitResponse<BinaryWriter = W>,
     {
         match self.0 {
             Some(body) => visitor.visit_binary(body),

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -209,19 +209,19 @@ pub trait Resource<I, O>: Sized {
     // FIXME ideally this would be a &'static [Endpoint] once const fns become more powerful
     fn endpoints<B, R>() -> Vec<Endpoint<Self, B, R>>
     where
-        B: RequestBody<Body = I>,
+        B: RequestBody<BinaryBody = I>,
         R: VisitResponse<BinaryWriter = O>;
 }
 
 /// An HTTP request body.
 pub trait RequestBody {
     /// The binary body type.
-    type Body;
+    type BinaryBody;
 
     /// Accepts a visitor, calling the correct method corresponding to this body type.
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitRequestBody<Self::Body>;
+        V: VisitRequestBody<Self::BinaryBody>;
 }
 
 /// A visitor over request body formats.
@@ -276,6 +276,7 @@ pub trait Response<W> {
 
 /// A visitor over response body formats.
 pub trait VisitResponse {
+    /// The server's binary response body writer type.
     type BinaryWriter;
 
     /// The output type returned by visit methods.

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -201,7 +201,7 @@ where
 /// An HTTP resource.
 ///
 /// The server-half of a Conjure service implements this trait.
-pub trait Resource<T>: Sized {
+pub trait Resource<I, O>: Sized {
     /// The resource's name.
     const NAME: &'static str;
 
@@ -209,8 +209,8 @@ pub trait Resource<T>: Sized {
     // FIXME ideally this would be a &'static [Endpoint] once const fns become more powerful
     fn endpoints<B, R>() -> Vec<Endpoint<Self, B, R>>
     where
-        B: RequestBody<Body = T>,
-        R: VisitResponse;
+        B: RequestBody<Body = I>,
+        R: VisitResponse<BinaryWriter = O>;
 }
 
 /// An HTTP request body.
@@ -267,15 +267,17 @@ pub trait VisitRequestBody<T>: Sized {
 }
 
 /// An HTTP response.
-pub trait Response {
+pub trait Response<W> {
     /// Accepts a visitor, calling the correct method corresponding to the response type.
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where
-        V: VisitResponse;
+        V: VisitResponse<BinaryWriter = W>;
 }
 
 /// A visitor over response body formats.
 pub trait VisitResponse {
+    type BinaryWriter;
+
     /// The output type returned by visit methods.
     type Output;
 
@@ -290,17 +292,20 @@ pub trait VisitResponse {
     /// Visits a streaming binary body.
     fn visit_binary<T>(self, body: T) -> Result<Self::Output, Error>
     where
-        T: WriteBody + 'static;
+        T: WriteBody<Self::BinaryWriter> + 'static;
 }
 
 /// A trait implemented by streaming bodies.
-pub trait WriteBody {
+pub trait WriteBody<W> {
     /// Writes the body out, in its entirety.
-    fn write_body(self, w: &mut dyn Write) -> Result<(), Error>;
+    fn write_body(self, w: &mut W) -> Result<(), Error>;
 }
 
-impl WriteBody for Vec<u8> {
-    fn write_body(self, w: &mut dyn Write) -> Result<(), Error> {
+impl<W> WriteBody<W> for Vec<u8>
+where
+    W: Write,
+{
+    fn write_body(self, w: &mut W) -> Result<(), Error> {
         w.write_all(&self).map_err(Error::internal_safe)
     }
 }

--- a/conjure-test/build.rs
+++ b/conjure-test/build.rs
@@ -7,7 +7,7 @@ fn main() {
 
     println!("cargo:rerun-if-changed={}", input);
     conjure_codegen::Config::new()
-        .run_rustfmt(false)
+        // .run_rustfmt(false)
         .strip_prefix("com.palantir.conjure".to_string())
         .generate_files(input, output)
         .unwrap();

--- a/conjure-test/build.rs
+++ b/conjure-test/build.rs
@@ -7,7 +7,6 @@ fn main() {
 
     println!("cargo:rerun-if-changed={}", input);
     conjure_codegen::Config::new()
-        // .run_rustfmt(false)
         .strip_prefix("com.palantir.conjure".to_string())
         .generate_files(input, output)
         .unwrap();

--- a/conjure-test/src/test/clients.rs
+++ b/conjure-test/src/test/clients.rs
@@ -80,6 +80,7 @@ impl TestClient {
 }
 
 impl Client for TestClient {
+    type RequestWriter = Vec<u8>;
     type ResponseBody = Vec<u8>;
 
     fn request<'a, T, U>(
@@ -93,7 +94,7 @@ impl Client for TestClient {
         response_visitor: U,
     ) -> Result<U::Output, Error>
     where
-        T: RequestBody<'a>,
+        T: RequestBody<'a, Vec<u8>>,
         U: VisitResponse<Vec<u8>>,
     {
         assert_eq!(method, self.method);
@@ -115,7 +116,7 @@ impl Client for TestClient {
 
 struct TestBodyVisitor;
 
-impl<'a> VisitRequestBody<'a> for TestBodyVisitor {
+impl<'a> VisitRequestBody<'a, Vec<u8>> for TestBodyVisitor {
     type Output = TestBody;
 
     fn visit_empty(self) -> TestBody {
@@ -132,7 +133,7 @@ impl<'a> VisitRequestBody<'a> for TestBodyVisitor {
 
     fn visit_binary<T>(self, mut body: T) -> TestBody
     where
-        T: WriteBody + 'a,
+        T: WriteBody<Vec<u8>> + 'a,
     {
         let mut buf = vec![];
         body.write_body(&mut buf).unwrap();

--- a/conjure-test/src/test/clients.rs
+++ b/conjure-test/src/test/clients.rs
@@ -80,8 +80,8 @@ impl TestClient {
 }
 
 impl Client for TestClient {
-    type RequestWriter = Vec<u8>;
-    type ResponseBody = Vec<u8>;
+    type BinaryWriter = Vec<u8>;
+    type BinaryBody = Vec<u8>;
 
     fn request<'a, T, U>(
         &self,

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -56,7 +56,7 @@ macro_rules! test_service_handler {
             )*
         }
 
-        impl TestService<Vec<u8>> for TestServiceHandler {
+        impl TestService<Vec<u8>, Vec<u8>> for TestServiceHandler {
             type StreamingResponseBody = Vec<u8>;
             type OptionalStreamingResponseBody = Vec<u8>;
             type StreamingAliasResponseBody = Vec<u8>;
@@ -233,6 +233,8 @@ impl RequestBody for TestBody {
 struct TestResponseVisitor;
 
 impl VisitResponse for TestResponseVisitor {
+    type BinaryWriter = Vec<u8>;
+
     type Output = TestBody;
 
     fn visit_empty(self) -> Result<TestBody, Error> {
@@ -249,7 +251,7 @@ impl VisitResponse for TestResponseVisitor {
 
     fn visit_binary<T>(self, body: T) -> Result<TestBody, Error>
     where
-        T: WriteBody + 'static,
+        T: WriteBody<Vec<u8>> + 'static,
     {
         let mut buf = vec![];
         body.write_body(&mut buf).unwrap();

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -211,7 +211,7 @@ enum TestBody {
 }
 
 impl RequestBody for TestBody {
-    type Body = Vec<u8>;
+    type BinaryBody = Vec<u8>;
 
     fn accept<V>(self, visitor: V) -> Result<V::Output, Error>
     where


### PR DESCRIPTION
Previously, `WriteBody` implementations just took `&mut dyn Write`, but this allows client and server implementations to pick their writer type explicitly.