### PR TITLE
Don't fail on IR field additions

### DIFF
--- a/changelog/@unreleased/pr-98.v2.yml
+++ b/changelog/@unreleased/pr-98.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`conjure-codegen` no longer fails to deserialize IR files with unknown
+    fields.'
+  links:
+  - https://github.com/palantir/conjure-rust/pull/98

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -427,7 +427,7 @@ impl Config {
         let ir = fs::read_to_string(ir_file)
             .with_context(|_| format!("error reading file {}", ir_file.display()))?;
 
-        let defs = conjure_serde::json::server_from_str(&ir)
+        let defs = conjure_serde::json::client_from_str(&ir)
             .with_context(|_| format!("error parsing Conjure IR file {}", ir_file.display()))?;
 
         Ok(defs)


### PR DESCRIPTION
cc palantir/conjure#494

## Before this PR
We used `server_from_str` when deserializing IR files, which fails on unknown fields.

## After this PR
==COMMIT_MSG==
`conjure-codegen` no longer fails to deserialize IR files with unknown fields.
==COMMIT_MSG==

