### PR TITLE
Fix parsing of boolean options

### DIFF
--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -33,7 +33,7 @@ enum Opts {
 // FIXME move aliases over to the standard names
 #[derive(StructOpt)]
 struct Args {
-    #[structopt(long = "exhaustive")]
+    #[structopt(long = "exhaustive", parse(try_from_str))]
     /// Generate exhaustively matchable enums and unions
     exhaustive: bool,
     #[structopt(long = "strip-prefix", value_name = "prefix", alias = "stripPrefix")]

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -33,7 +33,7 @@ enum Opts {
 // FIXME move aliases over to the standard names
 #[derive(StructOpt)]
 struct Args {
-    #[structopt(long = "exhaustive", parse(try_from_str))]
+    #[structopt(long = "exhaustive", parse(try_from_str), default_value = "false")]
     /// Generate exhaustively matchable enums and unions
     exhaustive: bool,
     #[structopt(long = "strip-prefix", value_name = "prefix", alias = "stripPrefix")]


### PR DESCRIPTION
## Before this PR

The CLI flag `exhaustive` is set to `true` when an argument is provided, even if the argument is `=false`. This doesn't conform with RFC-002.

The behavior can be fixed by providing a custom parser for the option, as suggested in https://github.com/TeXitoi/structopt/issues/212#issuecomment-561093886.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Align parsing of boolean flags with RFC 002
==COMMIT_MSG==

Closes #68 