### PR TITLE
Fix type paths in collection bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,12 +138,12 @@ dependencies = [
 
 [[package]]
 name = "conjure-codegen"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
- "conjure-error 0.3.3",
- "conjure-http 0.3.3",
- "conjure-object 0.3.3",
- "conjure-serde 0.3.3",
+ "conjure-error 0.3.4",
+ "conjure-http 0.3.4",
+ "conjure-object 0.3.4",
+ "conjure-serde 0.3.4",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -152,10 +152,10 @@ dependencies = [
 
 [[package]]
 name = "conjure-error"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-object 0.3.3",
+ "conjure-object 0.3.4",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,11 +164,11 @@ dependencies = [
 
 [[package]]
 name = "conjure-http"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
- "conjure-error 0.3.3",
- "conjure-object 0.3.3",
- "conjure-serde 0.3.3",
+ "conjure-error 0.3.4",
+ "conjure-object 0.3.4",
+ "conjure-serde 0.3.4",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "conjure-object"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -191,15 +191,15 @@ dependencies = [
 
 [[package]]
 name = "conjure-rust"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
- "conjure-codegen 0.3.3",
+ "conjure-codegen 0.3.4",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conjure-serde"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -209,14 +209,14 @@ dependencies = [
 
 [[package]]
 name = "conjure-test"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-codegen 0.3.3",
- "conjure-error 0.3.3",
- "conjure-http 0.3.3",
- "conjure-object 0.3.3",
- "conjure-serde 0.3.3",
+ "conjure-codegen 0.3.4",
+ "conjure-error 0.3.4",
+ "conjure-http 0.3.4",
+ "conjure-object 0.3.4",
+ "conjure-serde 0.3.4",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ quote = { version = "0.6", default-features = false }
 proc-macro2 = { version = "0.4", default-features = false }
 failure = "0.1"
 
-conjure-object = { version = "0.3.3", path = "../conjure-object" }
-conjure-serde = { version = "0.3.3", path = "../conjure-serde" }
-conjure-error = { version = "0.3.3", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.3.3", optional = true, path = "../conjure-http" }
+conjure-object = { version = "0.3.4", path = "../conjure-object" }
+conjure-serde = { version = "0.3.4", path = "../conjure-serde" }
+conjure-error = { version = "0.3.4", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.3.4", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -599,13 +599,10 @@ impl Context {
                     assign_rhs: quote!(#value_ident.into_iter().collect()),
                 }
             }
-            Type::Reference(def) => {
-                let type_ = self.type_name(def.name());
-                CollectionSetterBounds::Simple {
-                    argument_type: quote!(super::#type_),
-                    assign_rhs: value_ident,
-                }
-            }
+            Type::Reference(def) => CollectionSetterBounds::Simple {
+                argument_type: self.type_path(this_type, def),
+                assign_rhs: value_ident,
+            },
             Type::External(def) => {
                 self.collection_setter_bounds(this_type, def.fallback(), value_ident)
             }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,4 +15,4 @@ serde = "1.0"
 serde-value = "0.5"
 uuid = { version = "0.7", features = ["v4"] }
 
-conjure-object = { version = "0.3.3", path = "../conjure-object" }
+conjure-object = { version = "0.3.4", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ http = "0.1"
 lazy_static = "1.0"
 serde = "1.0"
 
-conjure-error = { version = "0.3.3", path = "../conjure-error" }
-conjure-object = { version = "0.3.3", path = "../conjure-object" }
-conjure-serde = { version = "0.3.3", path = "../conjure-serde" }
+conjure-error = { version = "0.3.4", path = "../conjure-error" }
+conjure-object = { version = "0.3.4", path = "../conjure-object" }
+conjure-serde = { version = "0.3.4", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.2"
 
-conjure-codegen = { version = "0.3.3", path = "../conjure-codegen" }
+conjure-codegen = { version = "0.3.4", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -141,6 +141,64 @@
       }
     }
   }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "OtherSubpackageCollections",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "list",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OtherSubpackageObject",
+                "package" : "com.palantir.conjure.bar.baz"
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "set",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OtherSubpackageObject",
+                "package" : "com.palantir.conjure.bar.baz"
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "map",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OtherSubpackageObject",
+                "package" : "com.palantir.conjure.bar.baz"
+              }
+            },
+            "valueType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SubpackageObject",
+                "package" : "com.palantir.conjure.foo"
+              }
+            }
+          }
+        }
+      } ]
+    }
+  }, {
     "type" : "alias",
     "alias" : {
       "typeName" : {

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -79,6 +79,11 @@ types:
         package: com.palantir.conjure.bar.baz
         fields:
           foo: SubpackageObject
+      OtherSubpackageCollections:
+        fields:
+          list: list<OtherSubpackageObject>
+          set: set<OtherSubpackageObject>
+          map: map<OtherSubpackageObject, SubpackageObject>
     errors:
       SimpleError:
         namespace: Test


### PR DESCRIPTION
This was missed when moving to respecting type packages.
