### PR TITLE
Clients now allow void methods to return JSON

### DIFF
--- a/changelog/@unreleased/pr-101.v2.yml
+++ b/changelog/@unreleased/pr-101.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: Clients now allow a server to return JSON to from an endpoint expected
+  description: Clients now allow a server to return JSON from an endpoint expected
     to return nothing.
   links:
   - https://github.com/palantir/conjure-rust/pull/101

--- a/changelog/@unreleased/pr-101.v2.yml
+++ b/changelog/@unreleased/pr-101.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Clients now allow a server to return JSON to from an endpoint expected
+    to return nothing.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/101

--- a/conjure-test/src/test/clients.rs
+++ b/conjure-test/src/test/clients.rs
@@ -318,6 +318,13 @@ fn empty_request() {
 }
 
 #[test]
+fn unexpected_json_response() {
+    let client = TestClient::new(Method::POST, "/test/emptyRequest")
+        .response(TestBody::Json(r#""hello world""#.to_string()));
+    check!(client, client.empty_request());
+}
+
+#[test]
 fn json_request() {
     let client = TestClient::new(Method::POST, "/test/jsonRequest")
         .body(TestBody::Json(r#""hello world""#.to_string()));


### PR DESCRIPTION
## Before this PR
Clients would previously treat an unexpected JSON response from an endpoint expected to return nothing as an error.

## After this PR
==COMMIT_MSG==
Clients now allow a server to return JSON to from an endpoint expected to return nothing.
==COMMIT_MSG==
