### PR TITLE
Fix getter of optional<binary> fields

### DIFF
--- a/changelog/@unreleased/pr-104.v2.yml
+++ b/changelog/@unreleased/pr-104.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed type generation for `optional<binary>` fields.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/104

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 
-conjure-object = { version = "0.7.0", path = "../conjure-object" }
-conjure-serde = { version = "0.7.0", path = "../conjure-serde" }
-conjure-error = { version = "0.7.0", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.7.0", optional = true, path = "../conjure-http" }
+conjure-object = { version = "0.7.1", path = "../conjure-object" }
+conjure-serde = { version = "0.7.1", path = "../conjure-serde" }
+conjure-error = { version = "0.7.1", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.7.1", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -378,7 +378,8 @@ impl Context {
     pub fn borrow_rust_type(&self, value: TokenStream, def: &Type) -> TokenStream {
         match def {
             Type::Primitive(def) => match *def {
-                PrimitiveType::String | PrimitiveType::Binary => quote!(&*#value),
+                PrimitiveType::String => quote!(&*#value),
+                PrimitiveType::Binary => quote!(&**#value),
                 PrimitiveType::Any | PrimitiveType::Rid | PrimitiveType::Bearertoken => {
                     quote!(&#value)
                 }

--- a/conjure-codegen/src/example_types/product/binary_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_example.rs
@@ -23,7 +23,7 @@ impl BinaryExample {
     }
     #[inline]
     pub fn binary(&self) -> &[u8] {
-        &*self.binary
+        &**self.binary
     }
 }
 #[doc = "A builder for the `BinaryExample` type."]

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.10"
 serde = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 
-conjure-object = { version = "0.7.0", path = "../conjure-object" }
+conjure-object = { version = "0.7.1", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,6 +14,6 @@ bytes = "0.5"
 http = "0.2"
 serde = "1.0"
 
-conjure-error = { version = "0.7.0", path = "../conjure-error" }
-conjure-object = { version = "0.7.0", path = "../conjure-object" }
-conjure-serde = { version = "0.7.0", path = "../conjure-serde" }
+conjure-error = { version = "0.7.1", path = "../conjure-error" }
+conjure-object = { version = "0.7.1", path = "../conjure-object" }
+conjure-serde = { version = "0.7.1", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "0.7.0", path = "../conjure-codegen" }
+conjure-codegen = { version = "0.7.1", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/conjure-test/src/test/objects.rs
+++ b/conjure-test/src/test/objects.rs
@@ -239,3 +239,18 @@ fn binary() {
     let value = CustomValueHandling::new(b"hello world".to_vec(), f64::INFINITY);
     test_serde(&value, json);
 }
+
+#[test]
+fn optional_binary_field() {
+    let json = r#"
+    {
+        "binary": "aGVsbG8gd29ybGQ="
+    }
+    "#;
+    let value = OptionalBinaryField::new(b"hello world".to_vec());
+    test_serde(&value, json);
+
+    let json = "{}";
+    let value = OptionalBinaryField::builder().build();
+    test_serde(&value, json);
+}

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -234,6 +234,26 @@
     "type" : "object",
     "object" : {
       "typeName" : {
+        "name" : "OptionalBinaryField",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "binary",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "BINARY"
+            }
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
         "name" : "OptionalConstructorFields",
         "package" : "com.palantir.conjure"
       },

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -93,6 +93,9 @@ types:
         fields:
           binary: binary
           double: double
+      OptionalBinaryField:
+        fields:
+          binary: optional<binary>
     errors:
       SimpleError:
         namespace: Test

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -5,6 +5,6 @@ authors = []
 edition = "2018"
 
 [dependencies]
-conjure-object = "0.7.0"
-conjure-error = "0.7.0"
-conjure-http = "0.7.0"
+conjure-object = "0.7.1"
+conjure-error = "0.7.1"
+conjure-http = "0.7.1"

--- a/example-api/src/product/binary_example.rs
+++ b/example-api/src/product/binary_example.rs
@@ -23,7 +23,7 @@ impl BinaryExample {
     }
     #[inline]
     pub fn binary(&self) -> &[u8] {
-        &*self.binary
+        &**self.binary
     }
 }
 #[doc = "A builder for the `BinaryExample` type."]


### PR DESCRIPTION
## Before this PR
The getter code failed to compile because we were one `*` short in the value conversion logic.

## After this PR
==COMMIT_MSG==
Fixed type generation for `optional<binary>` fields.
==COMMIT_MSG==

