### PR TITLE
Add support for Windows to the conjure-rust dist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@1.0.0
+
 executors:
   rust:
     docker: [{ image: rust:1.34.0 }]
@@ -97,6 +100,24 @@ jobs:
           root: /Users/distiller
           paths: root/project/target/x86_64-apple-darwin/release/conjure-rust
 
+  dist-windows:
+    executor: win/vs2019
+    working_directory: C:\Users\circleci\root\project
+    environment:
+      CARGO_HOME: C:\Users\circleci\usr\local\cargo
+    steps:
+      - attach_workspace: { at: C:\Users\circleci }
+      - run: |
+          $progressPreference = "silentlyContinue"
+          Invoke-WebRequest "https://static.rust-lang.org/dist/rust-1.34.0-x86_64-pc-windows-msvc.exe" -outfile rust.exe
+      - run: .\rust.exe /VERYSILENT /NORESTART /DIR="C:\Program Files\Rust"
+      - run: |
+          $env:Path += ";C:\Program Files\Rust\bin"
+          cargo build --release --target x86_64-pc-windows-msvc -p conjure-rust
+      - persist_to_workspace:
+          root: C:\Users\circleci
+          paths: root\project\target\x86_64-pc-windows-msvc\release\conjure-rust.exe
+
   publish:
     executor: rust
     steps:
@@ -110,7 +131,11 @@ jobs:
             mkdir $bin/$arch
             cp target/$arch/release/conjure-rust $bin/$arch
           done
-          cp .circleci/conjure-rust $bin
+          for arch in x86_64-pc-windows-msvc; do
+            mkdir $bin/$arch
+            cp target/$arch/release/conjure-rust.exe $bin/$arch
+          done
+          cp .circleci/conjure-rust{,.bat} $bin
           tar cvzf /tmp/$name.tgz -C $base $name
           ./.circleci/bintray-publish.sh /tmp/$name.tgz
 
@@ -136,8 +161,13 @@ workflows:
           filters:
             tags: { only: /.*/ }
             branches: { ignore: /.*/ }
+      - dist-windows:
+          requires: [checkout]
+          filters:
+            tags: { only: /.*/ }
+            branches: { ignore: /.*/ }
       - publish:
-          requires: [test, dist-linux, dist-macos]
+          requires: [test, dist-linux, dist-macos, dist-windows]
           filters:
             tags: { only: /.*/ }
             branches: { ignore: /.*/ }

--- a/.circleci/conjure-rust.bat
+++ b/.circleci/conjure-rust.bat
@@ -1,0 +1,1 @@
+@%~dp0\x86_64-pc-windows-msvc\conjure-rust.exe %*

--- a/changelog/@unreleased/pr-69.v2.yml
+++ b/changelog/@unreleased/pr-69.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: The conjure-rust distribution now supports Windows.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/69


### PR DESCRIPTION
## Before this PR
The conjure-rust distribution only contained binaries for Linux and macOS.

## After this PR
==COMMIT_MSG==
The conjure-rust distribution now supports Windows.
==COMMIT_MSG==

