### PR TITLE
Add constructors to propagate service errors

### DIFF
--- a/changelog/@unreleased/pr-105.v2.yml
+++ b/changelog/@unreleased/pr-105.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Added `Error` constructors to properly propagate service errors.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/105

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 
-conjure-object = { version = "0.7.1", path = "../conjure-object" }
-conjure-serde = { version = "0.7.1", path = "../conjure-serde" }
-conjure-error = { version = "0.7.1", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.7.1", optional = true, path = "../conjure-http" }
+conjure-object = { version = "0.7.2", path = "../conjure-object" }
+conjure-serde = { version = "0.7.2", path = "../conjure-serde" }
+conjure-error = { version = "0.7.2", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.7.2", optional = true, path = "../conjure-http" }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.10"
 serde = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 
-conjure-object = { version = "0.7.1", path = "../conjure-object" }
+conjure-object = { version = "0.7.2", path = "../conjure-object" }

--- a/conjure-error/src/error.rs
+++ b/conjure-error/src/error.rs
@@ -107,6 +107,22 @@ impl Error {
         )
     }
 
+    /// Creates a service error from a propagated error description and an unsafe cause.
+    pub fn propagated_service<E>(cause: E, error: SerializableError) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::service_inner(cause.into(), false, error, &[])
+    }
+
+    /// Creates a service error from a propagated error description and a safe cause.
+    pub fn propagated_service_safe<E>(cause: E, error: SerializableError) -> Error
+    where
+        E: Into<Box<dyn error::Error + Sync + Send>>,
+    {
+        Error::service_inner(cause.into(), true, error, &[])
+    }
+
     fn service_inner(
         cause: Box<dyn error::Error + Sync + Send>,
         cause_safe: bool,

--- a/conjure-error/src/lib.rs
+++ b/conjure-error/src/lib.rs
@@ -150,6 +150,7 @@ where
     }
 }
 
+// FIXME remove in next breaking release
 impl ErrorType for SerializableError {
     #[inline]
     fn code(&self) -> ErrorCode {

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,6 +14,6 @@ bytes = "0.5"
 http = "0.2"
 serde = "1.0"
 
-conjure-error = { version = "0.7.1", path = "../conjure-error" }
-conjure-object = { version = "0.7.1", path = "../conjure-object" }
-conjure-serde = { version = "0.7.1", path = "../conjure-serde" }
+conjure-error = { version = "0.7.2", path = "../conjure-error" }
+conjure-object = { version = "0.7.2", path = "../conjure-object" }
+conjure-serde = { version = "0.7.2", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "0.7.1", path = "../conjure-codegen" }
+conjure-codegen = { version = "0.7.2", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -5,6 +5,6 @@ authors = []
 edition = "2018"
 
 [dependencies]
-conjure-object = "0.7.1"
-conjure-error = "0.7.1"
-conjure-http = "0.7.1"
+conjure-object = "0.7.2"
+conjure-error = "0.7.2"
+conjure-http = "0.7.2"


### PR DESCRIPTION
## Before this PR
Service error propagation was handled via `SerializableError`'s `ErrorType` implementation and the normal `Error::service{,_safe}` methods, but the behavior was broken. All of the `SerializableError` fields (e.g. `errorName`, `errorInstanceId`, etc) would be added as parameters to the new error.

## After this PR
==COMMIT_MSG==
Added `Error` constructors to properly propagate service errors.
==COMMIT_MSG==

## Possible downsides?
We should remove the `ErrorType` impl to so people don't run into the bad behavior, but that can wait until the next breaking release.