### PR TITLE
Add camelCase aliases for command line params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,12 +137,12 @@ dependencies = [
 
 [[package]]
 name = "conjure-codegen"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
- "conjure-error 0.4.2",
- "conjure-http 0.4.2",
- "conjure-object 0.4.2",
- "conjure-serde 0.4.2",
+ "conjure-error 0.4.3",
+ "conjure-http 0.4.3",
+ "conjure-object 0.4.3",
+ "conjure-serde 0.4.3",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,10 +151,10 @@ dependencies = [
 
 [[package]]
 name = "conjure-error"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "backtrace 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-object 0.4.2",
+ "conjure-object 0.4.3",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -163,11 +163,11 @@ dependencies = [
 
 [[package]]
 name = "conjure-http"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
- "conjure-error 0.4.2",
- "conjure-object 0.4.2",
- "conjure-serde 0.4.2",
+ "conjure-error 0.4.3",
+ "conjure-object 0.4.3",
+ "conjure-serde 0.4.3",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "conjure-object"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,15 +190,15 @@ dependencies = [
 
 [[package]]
 name = "conjure-rust"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
- "conjure-codegen 0.4.2",
+ "conjure-codegen 0.4.3",
  "structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conjure-serde"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -208,14 +208,14 @@ dependencies = [
 
 [[package]]
 name = "conjure-test"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-codegen 0.4.2",
- "conjure-error 0.4.2",
- "conjure-http 0.4.2",
- "conjure-object 0.4.2",
- "conjure-serde 0.4.2",
+ "conjure-codegen 0.4.3",
+ "conjure-error 0.4.3",
+ "conjure-http 0.4.3",
+ "conjure-object 0.4.3",
+ "conjure-serde 0.4.3",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/changelog/@unreleased/pr-67.v2.yml
+++ b/changelog/@unreleased/pr-67.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Add camelCase flag aliases to `conjure-rust` for compatibility with
+    `gradle-conjure`.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/67

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 
-conjure-object = { version = "0.4.2", path = "../conjure-object" }
-conjure-serde = { version = "0.4.2", path = "../conjure-serde" }
-conjure-error = { version = "0.4.2", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.4.2", optional = true, path = "../conjure-http" }
+conjure-object = { version = "0.4.3", path = "../conjure-object" }
+conjure-serde = { version = "0.4.3", path = "../conjure-serde" }
+conjure-error = { version = "0.4.3", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.4.3", optional = true, path = "../conjure-http" }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,4 +15,4 @@ serde = "1.0"
 serde-value = "0.6"
 uuid = { version = "0.7", features = ["v4"] }
 
-conjure-object = { version = "0.4.2", path = "../conjure-object" }
+conjure-object = { version = "0.4.3", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ http = "0.1"
 lazy_static = "1.0"
 serde = "1.0"
 
-conjure-error = { version = "0.4.2", path = "../conjure-error" }
-conjure-object = { version = "0.4.2", path = "../conjure-object" }
-conjure-serde = { version = "0.4.2", path = "../conjure-serde" }
+conjure-error = { version = "0.4.3", path = "../conjure-error" }
+conjure-object = { version = "0.4.3", path = "../conjure-object" }
+conjure-serde = { version = "0.4.3", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "0.4.2", path = "../conjure-codegen" }
+conjure-codegen = { version = "0.4.3", path = "../conjure-codegen" }

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -30,22 +30,29 @@ enum Opts {
     Generate(Args),
 }
 
+// FIXME move aliases over to the standard names
 #[derive(StructOpt)]
 struct Args {
     #[structopt(long = "exhaustive")]
     /// Generate exhaustively matchable enums and unions
     exhaustive: bool,
-    #[structopt(long = "strip-prefix", value_name = "prefix")]
+    #[structopt(long = "strip-prefix", value_name = "prefix", alias = "stripPrefix")]
     /// Strip a prefix from types's package paths
     strip_prefix: Option<String>,
     /// The name of the generated crate
-    #[structopt(long = "crate-name", value_name = "name", requires = "crate-version")]
+    #[structopt(
+        long = "crate-name",
+        value_name = "name",
+        requires = "crate-version",
+        alias = "crateName"
+    )]
     crate_name: Option<String>,
     /// The version of the generated crate
     #[structopt(
         long = "crate-version",
         value_name = "version",
-        requires = "crate-name"
+        requires = "crate-name",
+        alias = "crateVersion"
     )]
     crate_version: Option<String>,
     #[structopt(name = "input-json", parse(from_os_str))]

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -5,6 +5,6 @@ authors = []
 edition = "2018"
 
 [dependencies]
-conjure-object = "0.4.2"
-conjure-error = "0.4.2"
-conjure-http = "0.4.2"
+conjure-object = "0.4.3"
+conjure-error = "0.4.3"
+conjure-http = "0.4.3"


### PR DESCRIPTION
The Conjure spec requires camelCase flags, and gradle-conjure won't work
otherwise.