### PR TITLE
Fix path pattern that use wildcard.

### DIFF
--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -20,6 +20,7 @@ heck = "0.3"
 quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
+regex = "1"
 
 conjure-object = { version = "0.7.2", path = "../conjure-object" }
 conjure-serde = { version = "0.7.2", path = "../conjure-serde" }

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -120,7 +120,8 @@ fn generate_endpoint(
         .parse::<TokenStream>()
         .unwrap();
 
-    let path = &**endpoint.http_path();
+    let re = regex::Regex::new("\\{(.*):[^}]*\\}").unwrap();
+    let path = re.replace(&**endpoint.http_path(), "{$1}");
 
     let path_params = quote!(path_params_);
     let setup_path_params = setup_path_params(ctx, endpoint, &path_params);

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use proc_macro2::TokenStream;
 use quote::quote;
+use regex::Regex;
 
 use crate::context::Context;
 use crate::types::{
@@ -24,6 +25,8 @@ enum Style {
     Async,
     Sync,
 }
+
+static PATH_PATTERN: Regex = Regex::new("\\{(.*):[^}]*\\}").unwrap();
 
 pub fn generate(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
     let async_ = generate_inner(ctx, def, Style::Async);
@@ -120,8 +123,7 @@ fn generate_endpoint(
         .parse::<TokenStream>()
         .unwrap();
 
-    let re = regex::Regex::new("\\{(.*):[^}]*\\}").unwrap();
-    let path = re.replace(&**endpoint.http_path(), "{$1}");
+    let path = PATH_PATTERN.replace(&**endpoint.http_path(), "{$1}");
 
     let path_params = quote!(path_params_);
     let setup_path_params = setup_path_params(ctx, endpoint, &path_params);

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -306,7 +306,7 @@ where
         self.0
             .request(
                 conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                "/catalog/datasets/{datasetRid}/branches/{branch}/resolve",
                 path_params_,
                 query_params_,
                 headers_,
@@ -830,7 +830,7 @@ where
         let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
         self.0.request(
             conjure_http::private::http::Method::GET,
-            "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+            "/catalog/datasets/{datasetRid}/branches/{branch}/resolve",
             path_params_,
             query_params_,
             headers_,

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -306,7 +306,7 @@ where
         self.0
             .request(
                 conjure_http::private::http::Method::GET,
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                "/catalog/datasets/{datasetRid}/branches/{branch}/resolve",
                 path_params_,
                 query_params_,
                 headers_,
@@ -830,7 +830,7 @@ where
         let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
         self.0.request(
             conjure_http::private::http::Method::GET,
-            "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+            "/catalog/datasets/{datasetRid}/branches/{branch}/resolve",
             path_params_,
             query_params_,
             headers_,


### PR DESCRIPTION
## Before this PR
Runtime failures would occur when a path definition includes a wildcard pattern due to path param substitution not working correctly. In the example below `branch` would not be substituted for `{branch:.+}`.
```
let mut path_params_ = conjure_http::PathParams::new();
conjure_http::private::encode_path_param(&mut path_params_, "datasetRid", dataset_rid);
conjure_http::private::encode_path_param(&mut path_params_, "branch", branch);
let query_params_ = conjure_http::QueryParams::new();
let mut headers_ = conjure_http::private::http::HeaderMap::new();
conjure_http::private::encode_header_auth(&mut headers_, auth_);
let body_ = conjure_http::private::EmptyRequestBody;
let response_visitor_ = conjure_http::private::DefaultSerializableResponseVisitor::new();
self.0
    .request(
        conjure_http::private::http::Method::GET,
        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
        path_params_,
        query_params_,
        headers_,
        body_,
        response_visitor_,
    )
    .await
```

## After this PR
Wildcard parameters are replaced prior to substitution. This approach is similar to https://github.com/palantir/conjure-python/blob/3706f915eafca5e8c546de2cfd6bacb4bec95b49/conjure-python-core/src/main/java/com/palantir/conjure/python/poet/PythonEndpointDefinition.java#L191.
==COMMIT_MSG==
Fix bug when path params contain wildcards.
==COMMIT_MSG==
