### PR TITLE
Avoid allocating to track field names when possible

### DIFF
--- a/changelog/@unreleased/pr-73.v2.yml
+++ b/changelog/@unreleased/pr-73.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Optimized the server-side JSON deserializer to avoid allocating owned
+    `String`s to store field names when possible.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/73

--- a/conjure-serde/src/json/test.rs
+++ b/conjure-serde/src/json/test.rs
@@ -136,4 +136,13 @@ fn server_unknown_fields() {
     assert!(e.is_data());
     assert!(e.to_string().contains("foo"));
     assert!(e.to_string().contains("bogus"));
+
+    let mut r = json.as_bytes();
+    let e = Foo::deserialize(&mut crate::json::ServerDeserializer::from_reader(&mut r))
+        .err()
+        .unwrap();
+
+    assert!(e.is_data());
+    assert!(e.to_string().contains("foo"));
+    assert!(e.to_string().contains("bogus"));
 }


### PR DESCRIPTION
## Before this PR
The server-side JSON deserializer needs to track field names to properly return errors when an unknown field is encountered. This previously always involved cloning the field name into a `String` each time one was encountered.

## After this PR
==COMMIT_MSG==
Optimized the server-side JSON deserializer to avoid allocating owned `String`s to store field names when possible.
==COMMIT_MSG==

