### PR TITLE
Support asynchronous clients and servers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 executors:
   rust:
-    docker: [{ image: rustlang/rust:nightly }]
+    docker: [{ image: rust:1.39.0 }]
 
 commands:
   restore_target:
@@ -55,8 +55,8 @@ jobs:
       - attach_workspace: { at: / }
       - run: rustup component add clippy rustfmt
       - restore_target: { job: test }
-        #- run: cargo clippy --all --all-targets
-        #- run: cargo fmt --all -- --check
+      - run: cargo clippy --all --all-targets
+      - run: cargo fmt --all -- --check
       - run: cargo test --all --all-features
       - run: |
           ./regenerate.sh
@@ -90,7 +90,7 @@ jobs:
     working_directory: /Users/distiller/root/project
     steps:
       - attach_workspace: { at: /Users/distiller }
-      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.34.0
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.39.0
       - run: sudo ln -s $CARGO_HOME/bin/* /usr/local/bin
       - restore_target: { job: dist-macos }
       - run: cargo build --release --target x86_64-apple-darwin -p conjure-rust
@@ -109,7 +109,7 @@ jobs:
       - attach_workspace: { at: C:\Users\circleci }
       - run: |
           $progressPreference = "silentlyContinue"
-          Invoke-WebRequest "https://static.rust-lang.org/dist/rust-1.34.0-x86_64-pc-windows-msvc.exe" -outfile rust.exe
+          Invoke-WebRequest "https://static.rust-lang.org/dist/rust-1.39.0-x86_64-pc-windows-msvc.exe" -outfile rust.exe
       - run: .\rust.exe /VERYSILENT /NORESTART /DIR="C:\Program Files\Rust"
       - run: |
           $env:Path += ";C:\Program Files\Rust\bin"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 executors:
   rust:
-    docker: [{ image: rust:1.34.0 }]
+    docker: [{ image: rustlang/rust:nightly }]
 
 commands:
   restore_target:
@@ -55,8 +55,8 @@ jobs:
       - attach_workspace: { at: / }
       - run: rustup component add clippy rustfmt
       - restore_target: { job: test }
-      - run: cargo clippy --all --all-targets
-      - run: cargo fmt --all -- --check
+        #- run: cargo clippy --all --all-targets
+        #- run: cargo fmt --all -- --check
       - run: cargo test --all --all-features
       - run: |
           ./regenerate.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,12 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -23,33 +23,33 @@ name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.38"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -75,7 +75,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -89,21 +89,20 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "c2-chacha"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -116,10 +115,10 @@ name = "chrono"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -130,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -142,7 +141,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -153,9 +152,9 @@ dependencies = [
  "conjure-http 0.4.6",
  "conjure-object 0.4.6",
  "conjure-serde 0.4.6",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -163,10 +162,10 @@ dependencies = [
 name = "conjure-error"
 version = "0.4.6"
 dependencies = [
- "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-object 0.4.6",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -178,9 +177,8 @@ dependencies = [
  "conjure-error 0.4.6",
  "conjure-object 0.4.6",
  "conjure-serde 0.4.6",
- "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -193,7 +191,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -204,7 +202,7 @@ name = "conjure-rust"
 version = "0.4.6"
 dependencies = [
  "conjure-codegen 0.4.6",
- "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -212,7 +210,7 @@ name = "conjure-serde"
 version = "0.4.6"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -221,7 +219,7 @@ dependencies = [
 name = "conjure-test"
 version = "0.4.6"
 dependencies = [
- "async-trait 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-codegen 0.4.6",
  "conjure-error 0.4.6",
@@ -229,29 +227,29 @@ dependencies = [
  "conjure-object 0.4.6",
  "conjure-serde 0.4.6",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -285,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -327,11 +325,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -340,12 +338,20 @@ name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "http"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -355,11 +361,10 @@ dependencies = [
 
 [[package]]
 name = "iovec"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -374,7 +379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -403,7 +408,7 @@ name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -412,15 +417,16 @@ name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -448,29 +454,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pin-project"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pin-project-internal 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-internal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -480,7 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -488,22 +494,14 @@ name = "proc-macro-error"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -515,7 +513,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -535,18 +533,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -554,8 +544,8 @@ name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -572,8 +562,8 @@ name = "rand"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -584,7 +574,7 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -593,7 +583,7 @@ name = "rand_chacha"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -615,7 +605,7 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -647,7 +637,7 @@ name = "rand_jitter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -659,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -670,7 +660,7 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -742,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -765,10 +755,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -777,7 +767,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -785,17 +775,17 @@ name = "serde_bytes"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -804,8 +794,8 @@ version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -815,7 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.10"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -825,54 +815,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.44"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.10.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -881,7 +861,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -901,7 +881,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -915,22 +895,17 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -944,7 +919,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -957,17 +932,12 @@ name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasi"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -991,25 +961,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum async-trait 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc11a44bf85d8097dedc52e4169d5e47b154a49918a89a29f454f803bd3e7e4"
+"checksum async-trait 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b64ebe56ac5fbe89417328eeb4291984d138056dcf694f1414ab0f26d49a6290"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
-"checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
-"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
+"checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
+"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
-"checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
+"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
-"checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
+"checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+"checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
-"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+"checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
@@ -1019,32 +989,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
 "checksum futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
 "checksum futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
-"checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
+"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
-"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
+"checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
+"checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+"checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+"checksum num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-"checksum pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d9156ea5979ae30ecc0460cd848738daf24cfb89eb11a41e0c369ba1f0e6aeb"
-"checksum pin-project-internal 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1a375fffcd7bf53d8302fb95c1e2f3e0a1a92bd57edcab796f26f9e527c2f3da"
+"checksum pin-project 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c5fce7042b4e4338a3f868e563fff394709c3ff62cf6908d407dd9e2caff96ed"
+"checksum pin-project-internal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7644b4721cc27235f667e735da8732f5b781c442157315674c0cb7f28b4cabf3"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
-"checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
+"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
@@ -1068,36 +1037,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
-"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 "checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
-"checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
+"checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe8d3289b63ef2f196d89e7701f986583c0895e764b78f052a55b9b5d34d84a"
-"checksum structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f3add731f5b4fb85931d362a3c92deb1ad7113649a8d51701fb257673705f122"
-"checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
-"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
+"checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
+"checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
+"checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "112784d5543df30660b04a72ca423bfbd90e8bb32f94dcf610f15401218b22c5"
-"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
+"checksum unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49f5526225fd8b77342d5986ab5f6055552e9c0776193b5b63fd53b46debfad7"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
 name = "conjure-http"
 version = "0.4.6"
 dependencies = [
+ "async-trait 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-error 0.4.6",
  "conjure-object 0.4.6",
  "conjure-serde 0.4.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,12 +146,12 @@ dependencies = [
 
 [[package]]
 name = "conjure-codegen"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
- "conjure-error 0.4.6",
- "conjure-http 0.4.6",
- "conjure-object 0.4.6",
- "conjure-serde 0.4.6",
+ "conjure-error 0.5.0",
+ "conjure-http 0.5.0",
+ "conjure-object 0.5.0",
+ "conjure-serde 0.5.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -160,10 +160,10 @@ dependencies = [
 
 [[package]]
 name = "conjure-error"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-object 0.4.6",
+ "conjure-object 0.5.0",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -172,19 +172,19 @@ dependencies = [
 
 [[package]]
 name = "conjure-http"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "async-trait 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-error 0.4.6",
- "conjure-object 0.4.6",
- "conjure-serde 0.4.6",
+ "conjure-error 0.5.0",
+ "conjure-object 0.5.0",
+ "conjure-serde 0.5.0",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conjure-object"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -199,15 +199,15 @@ dependencies = [
 
 [[package]]
 name = "conjure-rust"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
- "conjure-codegen 0.4.6",
+ "conjure-codegen 0.5.0",
  "structopt 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conjure-serde"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -217,15 +217,15 @@ dependencies = [
 
 [[package]]
 name = "conjure-test"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "async-trait 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "conjure-codegen 0.4.6",
- "conjure-error 0.4.6",
- "conjure-http 0.4.6",
- "conjure-object 0.4.6",
- "conjure-serde 0.4.6",
+ "conjure-codegen 0.5.0",
+ "conjure-error 0.5.0",
+ "conjure-http 0.5.0",
+ "conjure-object 0.5.0",
+ "conjure-serde 0.5.0",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +221,7 @@ dependencies = [
 name = "conjure-test"
 version = "0.4.6"
 dependencies = [
+ "async-trait 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-codegen 0.4.6",
  "conjure-error 0.4.6",
@@ -980,6 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum async-trait 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc11a44bf85d8097dedc52e4169d5e47b154a49918a89a29f454f803bd3e7e4"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -180,7 +180,6 @@ dependencies = [
  "conjure-serde 0.4.6",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -203,7 +202,7 @@ name = "conjure-rust"
 version = "0.4.6"
 dependencies = [
  "conjure-codegen 0.4.6",
- "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -250,7 +249,7 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -392,12 +391,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.8"
+name = "maybe-uninit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memchr"
@@ -458,26 +454,8 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pin-project"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "pin-project-internal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -806,8 +784,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -816,16 +797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -847,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -885,18 +866,6 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pin-project 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -974,7 +943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
+"checksum cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)" = "aa87058dce70a3ff5621797f1506cb837edd02ac4c0ae642b4542dce802908b8"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
@@ -999,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
@@ -1007,8 +976,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-"checksum pin-project 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c5fce7042b4e4338a3f868e563fff394709c3ff62cf6908d407dd9e2caff96ed"
-"checksum pin-project-internal 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7644b4721cc27235f667e735da8732f5b781c442157315674c0cb7f28b4cabf3"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
@@ -1048,16 +1015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542"
+"checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
-"checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
+"checksum structopt 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c167b61c7d4c126927f5346a4327ce20abf8a186b8041bbeb1ce49e5db49587b"
+"checksum structopt-derive 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "519621841414165d2ad0d4c92be8f41844203f2b67e245f9345a5a12d40c69d7"
 "checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
-"checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
+"checksum synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "575be94ccb86e8da37efb894a87e2b660be299b41d8ef347f9d6d79fbe61b1ba"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "112784d5543df30660b04a72ca423bfbd90e8bb32f94dcf610f15401218b22c5"
 "checksum unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49f5526225fd8b77342d5986ab5f6055552e9c0776193b5b63fd53b46debfad7"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,11 +24,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -98,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -109,7 +109,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -120,7 +120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -132,7 +132,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ dependencies = [
  "conjure-serde 0.4.6",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -153,10 +153,10 @@ dependencies = [
 name = "conjure-error"
 version = "0.4.6"
 dependencies = [
- "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "conjure-object 0.4.6",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -170,7 +170,8 @@ dependencies = [
  "conjure-serde 0.4.6",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -182,7 +183,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -193,7 +194,7 @@ name = "conjure-rust"
 version = "0.4.6"
 dependencies = [
  "conjure-codegen 0.4.6",
- "structopt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -201,9 +202,9 @@ name = "conjure-serde"
 version = "0.4.6"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -216,9 +217,10 @@ dependencies = [
  "conjure-http 0.4.6",
  "conjure-object 0.4.6",
  "conjure-serde 0.4.6",
+ "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -226,7 +228,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -252,11 +254,72 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures-channel-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-core-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-executor-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-io-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-sink-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-util-preview"
+version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -312,6 +375,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +402,14 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -351,7 +435,7 @@ name = "parking_lot_core"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -359,6 +443,29 @@ dependencies = [
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pin-project"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pin-project-internal 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
@@ -370,7 +477,7 @@ name = "proc-macro-error"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -385,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,7 +504,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -428,7 +535,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -451,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -647,10 +754,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -659,7 +766,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -667,28 +774,33 @@ name = "serde_bytes"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
@@ -702,21 +814,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -736,7 +848,7 @@ name = "syn"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -757,9 +869,9 @@ name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -781,6 +893,18 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -809,7 +933,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -858,17 +982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
-"checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
+"checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
-"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
-"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -876,6 +1000,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
+"checksum futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
+"checksum futures-executor-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "75236e88bd9fe88e5e8bfcd175b665d0528fe03ca4c5207fabc028c8f9d93e98"
+"checksum futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
+"checksum futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
+"checksum futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
+"checksum futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
@@ -884,21 +1015,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+"checksum pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3d9156ea5979ae30ecc0460cd848738daf24cfb89eb11a41e0c369ba1f0e6aeb"
+"checksum pin-project-internal 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1a375fffcd7bf53d8302fb95c1e2f3e0a1a92bd57edcab796f26f9e527c2f3da"
+"checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
+"checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-"checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
+"checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
@@ -923,21 +1060,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "f4473e8506b213730ff2061073b48fa51dcc66349219e2e7c5608f0296a1d95a"
+"checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 "checksum serde_bytes 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "45af0182ff64abaeea290235eb67da3825a576c5d53e642c4d5b652e12e6effc"
-"checksum serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "11e410fde43e157d789fc290d26bc940778ad0fdd47836426fbac36573710dbb"
-"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
+"checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
+"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ac9d6e93dd792b217bf89cda5c14566e3043960c6f9da890c2ba5d09d07804c"
-"checksum structopt-derive 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ae9e5165d463a0dea76967d021f8d0f9316057bf5163aa2a4843790e842ff37"
+"checksum structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe8d3289b63ef2f196d89e7701f986583c0895e764b78f052a55b9b5d34d84a"
+"checksum structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f3add731f5b4fb85931d362a3c92deb1ad7113649a8d51701fb257673705f122"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "112784d5543df30660b04a72ca423bfbd90e8bb32f94dcf610f15401218b22c5"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
  "conjure-http 0.4.6",
  "conjure-object 0.4.6",
  "conjure-serde 0.4.6",
- "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -263,63 +263,84 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "futures-channel-preview"
-version = "0.3.0-alpha.19"
+name = "futures"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "futures-core-preview"
-version = "0.3.0-alpha.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "futures-executor-preview"
-version = "0.3.0-alpha.19"
+name = "futures-channel"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "futures-io-preview"
-version = "0.3.0-alpha.19"
+name = "futures-core"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "futures-preview"
-version = "0.3.0-alpha.19"
+name = "futures-executor"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-executor-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "futures-sink-preview"
-version = "0.3.0-alpha.19"
+name = "futures-io"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "futures-util-preview"
-version = "0.3.0-alpha.19"
+name = "futures-macro"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-task"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -339,14 +360,6 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -418,15 +431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ordered-float"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +481,21 @@ dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -952,16 +971,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-"checksum futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
-"checksum futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
-"checksum futures-executor-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "75236e88bd9fe88e5e8bfcd175b665d0528fe03ca4c5207fabc028c8f9d93e98"
-"checksum futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
-"checksum futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
-"checksum futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
-"checksum futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
+"checksum futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
+"checksum futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
+"checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
+"checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
+"checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
+"checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
+"checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
+"checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+"checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
@@ -972,13 +992,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
+"checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
+"checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 
-conjure-object = { version = "0.4.6", path = "../conjure-object" }
-conjure-serde = { version = "0.4.6", path = "../conjure-serde" }
-conjure-error = { version = "0.4.6", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.4.6", optional = true, path = "../conjure-http" }
+conjure-object = { version = "0.5.0", path = "../conjure-object" }
+conjure-serde = { version = "0.5.0", path = "../conjure-serde" }
+conjure-error = { version = "0.5.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.5.0", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -818,6 +818,14 @@ impl Context {
         self.prelude_ident(name, "Default", "std::default::Default")
     }
 
+    pub fn sync_ident(&self, name: &TypeName) -> TokenStream {
+        self.prelude_ident(name, "Sync", "std::marker::Sync")
+    }
+
+    pub fn send_ident(&self, name: &TypeName) -> TokenStream {
+        self.prelude_ident(name, "Send", "std::marker::Send")
+    }
+
     fn prelude_ident(&self, name: &TypeName, short: &str, long: &str) -> TokenStream {
         let s = if self.type_name(name.name()) == short {
             long

--- a/conjure-codegen/src/example_types/another/mod.rs
+++ b/conjure-codegen/src/example_types/another/mod.rs
@@ -2,7 +2,7 @@
 pub use self::different_package::DifferentPackage;
 #[doc(inline)]
 pub use self::test_service::{
-    TestService, TestServiceAsyncClient, TestServiceClient, TestServiceResource,
+    AsyncTestService, TestService, TestServiceAsyncClient, TestServiceClient, TestServiceResource,
 };
 pub mod different_package;
 pub mod test_service;

--- a/conjure-codegen/src/example_types/another/mod.rs
+++ b/conjure-codegen/src/example_types/another/mod.rs
@@ -1,6 +1,8 @@
 #[doc(inline)]
 pub use self::different_package::DifferentPackage;
 #[doc(inline)]
-pub use self::test_service::{TestService, TestServiceClient, TestServiceResource};
+pub use self::test_service::{
+    TestService, TestServiceAsyncClient, TestServiceClient, TestServiceResource,
+};
 pub mod different_package;
 pub mod test_service;

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1052,7 +1052,7 @@ where
         )
     }
 }
-use conjure_http::server::Response as _;
+use conjure_http::server::{AsyncResponse as _, Response as _};
 #[doc = "A Markdown description of the service."]
 pub trait TestService<I, O> {
     #[doc = "The body type returned by the `get_raw_data` method."]
@@ -1176,6 +1176,354 @@ pub trait TestService<I, O> {
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error>;
 }
+#[doc = "A Markdown description of the service."]
+pub trait AsyncTestService<I, O> {
+    #[doc = "The body type returned by the `get_raw_data` method."]
+    type GetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
+    #[doc = "The body type returned by the `get_aliased_raw_data` method."]
+    type GetAliasedRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
+    #[doc = "The body type returned by the `maybe_get_raw_data` method."]
+    type MaybeGetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
+    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    fn get_file_systems<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        std::collections::BTreeMap<
+                            String,
+                            super::super::product::datasets::BackingFileSystem,
+                        >,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn create_dataset<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        request: super::super::product::CreateDatasetRequest,
+        test_header_arg: String,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        super::super::product::datasets::Dataset,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_dataset<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        Option<super::super::product::datasets::Dataset>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Self::GetRawDataBody, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_aliased_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn maybe_get_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        Option<Self::MaybeGetRawDataBody>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_aliased_string<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        super::super::product::AliasedString,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn upload_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        input: I,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn upload_aliased_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        input: I,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_branches<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        std::collections::BTreeSet<String>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    #[doc = "Gets all branches of this dataset."]
+    fn get_branches_deprecated<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        std::collections::BTreeSet<String>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn resolve_branch<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+        branch: String,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Option<String>, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_param<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Option<String>, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_query_params<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        query: String,
+        something: conjure_object::ResourceIdentifier,
+        optional_middle: Option<conjure_object::ResourceIdentifier>,
+        implicit: conjure_object::ResourceIdentifier,
+        set_end: std::collections::BTreeSet<String>,
+        optional_end: Option<conjure_object::ResourceIdentifier>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<i32, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_no_response_query_params<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        query: String,
+        something: conjure_object::ResourceIdentifier,
+        optional_middle: Option<conjure_object::ResourceIdentifier>,
+        implicit: conjure_object::ResourceIdentifier,
+        set_end: std::collections::BTreeSet<String>,
+        optional_end: Option<conjure_object::ResourceIdentifier>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_boolean<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<bool, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_double<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<f64, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_integer<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<i32, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_post_optional<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        maybe_string: Option<String>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Option<String>, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_optional_integer_and_double<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        maybe_integer: Option<i32>,
+        maybe_double: Option<f64>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+}
 pub struct TestServiceResource<T>(T);
 impl<T> TestServiceResource<T> {
     #[doc = r" Creates a new resource."]
@@ -1183,266 +1531,326 @@ impl<T> TestServiceResource<T> {
         TestServiceResource(handler)
     }
 }
-impl<T> TestServiceResource<T> {
-    fn get_file_systems<B, R>(
+struct GetFileSystemsHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetFileSystemsHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_file_systems(auth_)?;
+        let response = service_.0.get_file_systems(auth_)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn create_dataset<B, R>(
+}
+struct CreateDatasetHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for CreateDatasetHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let test_header_arg =
             conjure_http::private::parse_required_header(headers_, "testHeaderArg", "Test-Header")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let request = body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
-        let response = (self.0).create_dataset(auth_, request, test_header_arg)?;
+        let response = service_.0.create_dataset(auth_, request, test_header_arg)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn get_dataset<B, R>(
+}
+struct GetDatasetHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetDatasetHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_dataset(auth_, dataset_rid)?;
+        let response = service_.0.get_dataset(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn get_raw_data<B, R>(
+}
+struct GetRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_raw_data(auth_, dataset_rid)?;
+        let response = service_.0.get_raw_data(auth_, dataset_rid)?;
         conjure_http::private::BinaryResponse(response).accept(response_visitor_)
     }
-    fn get_aliased_raw_data<B, R>(
+}
+struct GetAliasedRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for GetAliasedRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_aliased_raw_data(auth_, dataset_rid)?;
+        let response = service_.0.get_aliased_raw_data(auth_, dataset_rid)?;
         conjure_http::private::BinaryResponse(response).accept(response_visitor_)
     }
-    fn maybe_get_raw_data<B, R>(
+}
+struct MaybeGetRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for MaybeGetRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).maybe_get_raw_data(auth_, dataset_rid)?;
+        let response = service_.0.maybe_get_raw_data(auth_, dataset_rid)?;
         conjure_http::private::OptionalBinaryResponse(response).accept(response_visitor_)
     }
-    fn get_aliased_string<B, R>(
+}
+struct GetAliasedStringHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for GetAliasedStringHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_aliased_string(auth_, dataset_rid)?;
+        let response = service_.0.get_aliased_string(auth_, dataset_rid)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn upload_raw_data<B, R>(
+}
+struct UploadRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for UploadRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
-        (self.0).upload_raw_data(auth_, input)?;
+        service_.0.upload_raw_data(auth_, input)?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
-    fn upload_aliased_raw_data<B, R>(
+}
+struct UploadAliasedRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for UploadAliasedRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
-        (self.0).upload_aliased_raw_data(auth_, input)?;
+        service_.0.upload_aliased_raw_data(auth_, input)?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
-    fn get_branches<B, R>(
+}
+struct GetBranchesHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetBranchesHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_branches(auth_, dataset_rid)?;
+        let response = service_.0.get_branches(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn get_branches_deprecated<B, R>(
+}
+struct GetBranchesDeprecatedHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for GetBranchesDeprecatedHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_branches_deprecated(auth_, dataset_rid)?;
+        let response = service_.0.get_branches_deprecated(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn resolve_branch<B, R>(
+}
+struct ResolveBranchHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for ResolveBranchHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let branch = conjure_http::private::parse_path_param(path_params_, "branch")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).resolve_branch(auth_, dataset_rid, branch)?;
+        let response = service_.0.resolve_branch(auth_, dataset_rid, branch)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn test_param<B, R>(
+}
+struct TestParamHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestParamHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_param(auth_, dataset_rid)?;
+        let response = service_.0.test_param(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn test_query_params<B, R>(
+}
+struct TestQueryParamsHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestQueryParamsHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         query_params_: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let something =
             conjure_http::private::parse_query_param(query_params_, "something", "different")?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
@@ -1470,7 +1878,7 @@ impl<T> TestServiceResource<T> {
         )?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let query = body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
-        let response = (self.0).test_query_params(
+        let response = service_.0.test_query_params(
             auth_,
             query,
             something,
@@ -1481,19 +1889,24 @@ impl<T> TestServiceResource<T> {
         )?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_no_response_query_params<B, R>(
+}
+struct TestNoResponseQueryParamsHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestNoResponseQueryParamsHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         query_params_: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let something =
             conjure_http::private::parse_query_param(query_params_, "something", "different")?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
@@ -1521,7 +1934,7 @@ impl<T> TestServiceResource<T> {
         )?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let query = body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
-        (self.0).test_no_response_query_params(
+        service_.0.test_no_response_query_params(
             auth_,
             query,
             something,
@@ -1532,92 +1945,114 @@ impl<T> TestServiceResource<T> {
         )?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
-    fn test_boolean<B, R>(
+}
+struct TestBooleanHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestBooleanHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_boolean(auth_)?;
+        let response = service_.0.test_boolean(auth_)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_double<B, R>(
+}
+struct TestDoubleHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestDoubleHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_double(auth_)?;
+        let response = service_.0.test_double(auth_)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_integer<B, R>(
+}
+struct TestIntegerHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestIntegerHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_integer(auth_)?;
+        let response = service_.0.test_integer(auth_)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_post_optional<B, R>(
+}
+struct TestPostOptionalHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestPostOptionalHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let maybe_string =
             body_.accept(conjure_http::private::DefaultSerializableRequestBodyVisitor::new())?;
-        let response = (self.0).test_post_optional(auth_, maybe_string)?;
+        let response = service_.0.test_post_optional(auth_, maybe_string)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn test_optional_integer_and_double<B, R>(
+}
+struct TestOptionalIntegerAndDoubleHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestOptionalIntegerAndDoubleHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         query_params_: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let mut maybe_integer: Option<i32> = Default::default();
         conjure_http::private::parse_optional_query_param(
             query_params_,
@@ -1634,7 +2069,9 @@ impl<T> TestServiceResource<T> {
         )?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        (self.0).test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
+        service_
+            .0
+            .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
 }
@@ -1649,328 +2086,1669 @@ where
         R: conjure_http::server::VisitResponse<BinaryWriter = O>,
     {
         vec![
-            conjure_http::server::Endpoint::new(
-                "getFileSystems",
-                conjure_http::private::http::Method::GET,
-                "/catalog/fileSystems",
-                TestServiceResource::get_file_systems,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "createDataset",
-                conjure_http::private::http::Method::POST,
-                "/catalog/datasets",
-                TestServiceResource::create_dataset,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "testHeaderArg",
-                            conjure_http::server::ParameterType::Header(
-                                conjure_http::server::HeaderParameter::new("Test-Header"),
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getFileSystems",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/fileSystems",
+                    &[],
+                    false,
+                ),
+                handler: &GetFileSystemsHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "createDataset",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "testHeaderArg",
+                                conjure_http::server::ParameterType::Header(
+                                    conjure_http::server::HeaderParameter::new("Test-Header"),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &CreateDatasetHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getDataset",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetDatasetHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "maybeGetRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &MaybeGetRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedString",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedStringHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw",
+                    &[],
+                    false,
+                ),
+                handler: &UploadRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadAliasedRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw-aliased",
+                    &[],
+                    false,
+                ),
+                handler: &UploadAliasedRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranches",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetBranchesHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranchesDeprecated",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    true,
+                ),
+                handler: &GetBranchesDeprecatedHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "resolveBranch",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getDataset",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}",
-                TestServiceResource::get_dataset,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "branch",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getRawData",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/raw",
-                TestServiceResource::get_raw_data,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &ResolveBranchHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testParam",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/testParam",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestParamHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getAliasedRawData",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/raw-aliased",
-                TestServiceResource::get_aliased_raw_data,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "maybeGetRawData",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/raw-maybe",
-                TestServiceResource::maybe_get_raw_data,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getAliasedString",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/string-aliased",
-                TestServiceResource::get_aliased_string,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "uploadRawData",
-                conjure_http::private::http::Method::POST,
-                "/catalog/datasets/upload-raw",
-                TestServiceResource::upload_raw_data,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "uploadAliasedRawData",
-                conjure_http::private::http::Method::POST,
-                "/catalog/datasets/upload-raw-aliased",
-                TestServiceResource::upload_aliased_raw_data,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "getBranches",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branches",
-                TestServiceResource::get_branches,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getBranchesDeprecated",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branchesDeprecated",
-                TestServiceResource::get_branches_deprecated,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestQueryParamsHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testNoResponseQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-no-response-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            )
-            .with_deprecated(true),
-            conjure_http::server::Endpoint::new(
-                "resolveBranch",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
-                TestServiceResource::resolve_branch,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "branch",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testParam",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/testParam",
-                TestServiceResource::test_param,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testQueryParams",
-                conjure_http::private::http::Method::POST,
-                "/catalog/test-query-params",
-                TestServiceResource::test_query_params,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "something",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("different"),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalMiddle",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalMiddle"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestNoResponseQueryParamsHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testBoolean",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/boolean",
+                    &[],
+                    false,
+                ),
+                handler: &TestBooleanHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/double",
+                    &[],
+                    false,
+                ),
+                handler: &TestDoubleHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testInteger",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/integer",
+                    &[],
+                    false,
+                ),
+                handler: &TestIntegerHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testPostOptional",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/optional",
+                    &[],
+                    false,
+                ),
+                handler: &TestPostOptionalHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testOptionalIntegerAndDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/optional-integer-double",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "maybeInteger",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeInteger"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "implicit",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("implicit"),
+                            conjure_http::server::Parameter::new(
+                                "maybeDouble",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeDouble"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "setEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("setEnd"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestOptionalIntegerAndDoubleHandler_,
+            },
+        ]
+    }
+}
+struct GetFileSystemsHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetFileSystemsHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_file_systems(auth_).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct CreateDatasetHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for CreateDatasetHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let test_header_arg = conjure_http::private::parse_required_header(
+                headers_,
+                "testHeaderArg",
+                "Test-Header",
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let request =
+                body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
+            let response = service_
+                .0
+                .create_dataset(auth_, request, test_header_arg)
+                .await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct GetDatasetHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetDatasetHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_dataset(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct GetRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_raw_data(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncBinaryResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct GetAliasedRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetAliasedRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_aliased_raw_data(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncBinaryResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct MaybeGetRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for MaybeGetRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.maybe_get_raw_data(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncOptionalBinaryResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct GetAliasedStringHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetAliasedStringHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_aliased_string(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct UploadRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for UploadRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
+            service_.0.upload_raw_data(auth_, input).await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+struct UploadAliasedRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for UploadAliasedRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
+            service_.0.upload_aliased_raw_data(auth_, input).await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+struct GetBranchesHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetBranchesHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_branches(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct GetBranchesDeprecatedHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetBranchesDeprecatedHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_
+                .0
+                .get_branches_deprecated(auth_, dataset_rid)
+                .await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct ResolveBranchHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for ResolveBranchHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let branch = conjure_http::private::parse_path_param(path_params_, "branch")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_
+                .0
+                .resolve_branch(auth_, dataset_rid, branch)
+                .await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct TestParamHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestParamHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_param(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct TestQueryParamsHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestQueryParamsHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        query_params_: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let something =
+                conjure_http::private::parse_query_param(query_params_, "something", "different")?;
+            let mut optional_middle: Option<conjure_object::ResourceIdentifier> =
+                Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalMiddle",
+                "optionalMiddle",
+                &mut optional_middle,
+            )?;
+            let implicit =
+                conjure_http::private::parse_query_param(query_params_, "implicit", "implicit")?;
+            let mut set_end: std::collections::BTreeSet<String> = Default::default();
+            conjure_http::private::parse_set_query_param(
+                query_params_,
+                "setEnd",
+                "setEnd",
+                &mut set_end,
+            )?;
+            let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalEnd",
+                "optionalEnd",
+                &mut optional_end,
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let query =
+                body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
+            let response = service_
+                .0
+                .test_query_params(
+                    auth_,
+                    query,
+                    something,
+                    optional_middle,
+                    implicit,
+                    set_end,
+                    optional_end,
+                )
+                .await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestNoResponseQueryParamsHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestNoResponseQueryParamsHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        query_params_: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let something =
+                conjure_http::private::parse_query_param(query_params_, "something", "different")?;
+            let mut optional_middle: Option<conjure_object::ResourceIdentifier> =
+                Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalMiddle",
+                "optionalMiddle",
+                &mut optional_middle,
+            )?;
+            let implicit =
+                conjure_http::private::parse_query_param(query_params_, "implicit", "implicit")?;
+            let mut set_end: std::collections::BTreeSet<String> = Default::default();
+            conjure_http::private::parse_set_query_param(
+                query_params_,
+                "setEnd",
+                "setEnd",
+                &mut set_end,
+            )?;
+            let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalEnd",
+                "optionalEnd",
+                &mut optional_end,
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let query =
+                body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
+            service_
+                .0
+                .test_no_response_query_params(
+                    auth_,
+                    query,
+                    something,
+                    optional_middle,
+                    implicit,
+                    set_end,
+                    optional_end,
+                )
+                .await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+struct TestBooleanHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestBooleanHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_boolean(auth_).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestDoubleHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestDoubleHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_double(auth_).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestIntegerHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestIntegerHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_integer(auth_).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestPostOptionalHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestPostOptionalHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let maybe_string = body_
+                .accept(conjure_http::private::DefaultSerializableRequestBodyVisitor::new())?;
+            let response = service_.0.test_post_optional(auth_, maybe_string).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct TestOptionalIntegerAndDoubleHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestOptionalIntegerAndDoubleHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        query_params_: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let mut maybe_integer: Option<i32> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "maybeInteger",
+                "maybeInteger",
+                &mut maybe_integer,
+            )?;
+            let mut maybe_double: Option<f64> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "maybeDouble",
+                "maybeDouble",
+                &mut maybe_double,
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            service_
+                .0
+                .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)
+                .await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+impl<T, I, O> conjure_http::server::AsyncResource<I, O> for TestServiceResource<T>
+where
+    T: AsyncTestService<I, O> + Sync + Send,
+    I: Send,
+{
+    const NAME: &'static str = "TestService";
+    fn endpoints<B, R>() -> Vec<conjure_http::server::AsyncEndpoint<Self, B, R>>
+    where
+        B: conjure_http::server::RequestBody<BinaryBody = I> + Send,
+        R: conjure_http::server::AsyncVisitResponse<BinaryWriter = O> + Send,
+    {
+        vec![
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getFileSystems",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/fileSystems",
+                    &[],
+                    false,
+                ),
+                handler: &GetFileSystemsHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "createDataset",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "testHeaderArg",
+                                conjure_http::server::ParameterType::Header(
+                                    conjure_http::server::HeaderParameter::new("Test-Header"),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &CreateDatasetHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getDataset",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetDatasetHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "maybeGetRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &MaybeGetRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedString",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedStringHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw",
+                    &[],
+                    false,
+                ),
+                handler: &UploadRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadAliasedRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw-aliased",
+                    &[],
+                    false,
+                ),
+                handler: &UploadAliasedRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranches",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetBranchesHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranchesDeprecated",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    true,
+                ),
+                handler: &GetBranchesDeprecatedHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "resolveBranch",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalEnd"),
+                            conjure_http::server::Parameter::new(
+                                "branch",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testNoResponseQueryParams",
-                conjure_http::private::http::Method::POST,
-                "/catalog/test-no-response-query-params",
-                TestServiceResource::test_no_response_query_params,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "something",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("different"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &ResolveBranchHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testParam",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/testParam",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestParamHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalMiddle",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalMiddle"),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "implicit",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("implicit"),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "setEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("setEnd"),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalEnd"),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testBoolean",
-                conjure_http::private::http::Method::GET,
-                "/catalog/boolean",
-                TestServiceResource::test_boolean,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testDouble",
-                conjure_http::private::http::Method::GET,
-                "/catalog/double",
-                TestServiceResource::test_double,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testInteger",
-                conjure_http::private::http::Method::GET,
-                "/catalog/integer",
-                TestServiceResource::test_integer,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testPostOptional",
-                conjure_http::private::http::Method::POST,
-                "/catalog/optional",
-                TestServiceResource::test_post_optional,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testOptionalIntegerAndDouble",
-                conjure_http::private::http::Method::GET,
-                "/catalog/optional-integer-double",
-                TestServiceResource::test_optional_integer_and_double,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "maybeInteger",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("maybeInteger"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestQueryParamsHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testNoResponseQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-no-response-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "maybeDouble",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("maybeDouble"),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
+                            ),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
+                            ),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
+                            ),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestNoResponseQueryParamsHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testBoolean",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/boolean",
+                    &[],
+                    false,
+                ),
+                handler: &TestBooleanHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/double",
+                    &[],
+                    false,
+                ),
+                handler: &TestDoubleHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testInteger",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/integer",
+                    &[],
+                    false,
+                ),
+                handler: &TestIntegerHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testPostOptional",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/optional",
+                    &[],
+                    false,
+                ),
+                handler: &TestPostOptionalHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testOptionalIntegerAndDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/optional-integer-double",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "maybeInteger",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeInteger"),
+                                ),
+                            ),
+                            conjure_http::server::Parameter::new(
+                                "maybeDouble",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeDouble"),
+                                ),
+                            ),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestOptionalIntegerAndDoubleHandlerAsync_,
+            },
         ]
     }
 }

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1,5 +1,552 @@
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
+pub struct TestServiceAsyncClient<T>(T);
+impl<T> TestServiceAsyncClient<T>
+where
+    T: conjure_http::client::AsyncClient,
+{
+    #[doc = r" Creates a new client."]
+    #[inline]
+    pub fn new(client: T) -> TestServiceAsyncClient<T> {
+        TestServiceAsyncClient(client)
+    }
+    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    pub async fn get_file_systems(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<
+        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
+        conjure_http::private::Error,
+    > {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/fileSystems",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn create_dataset(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        request: &super::super::product::CreateDatasetRequest,
+        test_header_arg: &str,
+    ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        conjure_http::private::encode_header(
+            &mut headers_,
+            "testHeaderArg",
+            "test-header",
+            test_header_arg,
+        )?;
+        let body_ = conjure_http::private::SerializableRequestBody(request);
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/datasets",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_dataset(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
+    {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<T::BinaryBody, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::BinaryResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/raw",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_aliased_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<T::BinaryBody, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::BinaryResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/raw-aliased",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn maybe_get_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<T::BinaryBody>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::OptionalBinaryResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/raw-maybe",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_aliased_string(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<super::super::product::AliasedString, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/string-aliased",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn upload_raw_data<U>(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        input: U,
+    ) -> Result<(), conjure_http::private::Error>
+    where
+        U: conjure_http::client::AsyncWriteBody<T::BinaryWriter> + Sync + Send,
+    {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::BinaryRequestBody(input);
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/datasets/upload-raw",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn upload_aliased_raw_data<U>(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        input: U,
+    ) -> Result<(), conjure_http::private::Error>
+    where
+        U: conjure_http::client::AsyncWriteBody<T::BinaryWriter> + Sync + Send,
+    {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::BinaryRequestBody(input);
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/datasets/upload-raw-aliased",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_branches(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/branches",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    #[doc = "Gets all branches of this dataset."]
+    #[deprecated(note = "use getBranches instead")]
+    pub async fn get_branches_deprecated(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn resolve_branch(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+        branch: &str,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        conjure_http::private::encode_path_param(&mut path_params_, "branch", branch);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_param(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/testParam",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_query_params(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        query: &str,
+        something: &conjure_object::ResourceIdentifier,
+        optional_middle: Option<&conjure_object::ResourceIdentifier>,
+        implicit: &conjure_object::ResourceIdentifier,
+        set_end: &std::collections::BTreeSet<String>,
+        optional_end: Option<&conjure_object::ResourceIdentifier>,
+    ) -> Result<i32, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        conjure_http::private::encode_query_param(&mut query_params_, "different", something);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalMiddle",
+            &optional_middle,
+        );
+        conjure_http::private::encode_query_param(&mut query_params_, "implicit", implicit);
+        conjure_http::private::encode_set_query_param(&mut query_params_, "setEnd", &set_end);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalEnd",
+            &optional_end,
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::SerializableRequestBody(query);
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/test-query-params",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_no_response_query_params(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        query: &str,
+        something: &conjure_object::ResourceIdentifier,
+        optional_middle: Option<&conjure_object::ResourceIdentifier>,
+        implicit: &conjure_object::ResourceIdentifier,
+        set_end: &std::collections::BTreeSet<String>,
+        optional_end: Option<&conjure_object::ResourceIdentifier>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        conjure_http::private::encode_query_param(&mut query_params_, "different", something);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalMiddle",
+            &optional_middle,
+        );
+        conjure_http::private::encode_query_param(&mut query_params_, "implicit", implicit);
+        conjure_http::private::encode_set_query_param(&mut query_params_, "setEnd", &set_end);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalEnd",
+            &optional_end,
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::SerializableRequestBody(query);
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/test-no-response-query-params",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_boolean(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<bool, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/boolean",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_double(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<f64, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/double",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_integer(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<i32, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/integer",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_post_optional(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        maybe_string: Option<&str>,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::SerializableRequestBody(maybe_string);
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/optional",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_optional_integer_and_double(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        maybe_integer: Option<i32>,
+        maybe_double: Option<f64>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "maybeInteger",
+            &maybe_integer,
+        );
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "maybeDouble",
+            &maybe_double,
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/optional-integer-double",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+}
+#[doc = "A Markdown description of the service."]
+#[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
 impl<T> TestServiceClient<T>
 where

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -213,8 +213,10 @@
 //!
 //! ### Servers
 //!
-//! Conjure generates a trait and accompanying wrapper resource which are used to implement the service's endpoints:
+//! Conjure generates a trait and accompanying wrapper resource which are used to implement the service's endpoints.
+//! Both synchronous and asynchronous servers are supported:
 //!
+//! Synchronous:
 //! ```ignore
 //! struct TestServiceHandler;
 //!
@@ -223,6 +225,29 @@
 //!     T: Read
 //! {
 //!     fn get_file_systems(
+//!         &self,
+//!         auth: AuthToken,
+//!     ) -> Result<BTreeMap<String, BackingFileSystem>, Error> {
+//!         // ...
+//!     }
+//!
+//!     // ...
+//! }
+//!
+//! let resource = TestServiceResource::new(TestServiceHandler);
+//! http_server.register(resource);
+//! ```
+//!
+//! Asynchronous:
+//! ```ignore
+//! struct TestServiceHandler;
+//!
+//! #[async_trait]
+//! impl<T> AsyncTestService<T> for TestServiceHandler
+//! where
+//!     T: AsyncRead + 'static + Send
+//! {
+//!     async fn get_file_systems(
 //!         &self,
 //!         auth: AuthToken,
 //!     ) -> Result<BTreeMap<String, BackingFileSystem>, Error> {
@@ -456,6 +481,7 @@ impl Config {
                     format!("{}Client", def.service_name().name()),
                     format!("{}AsyncClient", def.service_name().name()),
                     context.type_name(def.service_name().name()).to_string(),
+                    format!("Async{}", def.service_name().name()),
                     format!("{}Resource", def.service_name().name()),
                 ],
                 contents,

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -186,14 +186,27 @@
 //!
 //! ### Clients
 //!
-//! The client object wraps a raw HTTP client and provides methods to interact with the service's endpoints:
+//! The client object wraps a raw HTTP client and provides methods to interact with the service's endpoints. Both
+//! synchronous and asynchronous clients are provided:
 //!
+//! Synchronous:
 //! ```
 //! # use conjure_codegen::example_types::another::TestServiceClient;
 //! # fn foo<T: conjure_http::client::Client>(http_client: T) -> Result<(), conjure_error::Error> {
 //! # let auth_token = "foobar".parse().unwrap();
 //! let client = TestServiceClient::new(http_client);
 //! let file_systems = client.get_file_systems(&auth_token)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Asynchronous:
+//! ```
+//! # use conjure_codegen::example_types::another::TestServiceAsyncClient;
+//! # async fn foo<T: conjure_http::client::AsyncClient>(http_client: T) -> Result<(), conjure_error::Error> {
+//! # let auth_token = "foobar".parse().unwrap();
+//! let client = TestServiceAsyncClient::new(http_client);
+//! let file_systems = client.get_file_systems(&auth_token).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -376,6 +389,7 @@ impl Config {
             if self.run_rustfmt {
                 let file_name = if lib_root { "lib.rs" } else { "mod.rs" };
                 let _ = Command::new(&self.rustfmt)
+                    .arg("--edition=2018")
                     .arg(&src_dir.join(file_name))
                     .status();
             }
@@ -440,6 +454,7 @@ impl Config {
                 module_name: context.module_name(def.service_name()),
                 type_names: vec![
                     format!("{}Client", def.service_name().name()),
+                    format!("{}AsyncClient", def.service_name().name()),
                     context.type_name(def.service_name().name()).to_string(),
                     format!("{}Resource", def.service_name().name()),
                 ],

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,4 +15,4 @@ serde = "1.0"
 serde-value = "0.6"
 uuid = { version = "0.7", features = ["v4"] }
 
-conjure-object = { version = "0.4.6", path = "../conjure-object" }
+conjure-object = { version = "0.5.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 async-trait = "0.1"
 http = "0.1"
 serde = "1.0"
-tokio-io = { version = "0.2.0-alpha.5", features = ["util"] }
 
 conjure-error = { version = "0.4.6", path = "../conjure-error" }
 conjure-object = { version = "0.4.6", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/palantir/conjure-rust"
 readme = "../README.md"
 
 [dependencies]
+async-trait = "0.1"
 http = "0.1"
 serde = "1.0"
 tokio-io = { version = "0.2.0-alpha.5", features = ["util"] }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,6 +13,6 @@ async-trait = "0.1"
 http = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "0.4.6", path = "../conjure-error" }
-conjure-object = { version = "0.4.6", path = "../conjure-object" }
-conjure-serde = { version = "0.4.6", path = "../conjure-serde" }
+conjure-error = { version = "0.5.0", path = "../conjure-error" }
+conjure-object = { version = "0.5.0", path = "../conjure-object" }
+conjure-serde = { version = "0.5.0", path = "../conjure-serde" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -10,7 +10,6 @@ readme = "../README.md"
 
 [dependencies]
 http = "0.1"
-lazy_static = "1.0"
 serde = "1.0"
 tokio-io = { version = "0.2.0-alpha.5", features = ["util"] }
 

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -12,6 +12,7 @@ readme = "../README.md"
 http = "0.1"
 lazy_static = "1.0"
 serde = "1.0"
+tokio-io = { version = "0.2.0-alpha.5", features = ["util"] }
 
 conjure-error = { version = "0.4.6", path = "../conjure-error" }
 conjure-object = { version = "0.4.6", path = "../conjure-object" }

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -22,8 +22,6 @@ use std::error;
 use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
-use tokio_io::{AsyncWrite, AsyncWriteExt};
-
 use crate::{PathParams, QueryParams};
 
 /// A trait implemented by HTTP client implementations.
@@ -217,7 +215,7 @@ where
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore
 /// use async_trait::async_trait;
 /// use conjure_error::Error;
 /// use conjure_http::client::AsyncWriteBody;
@@ -256,21 +254,4 @@ pub trait AsyncWriteBody<W> {
     async fn reset(self: Pin<&mut Self>) -> bool
     where
         W: 'async_trait;
-}
-
-#[async_trait]
-impl<W> AsyncWriteBody<W> for &[u8]
-where
-    W: AsyncWrite + Send,
-{
-    async fn write_body(self: Pin<&mut Self>, mut w: Pin<&mut W>) -> Result<(), Error> {
-        w.write_all(*self).await.map_err(Error::internal_safe)
-    }
-
-    async fn reset(self: Pin<&mut Self>) -> bool
-    where
-        W: 'async_trait,
-    {
-        true
-    }
 }

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -18,7 +18,10 @@ use conjure_error::Error;
 use http::{HeaderMap, Method};
 use serde::{Deserializer, Serialize};
 use std::error;
+use std::future::Future;
 use std::io::Write;
+use std::pin::Pin;
+use tokio_io::{AsyncWrite, AsyncWriteExt};
 
 use crate::{PathParams, QueryParams};
 
@@ -53,12 +56,51 @@ pub trait Client {
         U: VisitResponse<Self::BinaryBody>;
 }
 
+/// A trait implemented by async HTTP client implementations.
+pub trait AsyncClient {
+    /// The client's binary request body writer type.
+    type BinaryWriter;
+    /// The client's binary response body type.
+    type BinaryBody;
+
+    /// Makes an async HTTP request.
+    ///
+    /// The client is responsible for assembling the request URI. It is provided with the path template, unencoded path
+    /// parameters, unencoded query parameters, header parameters, and request body.
+    ///
+    /// A response must only be returned if it has a 2xx status code. The client is responsible for handling all other
+    /// status codes (for example, converting a 5xx response into a service error). The client is also responsible for
+    /// decoding the response body if necessary.
+    #[allow(clippy::too_many_arguments)]
+    fn request<'a, T, U>(
+        &'a self,
+        method: Method,
+        path: &'static str,
+        path_params: PathParams,
+        query_params: QueryParams,
+        headers: HeaderMap,
+        body: T,
+        response_visitor: U,
+    ) -> Pin<Box<dyn Future<Output = Result<U::Output, Error>> + Send + 'a>>
+    where
+        T: AsyncRequestBody<'a, Self::BinaryWriter> + Send + 'a,
+        U: VisitResponse<Self::BinaryBody> + Send + 'a;
+}
+
 /// A trait implemented by request bodies.
 pub trait RequestBody<'a, W> {
     /// Accepts a visitor, calling the correct method corresponding to this body type.
     fn accept<V>(self, visitor: V) -> V::Output
     where
         V: VisitRequestBody<'a, W>;
+}
+
+/// A trait implemented by async request bodies.
+pub trait AsyncRequestBody<'a, W> {
+    /// Accepts a visitor, calling the correct method corresponding to this body type.
+    fn accept<V>(self, visitor: V) -> V::Output
+    where
+        V: AsyncVisitRequestBody<'a, W>;
 }
 
 /// A visitor over request body formats.
@@ -78,6 +120,25 @@ pub trait VisitRequestBody<'a, W> {
     fn visit_binary<T>(self, body: T) -> Self::Output
     where
         T: WriteBody<W> + 'a;
+}
+
+/// A visitor over async request body formats.
+pub trait AsyncVisitRequestBody<'a, W> {
+    /// The output type returned by visit methods.
+    type Output;
+
+    /// Visits an empty body.
+    fn visit_empty(self) -> Self::Output;
+
+    /// Visits a serializable body.
+    fn visit_serializable<T>(self, body: T) -> Self::Output
+    where
+        T: Serialize + 'a;
+
+    /// Visits a streaming, binary body.
+    fn visit_binary<T>(self, body: T) -> Self::Output
+    where
+        T: AsyncWriteBody<W> + Sync + Send + 'a;
 }
 
 /// A visitor over HTTP responses.
@@ -146,5 +207,37 @@ where
 
     fn reset(&mut self) -> bool {
         true
+    }
+}
+
+/// A trait implemented by async streaming bodies.
+pub trait AsyncWriteBody<W> {
+    /// Writes the body out, in its entirety.
+    ///
+    /// Behavior is unspecified if this method is called twice without a successful call to `reset` in between.
+    fn write_body<'a>(
+        self: Pin<&'a mut Self>,
+        w: Pin<&'a mut W>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
+
+    /// Attempts to reset the body so that it can be written out again.
+    ///
+    /// Returns `true` if successful. Behavior is unspecified if this is not called after a call to `write_body`.
+    fn reset<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
+}
+
+impl<W> AsyncWriteBody<W> for &[u8]
+where
+    W: AsyncWrite + Send,
+{
+    fn write_body<'a>(
+        self: Pin<&'a mut Self>,
+        mut w: Pin<&'a mut W>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move { w.write_all(*self).await.map_err(Error::internal_safe) })
+    }
+
+    fn reset<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+        Box::pin(async { true })
     }
 }

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -14,6 +14,7 @@
 
 //! The Conjure HTTP client API.
 
+use crate::{PathParams, QueryParams};
 use async_trait::async_trait;
 use conjure_error::Error;
 use http::{HeaderMap, Method};
@@ -22,7 +23,6 @@ use std::error;
 use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
-use crate::{PathParams, QueryParams};
 
 /// A trait implemented by HTTP client implementations.
 pub trait Client {

--- a/conjure-http/src/private/mod.rs
+++ b/conjure-http/src/private/mod.rs
@@ -15,6 +15,8 @@
 pub use conjure_error::Error;
 pub use conjure_serde::json;
 pub use http;
+pub use std::future::Future;
+pub use std::pin::Pin;
 
 pub use crate::private::client::*;
 pub use crate::private::server::*;

--- a/conjure-http/src/query_params/mod.rs
+++ b/conjure-http/src/query_params/mod.rs
@@ -75,8 +75,8 @@ impl QueryParams {
 }
 
 impl<'a> IntoIterator for &'a QueryParams {
-    type IntoIter = Iter<'a>;
     type Item = (&'a str, &'a Values);
+    type IntoIter = Iter<'a>;
 
     #[inline]
     fn into_iter(self) -> Iter<'a> {
@@ -89,7 +89,8 @@ impl<'a> Index<&'a str> for QueryParams {
 
     #[inline]
     fn index(&self, key: &'a str) -> &Values {
-        self.0.get(key).unwrap_or_else(|| &*values::EMPTY)
+        static EMPTY: Values = Values::new();
+        self.0.get(key).unwrap_or_else(|| &EMPTY)
     }
 }
 

--- a/conjure-http/src/query_params/values.rs
+++ b/conjure-http/src/query_params/values.rs
@@ -14,14 +14,8 @@
 
 //! Query parameter values.
 
-use lazy_static::lazy_static;
 use std::ops::Index;
 use std::slice;
-
-// FIXME replace with const fn Values::new once Vec::new is const
-lazy_static! {
-    pub(crate) static ref EMPTY: Values = Values::new();
-}
 
 /// A data structure storing the values for a specific query parameter.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -29,8 +23,8 @@ pub struct Values(Vec<String>);
 
 impl Values {
     #[inline]
-    pub(crate) fn new() -> Values {
-        Values(vec![])
+    pub(crate) const fn new() -> Values {
+        Values(Vec::new())
     }
 
     #[inline]
@@ -79,8 +73,8 @@ impl Index<usize> for Values {
 }
 
 impl<'a> IntoIterator for &'a Values {
-    type IntoIter = Iter<'a>;
     type Item = &'a str;
+    type IntoIter = Iter<'a>;
 
     #[inline]
     fn into_iter(self) -> Iter<'a> {

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -21,9 +21,7 @@ use std::error;
 use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
-
 use crate::{PathParams, QueryParams};
-use tokio_io::{AsyncWrite, AsyncWriteExt};
 
 /// A trait implemented by synchronous endpoint handlers.
 pub trait Handler<T, B, R>
@@ -425,7 +423,7 @@ where
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore
 /// use async_trait::async_trait;
 /// use conjure_error::Error;
 /// use conjure_http::server::AsyncWriteBody;
@@ -448,14 +446,4 @@ where
 pub trait AsyncWriteBody<W> {
     /// Writes the body out, in its entirety.
     async fn write_body(self, w: Pin<&mut W>) -> Result<(), Error>;
-}
-
-#[async_trait]
-impl<W> AsyncWriteBody<W> for Vec<u8>
-where
-    W: AsyncWrite + Send,
-{
-    async fn write_body(self, mut w: Pin<&mut W>) -> Result<(), Error> {
-        w.write_all(&self).await.map_err(Error::internal_safe)
-    }
 }

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 //! The Conjure HTTP server API.
+use crate::{PathParams, QueryParams};
 use async_trait::async_trait;
 use conjure_error::{Error, InvalidArgument};
 use http::{HeaderMap, Method};
@@ -21,7 +22,6 @@ use std::error;
 use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
-use crate::{PathParams, QueryParams};
 
 /// A trait implemented by synchronous endpoint handlers.
 pub trait Handler<T, B, R>

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "0.4.6", path = "../conjure-codegen" }
+conjure-codegen = { version = "0.5.0", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -14,7 +14,7 @@ conjure-http = { path = "../conjure-http" }
 
 [dev-dependencies]
 async-trait = "0.1"
-futures-preview = "0.3.0-alpha.19"
+futures = "0.3.0"
 serde = "1.0"
 serde_json = "1.0"
 base64 = "0.10"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -13,6 +13,7 @@ conjure-error = { path = "../conjure-error" }
 conjure-http = { path = "../conjure-http" }
 
 [dev-dependencies]
+futures-preview = "0.3.0-alpha.19"
 serde = "1.0"
 serde_json = "1.0"
 base64 = "0.10"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -13,6 +13,7 @@ conjure-error = { path = "../conjure-error" }
 conjure-http = { path = "../conjure-http" }
 
 [dev-dependencies]
+async-trait = "0.1"
 futures-preview = "0.3.0-alpha.19"
 serde = "1.0"
 serde_json = "1.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "0.4.6"
+version = "0.5.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 
@@ -14,7 +14,7 @@ conjure-http = { path = "../conjure-http" }
 
 [dev-dependencies]
 async-trait = "0.1"
-futures = "0.3.0"
+futures = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 base64 = "0.10"

--- a/conjure-test/src/test/clients.rs
+++ b/conjure-test/src/test/clients.rs
@@ -339,14 +339,20 @@ fn optional_json_request() {
 fn streaming_request() {
     let client = TestClient::new(Method::POST, "/test/streamingRequest")
         .body(TestBody::Streaming(vec![0, 1, 2, 3]));
-    check!(client, client.streaming_request(StreamingBody(&[0, 1, 2, 3][..])));
+    check!(
+        client,
+        client.streaming_request(StreamingBody(&[0, 1, 2, 3][..]))
+    );
 }
 
 #[test]
 fn streaming_alias_request() {
     let client = TestClient::new(Method::POST, "/test/streamingAliasRequest")
         .body(TestBody::Streaming(vec![0, 1, 2, 3]));
-    check!(client, client.streaming_alias_request(StreamingBody(&[0, 1, 2, 3][..])));
+    check!(
+        client,
+        client.streaming_alias_request(StreamingBody(&[0, 1, 2, 3][..]))
+    );
 }
 
 #[test]

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -654,6 +654,33 @@
   } ],
   "services" : [ {
     "serviceName" : {
+      "name" : "TinyService",
+      "package" : "com.palantir.conjure"
+    },
+    "endpoints" : [ {
+      "endpointName" : "foo",
+      "httpMethod" : "POST",
+      "httpPath" : "/tiny/foo",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BINARY"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ]
+      } ],
+      "returns" : {
+        "type" : "primitive",
+        "primitive" : "BINARY"
+      },
+      "markers" : [ ]
+    } ]
+  }, {
+    "serviceName" : {
       "name" : "TestService",
       "package" : "com.palantir.conjure"
     },

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -99,6 +99,17 @@ types:
           unsafeFoo: boolean
 
 services:
+  TinyService:
+    name: Tiny Service
+    package: com.palantir.conjure
+    base-path: /tiny
+    endpoints:
+      foo:
+        http: POST /foo
+        args:
+          body: binary
+        returns: binary
+
   TestService:
     name: Test Service
     package: com.palantir.conjure

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -5,6 +5,6 @@ authors = []
 edition = "2018"
 
 [dependencies]
-conjure-object = "0.4.6"
-conjure-error = "0.4.6"
-conjure-http = "0.4.6"
+conjure-object = "0.5.0"
+conjure-error = "0.5.0"
+conjure-http = "0.5.0"

--- a/example-api/src/another/mod.rs
+++ b/example-api/src/another/mod.rs
@@ -2,7 +2,7 @@
 pub use self::different_package::DifferentPackage;
 #[doc(inline)]
 pub use self::test_service::{
-    TestService, TestServiceAsyncClient, TestServiceClient, TestServiceResource,
+    AsyncTestService, TestService, TestServiceAsyncClient, TestServiceClient, TestServiceResource,
 };
 pub mod different_package;
 pub mod test_service;

--- a/example-api/src/another/mod.rs
+++ b/example-api/src/another/mod.rs
@@ -1,6 +1,8 @@
 #[doc(inline)]
 pub use self::different_package::DifferentPackage;
 #[doc(inline)]
-pub use self::test_service::{TestService, TestServiceClient, TestServiceResource};
+pub use self::test_service::{
+    TestService, TestServiceAsyncClient, TestServiceClient, TestServiceResource,
+};
 pub mod different_package;
 pub mod test_service;

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -1052,7 +1052,7 @@ where
         )
     }
 }
-use conjure_http::server::Response as _;
+use conjure_http::server::{AsyncResponse as _, Response as _};
 #[doc = "A Markdown description of the service."]
 pub trait TestService<I, O> {
     #[doc = "The body type returned by the `get_raw_data` method."]
@@ -1176,6 +1176,354 @@ pub trait TestService<I, O> {
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error>;
 }
+#[doc = "A Markdown description of the service."]
+pub trait AsyncTestService<I, O> {
+    #[doc = "The body type returned by the `get_raw_data` method."]
+    type GetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
+    #[doc = "The body type returned by the `get_aliased_raw_data` method."]
+    type GetAliasedRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
+    #[doc = "The body type returned by the `maybe_get_raw_data` method."]
+    type MaybeGetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
+    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    fn get_file_systems<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        std::collections::BTreeMap<
+                            String,
+                            super::super::product::datasets::BackingFileSystem,
+                        >,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn create_dataset<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        request: super::super::product::CreateDatasetRequest,
+        test_header_arg: String,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        super::super::product::datasets::Dataset,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_dataset<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        Option<super::super::product::datasets::Dataset>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Self::GetRawDataBody, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_aliased_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn maybe_get_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        Option<Self::MaybeGetRawDataBody>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_aliased_string<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        super::super::product::AliasedString,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn upload_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        input: I,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn upload_aliased_raw_data<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        input: I,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn get_branches<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        std::collections::BTreeSet<String>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    #[doc = "Gets all branches of this dataset."]
+    fn get_branches_deprecated<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<
+                        std::collections::BTreeSet<String>,
+                        conjure_http::private::Error,
+                    >,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn resolve_branch<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+        branch: String,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Option<String>, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_param<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        dataset_rid: conjure_object::ResourceIdentifier,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Option<String>, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_query_params<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        query: String,
+        something: conjure_object::ResourceIdentifier,
+        optional_middle: Option<conjure_object::ResourceIdentifier>,
+        implicit: conjure_object::ResourceIdentifier,
+        set_end: std::collections::BTreeSet<String>,
+        optional_end: Option<conjure_object::ResourceIdentifier>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<i32, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_no_response_query_params<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        query: String,
+        something: conjure_object::ResourceIdentifier,
+        optional_middle: Option<conjure_object::ResourceIdentifier>,
+        implicit: conjure_object::ResourceIdentifier,
+        set_end: std::collections::BTreeSet<String>,
+        optional_end: Option<conjure_object::ResourceIdentifier>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_boolean<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<bool, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_double<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<f64, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_integer<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<i32, conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_post_optional<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        maybe_string: Option<String>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<Option<String>, conjure_http::private::Error>,
+                >
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+    fn test_optional_integer_and_double<'life0, 'async_trait>(
+        &'life0 self,
+        auth_: conjure_object::BearerToken,
+        maybe_integer: Option<i32>,
+        maybe_double: Option<f64>,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<Output = Result<(), conjure_http::private::Error>>
+                + 'async_trait
+                + Send,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'life0;
+}
 pub struct TestServiceResource<T>(T);
 impl<T> TestServiceResource<T> {
     #[doc = r" Creates a new resource."]
@@ -1183,266 +1531,326 @@ impl<T> TestServiceResource<T> {
         TestServiceResource(handler)
     }
 }
-impl<T> TestServiceResource<T> {
-    fn get_file_systems<B, R>(
+struct GetFileSystemsHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetFileSystemsHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_file_systems(auth_)?;
+        let response = service_.0.get_file_systems(auth_)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn create_dataset<B, R>(
+}
+struct CreateDatasetHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for CreateDatasetHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let test_header_arg =
             conjure_http::private::parse_required_header(headers_, "testHeaderArg", "Test-Header")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let request = body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
-        let response = (self.0).create_dataset(auth_, request, test_header_arg)?;
+        let response = service_.0.create_dataset(auth_, request, test_header_arg)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn get_dataset<B, R>(
+}
+struct GetDatasetHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetDatasetHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_dataset(auth_, dataset_rid)?;
+        let response = service_.0.get_dataset(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn get_raw_data<B, R>(
+}
+struct GetRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_raw_data(auth_, dataset_rid)?;
+        let response = service_.0.get_raw_data(auth_, dataset_rid)?;
         conjure_http::private::BinaryResponse(response).accept(response_visitor_)
     }
-    fn get_aliased_raw_data<B, R>(
+}
+struct GetAliasedRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for GetAliasedRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_aliased_raw_data(auth_, dataset_rid)?;
+        let response = service_.0.get_aliased_raw_data(auth_, dataset_rid)?;
         conjure_http::private::BinaryResponse(response).accept(response_visitor_)
     }
-    fn maybe_get_raw_data<B, R>(
+}
+struct MaybeGetRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for MaybeGetRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).maybe_get_raw_data(auth_, dataset_rid)?;
+        let response = service_.0.maybe_get_raw_data(auth_, dataset_rid)?;
         conjure_http::private::OptionalBinaryResponse(response).accept(response_visitor_)
     }
-    fn get_aliased_string<B, R>(
+}
+struct GetAliasedStringHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for GetAliasedStringHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_aliased_string(auth_, dataset_rid)?;
+        let response = service_.0.get_aliased_string(auth_, dataset_rid)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn upload_raw_data<B, R>(
+}
+struct UploadRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for UploadRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
-        (self.0).upload_raw_data(auth_, input)?;
+        service_.0.upload_raw_data(auth_, input)?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
-    fn upload_aliased_raw_data<B, R>(
+}
+struct UploadAliasedRawDataHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for UploadAliasedRawDataHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
-        (self.0).upload_aliased_raw_data(auth_, input)?;
+        service_.0.upload_aliased_raw_data(auth_, input)?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
-    fn get_branches<B, R>(
+}
+struct GetBranchesHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for GetBranchesHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_branches(auth_, dataset_rid)?;
+        let response = service_.0.get_branches(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn get_branches_deprecated<B, R>(
+}
+struct GetBranchesDeprecatedHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for GetBranchesDeprecatedHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).get_branches_deprecated(auth_, dataset_rid)?;
+        let response = service_.0.get_branches_deprecated(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn resolve_branch<B, R>(
+}
+struct ResolveBranchHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for ResolveBranchHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let branch = conjure_http::private::parse_path_param(path_params_, "branch")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).resolve_branch(auth_, dataset_rid, branch)?;
+        let response = service_.0.resolve_branch(auth_, dataset_rid, branch)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn test_param<B, R>(
+}
+struct TestParamHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestParamHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         path_params_: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_param(auth_, dataset_rid)?;
+        let response = service_.0.test_param(auth_, dataset_rid)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn test_query_params<B, R>(
+}
+struct TestQueryParamsHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestQueryParamsHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         query_params_: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let something =
             conjure_http::private::parse_query_param(query_params_, "something", "different")?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
@@ -1470,7 +1878,7 @@ impl<T> TestServiceResource<T> {
         )?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let query = body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
-        let response = (self.0).test_query_params(
+        let response = service_.0.test_query_params(
             auth_,
             query,
             something,
@@ -1481,19 +1889,24 @@ impl<T> TestServiceResource<T> {
         )?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_no_response_query_params<B, R>(
+}
+struct TestNoResponseQueryParamsHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestNoResponseQueryParamsHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         query_params_: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let something =
             conjure_http::private::parse_query_param(query_params_, "something", "different")?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
@@ -1521,7 +1934,7 @@ impl<T> TestServiceResource<T> {
         )?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let query = body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
-        (self.0).test_no_response_query_params(
+        service_.0.test_no_response_query_params(
             auth_,
             query,
             something,
@@ -1532,92 +1945,114 @@ impl<T> TestServiceResource<T> {
         )?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
-    fn test_boolean<B, R>(
+}
+struct TestBooleanHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestBooleanHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_boolean(auth_)?;
+        let response = service_.0.test_boolean(auth_)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_double<B, R>(
+}
+struct TestDoubleHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestDoubleHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_double(auth_)?;
+        let response = service_.0.test_double(auth_)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_integer<B, R>(
+}
+struct TestIntegerHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R> for TestIntegerHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        let response = (self.0).test_integer(auth_)?;
+        let response = service_.0.test_integer(auth_)?;
         conjure_http::private::SerializableResponse(response).accept(response_visitor_)
     }
-    fn test_post_optional<B, R>(
+}
+struct TestPostOptionalHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestPostOptionalHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         _: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         let maybe_string =
             body_.accept(conjure_http::private::DefaultSerializableRequestBodyVisitor::new())?;
-        let response = (self.0).test_post_optional(auth_, maybe_string)?;
+        let response = service_.0.test_post_optional(auth_, maybe_string)?;
         conjure_http::private::DefaultSerializableResponse(response).accept(response_visitor_)
     }
-    fn test_optional_integer_and_double<B, R>(
+}
+struct TestOptionalIntegerAndDoubleHandler_;
+impl<T, B, R> conjure_http::server::Handler<TestServiceResource<T>, B, R>
+    for TestOptionalIntegerAndDoubleHandler_
+where
+    T: TestService<B::BinaryBody, R::BinaryWriter>,
+    B: conjure_http::server::RequestBody,
+    R: conjure_http::server::VisitResponse,
+{
+    fn handle(
         &self,
+        service_: &TestServiceResource<T>,
         _: &conjure_http::PathParams,
         query_params_: &conjure_http::QueryParams,
         headers_: &conjure_http::private::http::HeaderMap,
         body_: B,
         response_visitor_: R,
-    ) -> Result<R::Output, conjure_http::private::Error>
-    where
-        T: TestService<B::BinaryBody, R::BinaryWriter>,
-        B: conjure_http::server::RequestBody,
-        R: conjure_http::server::VisitResponse,
-    {
+    ) -> Result<R::Output, conjure_http::private::Error> {
         let mut maybe_integer: Option<i32> = Default::default();
         conjure_http::private::parse_optional_query_param(
             query_params_,
@@ -1634,7 +2069,9 @@ impl<T> TestServiceResource<T> {
         )?;
         let auth_ = conjure_http::private::parse_header_auth(headers_)?;
         body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
-        (self.0).test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
+        service_
+            .0
+            .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
         conjure_http::private::EmptyResponse.accept(response_visitor_)
     }
 }
@@ -1649,328 +2086,1669 @@ where
         R: conjure_http::server::VisitResponse<BinaryWriter = O>,
     {
         vec![
-            conjure_http::server::Endpoint::new(
-                "getFileSystems",
-                conjure_http::private::http::Method::GET,
-                "/catalog/fileSystems",
-                TestServiceResource::get_file_systems,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "createDataset",
-                conjure_http::private::http::Method::POST,
-                "/catalog/datasets",
-                TestServiceResource::create_dataset,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "testHeaderArg",
-                            conjure_http::server::ParameterType::Header(
-                                conjure_http::server::HeaderParameter::new("Test-Header"),
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getFileSystems",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/fileSystems",
+                    &[],
+                    false,
+                ),
+                handler: &GetFileSystemsHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "createDataset",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "testHeaderArg",
+                                conjure_http::server::ParameterType::Header(
+                                    conjure_http::server::HeaderParameter::new("Test-Header"),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &CreateDatasetHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getDataset",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetDatasetHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "maybeGetRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &MaybeGetRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedString",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedStringHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw",
+                    &[],
+                    false,
+                ),
+                handler: &UploadRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadAliasedRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw-aliased",
+                    &[],
+                    false,
+                ),
+                handler: &UploadAliasedRawDataHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranches",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetBranchesHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranchesDeprecated",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    true,
+                ),
+                handler: &GetBranchesDeprecatedHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "resolveBranch",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getDataset",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}",
-                TestServiceResource::get_dataset,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "branch",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getRawData",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/raw",
-                TestServiceResource::get_raw_data,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &ResolveBranchHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testParam",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/testParam",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestParamHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getAliasedRawData",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/raw-aliased",
-                TestServiceResource::get_aliased_raw_data,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "maybeGetRawData",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/raw-maybe",
-                TestServiceResource::maybe_get_raw_data,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getAliasedString",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/string-aliased",
-                TestServiceResource::get_aliased_string,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "uploadRawData",
-                conjure_http::private::http::Method::POST,
-                "/catalog/datasets/upload-raw",
-                TestServiceResource::upload_raw_data,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "uploadAliasedRawData",
-                conjure_http::private::http::Method::POST,
-                "/catalog/datasets/upload-raw-aliased",
-                TestServiceResource::upload_aliased_raw_data,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "getBranches",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branches",
-                TestServiceResource::get_branches,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "getBranchesDeprecated",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branchesDeprecated",
-                TestServiceResource::get_branches_deprecated,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestQueryParamsHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testNoResponseQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-no-response-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            )
-            .with_deprecated(true),
-            conjure_http::server::Endpoint::new(
-                "resolveBranch",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
-                TestServiceResource::resolve_branch,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "branch",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testParam",
-                conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/testParam",
-                TestServiceResource::test_param,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] =
-                        &[conjure_http::server::Parameter::new(
-                            "datasetRid",
-                            conjure_http::server::ParameterType::Path(
-                                conjure_http::server::PathParameter::new(),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
                             ),
-                        )];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testQueryParams",
-                conjure_http::private::http::Method::POST,
-                "/catalog/test-query-params",
-                TestServiceResource::test_query_params,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "something",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("different"),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalMiddle",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalMiddle"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestNoResponseQueryParamsHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testBoolean",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/boolean",
+                    &[],
+                    false,
+                ),
+                handler: &TestBooleanHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/double",
+                    &[],
+                    false,
+                ),
+                handler: &TestDoubleHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testInteger",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/integer",
+                    &[],
+                    false,
+                ),
+                handler: &TestIntegerHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testPostOptional",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/optional",
+                    &[],
+                    false,
+                ),
+                handler: &TestPostOptionalHandler_,
+            },
+            conjure_http::server::Endpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testOptionalIntegerAndDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/optional-integer-double",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "maybeInteger",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeInteger"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "implicit",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("implicit"),
+                            conjure_http::server::Parameter::new(
+                                "maybeDouble",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeDouble"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "setEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("setEnd"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestOptionalIntegerAndDoubleHandler_,
+            },
+        ]
+    }
+}
+struct GetFileSystemsHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetFileSystemsHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_file_systems(auth_).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct CreateDatasetHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for CreateDatasetHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let test_header_arg = conjure_http::private::parse_required_header(
+                headers_,
+                "testHeaderArg",
+                "Test-Header",
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let request =
+                body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
+            let response = service_
+                .0
+                .create_dataset(auth_, request, test_header_arg)
+                .await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct GetDatasetHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetDatasetHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_dataset(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct GetRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_raw_data(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncBinaryResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct GetAliasedRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetAliasedRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_aliased_raw_data(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncBinaryResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct MaybeGetRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for MaybeGetRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.maybe_get_raw_data(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncOptionalBinaryResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct GetAliasedStringHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetAliasedStringHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_aliased_string(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct UploadRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for UploadRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
+            service_.0.upload_raw_data(auth_, input).await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+struct UploadAliasedRawDataHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for UploadAliasedRawDataHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let input = body_.accept(conjure_http::private::BinaryRequestBodyVisitor)?;
+            service_.0.upload_aliased_raw_data(auth_, input).await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+struct GetBranchesHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetBranchesHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.get_branches(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct GetBranchesDeprecatedHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for GetBranchesDeprecatedHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_
+                .0
+                .get_branches_deprecated(auth_, dataset_rid)
+                .await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct ResolveBranchHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for ResolveBranchHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let branch = conjure_http::private::parse_path_param(path_params_, "branch")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_
+                .0
+                .resolve_branch(auth_, dataset_rid, branch)
+                .await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct TestParamHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestParamHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        path_params_: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let dataset_rid = conjure_http::private::parse_path_param(path_params_, "datasetRid")?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_param(auth_, dataset_rid).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct TestQueryParamsHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestQueryParamsHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        query_params_: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let something =
+                conjure_http::private::parse_query_param(query_params_, "something", "different")?;
+            let mut optional_middle: Option<conjure_object::ResourceIdentifier> =
+                Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalMiddle",
+                "optionalMiddle",
+                &mut optional_middle,
+            )?;
+            let implicit =
+                conjure_http::private::parse_query_param(query_params_, "implicit", "implicit")?;
+            let mut set_end: std::collections::BTreeSet<String> = Default::default();
+            conjure_http::private::parse_set_query_param(
+                query_params_,
+                "setEnd",
+                "setEnd",
+                &mut set_end,
+            )?;
+            let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalEnd",
+                "optionalEnd",
+                &mut optional_end,
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let query =
+                body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
+            let response = service_
+                .0
+                .test_query_params(
+                    auth_,
+                    query,
+                    something,
+                    optional_middle,
+                    implicit,
+                    set_end,
+                    optional_end,
+                )
+                .await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestNoResponseQueryParamsHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestNoResponseQueryParamsHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        query_params_: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let something =
+                conjure_http::private::parse_query_param(query_params_, "something", "different")?;
+            let mut optional_middle: Option<conjure_object::ResourceIdentifier> =
+                Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalMiddle",
+                "optionalMiddle",
+                &mut optional_middle,
+            )?;
+            let implicit =
+                conjure_http::private::parse_query_param(query_params_, "implicit", "implicit")?;
+            let mut set_end: std::collections::BTreeSet<String> = Default::default();
+            conjure_http::private::parse_set_query_param(
+                query_params_,
+                "setEnd",
+                "setEnd",
+                &mut set_end,
+            )?;
+            let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "optionalEnd",
+                "optionalEnd",
+                &mut optional_end,
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let query =
+                body_.accept(conjure_http::private::SerializableRequestBodyVisitor::new())?;
+            service_
+                .0
+                .test_no_response_query_params(
+                    auth_,
+                    query,
+                    something,
+                    optional_middle,
+                    implicit,
+                    set_end,
+                    optional_end,
+                )
+                .await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+struct TestBooleanHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestBooleanHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_boolean(auth_).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestDoubleHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestDoubleHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_double(auth_).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestIntegerHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestIntegerHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            let response = service_.0.test_integer(auth_).await?;
+            conjure_http::private::AsyncSerializableResponse(response).accept(response_visitor_)
+        })
+    }
+}
+struct TestPostOptionalHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestPostOptionalHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        _: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            let maybe_string = body_
+                .accept(conjure_http::private::DefaultSerializableRequestBodyVisitor::new())?;
+            let response = service_.0.test_post_optional(auth_, maybe_string).await?;
+            conjure_http::private::AsyncDefaultSerializableResponse(response)
+                .accept(response_visitor_)
+        })
+    }
+}
+struct TestOptionalIntegerAndDoubleHandlerAsync_;
+impl<T, B, R> conjure_http::server::AsyncHandler<TestServiceResource<T>, B, R>
+    for TestOptionalIntegerAndDoubleHandlerAsync_
+where
+    T: AsyncTestService<B::BinaryBody, R::BinaryWriter> + Sync + Send,
+    B: conjure_http::server::RequestBody + Send,
+    B::BinaryBody: Send,
+    R: conjure_http::server::AsyncVisitResponse + Send,
+{
+    fn handle<'a>(
+        &self,
+        service_: &'a TestServiceResource<T>,
+        _: &'a conjure_http::PathParams,
+        query_params_: &'a conjure_http::QueryParams,
+        headers_: &'a conjure_http::private::http::HeaderMap,
+        body_: B,
+        response_visitor_: R,
+    ) -> conjure_http::private::Pin<
+        Box<
+            dyn conjure_http::private::Future<
+                    Output = Result<R::Output, conjure_http::private::Error>,
+                > + Send
+                + 'a,
+        >,
+    >
+    where
+        T: 'a,
+        B: 'a,
+        R: 'a,
+    {
+        Box::pin(async move {
+            let mut maybe_integer: Option<i32> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "maybeInteger",
+                "maybeInteger",
+                &mut maybe_integer,
+            )?;
+            let mut maybe_double: Option<f64> = Default::default();
+            conjure_http::private::parse_optional_query_param(
+                query_params_,
+                "maybeDouble",
+                "maybeDouble",
+                &mut maybe_double,
+            )?;
+            let auth_ = conjure_http::private::parse_header_auth(headers_)?;
+            body_.accept(conjure_http::private::EmptyRequestBodyVisitor)?;
+            service_
+                .0
+                .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)
+                .await?;
+            conjure_http::private::AsyncEmptyResponse.accept(response_visitor_)
+        })
+    }
+}
+impl<T, I, O> conjure_http::server::AsyncResource<I, O> for TestServiceResource<T>
+where
+    T: AsyncTestService<I, O> + Sync + Send,
+    I: Send,
+{
+    const NAME: &'static str = "TestService";
+    fn endpoints<B, R>() -> Vec<conjure_http::server::AsyncEndpoint<Self, B, R>>
+    where
+        B: conjure_http::server::RequestBody<BinaryBody = I> + Send,
+        R: conjure_http::server::AsyncVisitResponse<BinaryWriter = O> + Send,
+    {
+        vec![
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getFileSystems",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/fileSystems",
+                    &[],
+                    false,
+                ),
+                handler: &GetFileSystemsHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "createDataset",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "testHeaderArg",
+                                conjure_http::server::ParameterType::Header(
+                                    conjure_http::server::HeaderParameter::new("Test-Header"),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &CreateDatasetHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getDataset",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetDatasetHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "maybeGetRawData",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &MaybeGetRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getAliasedString",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetAliasedStringHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw",
+                    &[],
+                    false,
+                ),
+                handler: &UploadRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "uploadAliasedRawData",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/datasets/upload-raw-aliased",
+                    &[],
+                    false,
+                ),
+                handler: &UploadAliasedRawDataHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranches",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &GetBranchesHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "getBranchesDeprecated",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    true,
+                ),
+                handler: &GetBranchesDeprecatedHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "resolveBranch",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalEnd"),
+                            conjure_http::server::Parameter::new(
+                                "branch",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testNoResponseQueryParams",
-                conjure_http::private::http::Method::POST,
-                "/catalog/test-no-response-query-params",
-                TestServiceResource::test_no_response_query_params,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "something",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("different"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &ResolveBranchHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testParam",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/datasets/{datasetRid}/testParam",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] =
+                            &[conjure_http::server::Parameter::new(
+                                "datasetRid",
+                                conjure_http::server::ParameterType::Path(
+                                    conjure_http::server::PathParameter::new(),
+                                ),
+                            )];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestParamHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalMiddle",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalMiddle"),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "implicit",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("implicit"),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "setEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("setEnd"),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "optionalEnd",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("optionalEnd"),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
-            conjure_http::server::Endpoint::new(
-                "testBoolean",
-                conjure_http::private::http::Method::GET,
-                "/catalog/boolean",
-                TestServiceResource::test_boolean,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testDouble",
-                conjure_http::private::http::Method::GET,
-                "/catalog/double",
-                TestServiceResource::test_double,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testInteger",
-                conjure_http::private::http::Method::GET,
-                "/catalog/integer",
-                TestServiceResource::test_integer,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testPostOptional",
-                conjure_http::private::http::Method::POST,
-                "/catalog/optional",
-                TestServiceResource::test_post_optional,
-                &[],
-            ),
-            conjure_http::server::Endpoint::new(
-                "testOptionalIntegerAndDouble",
-                conjure_http::private::http::Method::GET,
-                "/catalog/optional-integer-double",
-                TestServiceResource::test_optional_integer_and_double,
-                {
-                    const PARAMS: &[conjure_http::server::Parameter] = &[
-                        conjure_http::server::Parameter::new(
-                            "maybeInteger",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("maybeInteger"),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestQueryParamsHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testNoResponseQueryParams",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/test-no-response-query-params",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "something",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("different"),
+                                ),
                             ),
-                        ),
-                        conjure_http::server::Parameter::new(
-                            "maybeDouble",
-                            conjure_http::server::ParameterType::Query(
-                                conjure_http::server::QueryParameter::new("maybeDouble"),
+                            conjure_http::server::Parameter::new(
+                                "optionalMiddle",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalMiddle"),
+                                ),
                             ),
-                        ),
-                    ];
-                    PARAMS
-                },
-            ),
+                            conjure_http::server::Parameter::new(
+                                "implicit",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("implicit"),
+                                ),
+                            ),
+                            conjure_http::server::Parameter::new(
+                                "setEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("setEnd"),
+                                ),
+                            ),
+                            conjure_http::server::Parameter::new(
+                                "optionalEnd",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("optionalEnd"),
+                                ),
+                            ),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestNoResponseQueryParamsHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testBoolean",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/boolean",
+                    &[],
+                    false,
+                ),
+                handler: &TestBooleanHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/double",
+                    &[],
+                    false,
+                ),
+                handler: &TestDoubleHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testInteger",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/integer",
+                    &[],
+                    false,
+                ),
+                handler: &TestIntegerHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testPostOptional",
+                    conjure_http::private::http::Method::POST,
+                    "/catalog/optional",
+                    &[],
+                    false,
+                ),
+                handler: &TestPostOptionalHandlerAsync_,
+            },
+            conjure_http::server::AsyncEndpoint {
+                metadata: conjure_http::server::Metadata::new(
+                    "testOptionalIntegerAndDouble",
+                    conjure_http::private::http::Method::GET,
+                    "/catalog/optional-integer-double",
+                    {
+                        const PARAMS: &[conjure_http::server::Parameter] = &[
+                            conjure_http::server::Parameter::new(
+                                "maybeInteger",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeInteger"),
+                                ),
+                            ),
+                            conjure_http::server::Parameter::new(
+                                "maybeDouble",
+                                conjure_http::server::ParameterType::Query(
+                                    conjure_http::server::QueryParameter::new("maybeDouble"),
+                                ),
+                            ),
+                        ];
+                        PARAMS
+                    },
+                    false,
+                ),
+                handler: &TestOptionalIntegerAndDoubleHandlerAsync_,
+            },
         ]
     }
 }

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -1,5 +1,552 @@
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
+pub struct TestServiceAsyncClient<T>(T);
+impl<T> TestServiceAsyncClient<T>
+where
+    T: conjure_http::client::AsyncClient,
+{
+    #[doc = r" Creates a new client."]
+    #[inline]
+    pub fn new(client: T) -> TestServiceAsyncClient<T> {
+        TestServiceAsyncClient(client)
+    }
+    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    pub async fn get_file_systems(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<
+        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
+        conjure_http::private::Error,
+    > {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/fileSystems",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn create_dataset(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        request: &super::super::product::CreateDatasetRequest,
+        test_header_arg: &str,
+    ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        conjure_http::private::encode_header(
+            &mut headers_,
+            "testHeaderArg",
+            "test-header",
+            test_header_arg,
+        )?;
+        let body_ = conjure_http::private::SerializableRequestBody(request);
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/datasets",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_dataset(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
+    {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<T::BinaryBody, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::BinaryResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/raw",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_aliased_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<T::BinaryBody, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::BinaryResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/raw-aliased",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn maybe_get_raw_data(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<T::BinaryBody>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::OptionalBinaryResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/raw-maybe",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_aliased_string(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<super::super::product::AliasedString, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/string-aliased",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn upload_raw_data<U>(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        input: U,
+    ) -> Result<(), conjure_http::private::Error>
+    where
+        U: conjure_http::client::AsyncWriteBody<T::BinaryWriter> + Sync + Send,
+    {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::BinaryRequestBody(input);
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/datasets/upload-raw",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn upload_aliased_raw_data<U>(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        input: U,
+    ) -> Result<(), conjure_http::private::Error>
+    where
+        U: conjure_http::client::AsyncWriteBody<T::BinaryWriter> + Sync + Send,
+    {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::BinaryRequestBody(input);
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/datasets/upload-raw-aliased",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn get_branches(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/branches",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    #[doc = "Gets all branches of this dataset."]
+    #[deprecated(note = "use getBranches instead")]
+    pub async fn get_branches_deprecated(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn resolve_branch(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+        branch: &str,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        conjure_http::private::encode_path_param(&mut path_params_, "branch", branch);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_param(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        dataset_rid: &conjure_object::ResourceIdentifier,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let mut path_params_ = conjure_http::PathParams::new();
+        conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/datasets/{datasetRid}/testParam",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_query_params(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        query: &str,
+        something: &conjure_object::ResourceIdentifier,
+        optional_middle: Option<&conjure_object::ResourceIdentifier>,
+        implicit: &conjure_object::ResourceIdentifier,
+        set_end: &std::collections::BTreeSet<String>,
+        optional_end: Option<&conjure_object::ResourceIdentifier>,
+    ) -> Result<i32, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        conjure_http::private::encode_query_param(&mut query_params_, "different", something);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalMiddle",
+            &optional_middle,
+        );
+        conjure_http::private::encode_query_param(&mut query_params_, "implicit", implicit);
+        conjure_http::private::encode_set_query_param(&mut query_params_, "setEnd", &set_end);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalEnd",
+            &optional_end,
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::SerializableRequestBody(query);
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/test-query-params",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_no_response_query_params(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        query: &str,
+        something: &conjure_object::ResourceIdentifier,
+        optional_middle: Option<&conjure_object::ResourceIdentifier>,
+        implicit: &conjure_object::ResourceIdentifier,
+        set_end: &std::collections::BTreeSet<String>,
+        optional_end: Option<&conjure_object::ResourceIdentifier>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        conjure_http::private::encode_query_param(&mut query_params_, "different", something);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalMiddle",
+            &optional_middle,
+        );
+        conjure_http::private::encode_query_param(&mut query_params_, "implicit", implicit);
+        conjure_http::private::encode_set_query_param(&mut query_params_, "setEnd", &set_end);
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "optionalEnd",
+            &optional_end,
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::SerializableRequestBody(query);
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/test-no-response-query-params",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_boolean(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<bool, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/boolean",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_double(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<f64, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/double",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_integer(
+        &self,
+        auth_: &conjure_object::BearerToken,
+    ) -> Result<i32, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::SerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/integer",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_post_optional(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        maybe_string: Option<&str>,
+    ) -> Result<Option<String>, conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let query_params_ = conjure_http::QueryParams::new();
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::SerializableRequestBody(maybe_string);
+        let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
+        self.0
+            .request(
+                conjure_http::private::http::Method::POST,
+                "/catalog/optional",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+    pub async fn test_optional_integer_and_double(
+        &self,
+        auth_: &conjure_object::BearerToken,
+        maybe_integer: Option<i32>,
+        maybe_double: Option<f64>,
+    ) -> Result<(), conjure_http::private::Error> {
+        let path_params_ = conjure_http::PathParams::new();
+        let mut query_params_ = conjure_http::QueryParams::new();
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "maybeInteger",
+            &maybe_integer,
+        );
+        conjure_http::private::encode_optional_query_param(
+            &mut query_params_,
+            "maybeDouble",
+            &maybe_double,
+        );
+        let mut headers_ = conjure_http::private::http::HeaderMap::new();
+        conjure_http::private::encode_header_auth(&mut headers_, auth_);
+        let body_ = conjure_http::private::EmptyRequestBody;
+        let response_visitor_ = conjure_http::private::EmptyResponseVisitor;
+        self.0
+            .request(
+                conjure_http::private::http::Method::GET,
+                "/catalog/optional-integer-double",
+                path_params_,
+                query_params_,
+                headers_,
+                body_,
+                response_visitor_,
+            )
+            .await
+    }
+}
+#[doc = "A Markdown description of the service."]
+#[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
 impl<T> TestServiceClient<T>
 where


### PR DESCRIPTION
Thanks to async/await the implementation and API of async clients is
pretty close to the API of the sync clients! This means that almost all
of the codegen is shared, with a flag passed around to make the few
changes we need here and there.