### PR TITLE
Accept productName/productVersion flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,12 +137,12 @@ dependencies = [
 
 [[package]]
 name = "conjure-codegen"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
- "conjure-error 0.4.4",
- "conjure-http 0.4.4",
- "conjure-object 0.4.4",
- "conjure-serde 0.4.4",
+ "conjure-error 0.4.5",
+ "conjure-http 0.4.5",
+ "conjure-object 0.4.5",
+ "conjure-serde 0.4.5",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,10 +151,10 @@ dependencies = [
 
 [[package]]
 name = "conjure-error"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-object 0.4.4",
+ "conjure-object 0.4.5",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -163,11 +163,11 @@ dependencies = [
 
 [[package]]
 name = "conjure-http"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
- "conjure-error 0.4.4",
- "conjure-object 0.4.4",
- "conjure-serde 0.4.4",
+ "conjure-error 0.4.5",
+ "conjure-object 0.4.5",
+ "conjure-serde 0.4.5",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "conjure-object"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,15 +190,15 @@ dependencies = [
 
 [[package]]
 name = "conjure-rust"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
- "conjure-codegen 0.4.4",
+ "conjure-codegen 0.4.5",
  "structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conjure-serde"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -208,14 +208,14 @@ dependencies = [
 
 [[package]]
 name = "conjure-test"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-codegen 0.4.4",
- "conjure-error 0.4.4",
- "conjure-http 0.4.4",
- "conjure-object 0.4.4",
- "conjure-serde 0.4.4",
+ "conjure-codegen 0.4.5",
+ "conjure-error 0.4.5",
+ "conjure-http 0.4.5",
+ "conjure-object 0.4.5",
+ "conjure-serde 0.4.5",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/changelog/@unreleased/pr-70.v2.yml
+++ b/changelog/@unreleased/pr-70.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The generator now accepts `--productName` and `--productVersion` flags
+    as aliases for `--crateName` and `--crateVersion` respectively.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/70

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 
-conjure-object = { version = "0.4.4", path = "../conjure-object" }
-conjure-serde = { version = "0.4.4", path = "../conjure-serde" }
-conjure-error = { version = "0.4.4", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.4.4", optional = true, path = "../conjure-http" }
+conjure-object = { version = "0.4.5", path = "../conjure-object" }
+conjure-serde = { version = "0.4.5", path = "../conjure-serde" }
+conjure-error = { version = "0.4.5", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.4.5", optional = true, path = "../conjure-http" }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,4 +15,4 @@ serde = "1.0"
 serde-value = "0.6"
 uuid = { version = "0.7", features = ["v4"] }
 
-conjure-object = { version = "0.4.4", path = "../conjure-object" }
+conjure-object = { version = "0.4.5", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ http = "0.1"
 lazy_static = "1.0"
 serde = "1.0"
 
-conjure-error = { version = "0.4.4", path = "../conjure-error" }
-conjure-object = { version = "0.4.4", path = "../conjure-object" }
-conjure-serde = { version = "0.4.4", path = "../conjure-serde" }
+conjure-error = { version = "0.4.5", path = "../conjure-error" }
+conjure-object = { version = "0.4.5", path = "../conjure-object" }
+conjure-serde = { version = "0.4.5", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "0.4.4", path = "../conjure-codegen" }
+conjure-codegen = { version = "0.4.5", path = "../conjure-codegen" }

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -44,7 +44,8 @@ struct Args {
         long = "crate-name",
         value_name = "name",
         requires = "crate-version",
-        alias = "crateName"
+        alias = "crateName",
+        alias = "productName"
     )]
     crate_name: Option<String>,
     /// The version of the generated crate
@@ -52,7 +53,8 @@ struct Args {
         long = "crate-version",
         value_name = "version",
         requires = "crate-name",
-        alias = "crateVersion"
+        alias = "crateVersion",
+        alias = "productVersion"
     )]
     crate_version: Option<String>,
     #[structopt(name = "input-json", parse(from_os_str))]

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -5,6 +5,6 @@ authors = []
 edition = "2018"
 
 [dependencies]
-conjure-object = "0.4.4"
-conjure-error = "0.4.4"
-conjure-http = "0.4.4"
+conjure-object = "0.4.5"
+conjure-error = "0.4.5"
+conjure-http = "0.4.5"


### PR DESCRIPTION
## Before this PR
This generator couldn't be used with the Gradle conjure-local plugin because it always passes `--productName` and `--productVersion` flags.

## After this PR
==COMMIT_MSG==
The generator now accepts `--productName` and `--productVersion` flags as aliases for `--crateName` and `--crateVersion` respectively.
==COMMIT_MSG==

