### PR TITLE
Support the new endpoint tags API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 executors:
   rust:
-    docker: [{ image: rust:1.41.0 }]
+    docker: [{ image: rust:1.47.0 }]
 
 commands:
   restore_target:
@@ -91,7 +91,7 @@ jobs:
     working_directory: /Users/distiller/root/project
     steps:
       - attach_workspace: { at: /Users/distiller }
-      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.41.0
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.47.0
       - run: sudo ln -s $CARGO_HOME/bin/* /usr/local/bin
       - restore_target: { job: dist-macos }
       - run: cargo build --release --target x86_64-apple-darwin -p conjure-rust
@@ -110,7 +110,7 @@ jobs:
       - attach_workspace: { at: C:\Users\circleci }
       - run: |
           $progressPreference = "silentlyContinue"
-          Invoke-WebRequest "https://static.rust-lang.org/dist/rust-1.41.0-x86_64-pc-windows-msvc.exe" -outfile rust.exe
+          Invoke-WebRequest "https://static.rust-lang.org/dist/rust-1.47.0-x86_64-pc-windows-msvc.exe" -outfile rust.exe
       - run: .\rust.exe /VERYSILENT /NORESTART /DIR="C:\Program Files\Rust"
       - run: |
           $env:Path += ";C:\Program Files\Rust\bin"

--- a/changelog/@unreleased/pr-118.v2.yml
+++ b/changelog/@unreleased/pr-118.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Server endpoint arguments with the `safe` tag will be marked as safe.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/118

--- a/conjure-codegen/conjure-api-4.14.0.conjure.json
+++ b/conjure-codegen/conjure-api-4.14.0.conjure.json
@@ -104,6 +104,17 @@
             }
           }
         }
+      }, {
+        "fieldName" : "tags",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
       } ]
     }
   }, {
@@ -207,6 +218,21 @@
                 "name" : "ServiceDefinition",
                 "package" : "com.palantir.conjure.spec"
               }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "extensions",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
             }
           }
         }
@@ -354,6 +380,17 @@
                 "name" : "Type",
                 "package" : "com.palantir.conjure.spec"
               }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "tags",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
             }
           }
         }
@@ -1210,5 +1247,8 @@
       } ]
     }
   } ],
-  "services" : [ ]
+  "services" : [ ],
+  "extensions" : {
+    "recommended-product-dependencies" : [ ]
+  }
 }

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -169,10 +169,10 @@ fn generate_endpoint(
 }
 
 fn body_arg(endpoint: &EndpointDefinition) -> Option<&ArgumentDefinition> {
-    endpoint.args().iter().find(|a| match a.param_type() {
-        ParameterType::Body(_) => true,
-        _ => false,
-    })
+    endpoint
+        .args()
+        .iter()
+        .find(|a| matches!(a.param_type(), ParameterType::Body(_)))
 }
 
 fn params(ctx: &Context, body_arg: Option<&ArgumentDefinition>) -> TokenStream {

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![allow(clippy::match_like_matches_macro)]
+
 use heck::{CamelCase, SnakeCase};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -434,11 +434,7 @@ impl Config {
     }
 
     fn create_modules(&self, defs: &ConjureDefinition) -> ModuleTrie {
-        let context = Context::new(
-            &defs,
-            self.exhaustive,
-            self.strip_prefix.as_ref().map(|s| &**s),
-        );
+        let context = Context::new(&defs, self.exhaustive, self.strip_prefix.as_deref());
 
         let mut root = ModuleTrie::new();
 

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -817,7 +817,9 @@ fn parameter(ctx: &Context, argument: &ArgumentDefinition) -> Option<TokenStream
         ParameterType::Body(_) => return None,
     };
 
-    let safe = if argument.markers().iter().any(|a| ctx.is_safe_arg(a)) {
+    let safe = if argument.tags().iter().any(|s| s == "safe")
+        || argument.markers().iter().any(|a| ctx.is_safe_arg(a))
+    {
         quote! {
             .with_safe(true)
         }

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -627,10 +627,10 @@ fn extract_auth(
 }
 
 fn extract_body(ctx: &Context, endpoint: &EndpointDefinition, body: &TokenStream) -> TokenStream {
-    let arg = endpoint.args().iter().find(|a| match a.param_type() {
-        ParameterType::Body(_) => true,
-        _ => false,
-    });
+    let arg = endpoint
+        .args()
+        .iter()
+        .find(|a| matches!(a.param_type(), ParameterType::Body(_)));
 
     let arg = match arg {
         Some(arg) => arg,

--- a/conjure-codegen/src/types/argument_definition.rs
+++ b/conjure-codegen/src/types/argument_definition.rs
@@ -8,6 +8,7 @@ pub struct ArgumentDefinition {
     param_type: Box<super::ParameterType>,
     docs: Option<super::Documentation>,
     markers: Vec<super::Type>,
+    tags: Vec<String>,
 }
 impl ArgumentDefinition {
     #[doc = r" Returns a new builder."]
@@ -35,6 +36,10 @@ impl ArgumentDefinition {
     pub fn markers(&self) -> &[super::Type] {
         &*self.markers
     }
+    #[inline]
+    pub fn tags(&self) -> &[String] {
+        &*self.tags
+    }
 }
 #[doc = "A builder for the `ArgumentDefinition` type."]
 #[derive(Debug, Clone, Default)]
@@ -44,6 +49,7 @@ pub struct Builder {
     param_type: Option<Box<super::ParameterType>>,
     docs: Option<super::Documentation>,
     markers: Vec<super::Type>,
+    tags: Vec<String>,
 }
 impl Builder {
     #[doc = r""]
@@ -92,6 +98,27 @@ impl Builder {
         self.markers.push(value);
         self
     }
+    pub fn tags<T>(&mut self, tags: T) -> &mut Self
+    where
+        T: IntoIterator<Item = String>,
+    {
+        self.tags = tags.into_iter().collect();
+        self
+    }
+    pub fn extend_tags<T>(&mut self, tags: T) -> &mut Self
+    where
+        T: IntoIterator<Item = String>,
+    {
+        self.tags.extend(tags);
+        self
+    }
+    pub fn push_tags<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.tags.push(value.into());
+        self
+    }
     #[doc = r" Constructs a new instance of the type."]
     #[doc = r""]
     #[doc = r" # Panics"]
@@ -108,6 +135,7 @@ impl Builder {
                 .expect("field param_type was not set"),
             docs: self.docs.clone(),
             markers: self.markers.clone(),
+            tags: self.tags.clone(),
         }
     }
 }
@@ -120,6 +148,7 @@ impl From<ArgumentDefinition> for Builder {
             param_type: Some(_v.param_type),
             docs: _v.docs,
             markers: _v.markers,
+            tags: _v.tags,
         }
     }
 }
@@ -137,6 +166,10 @@ impl ser::Serialize for ArgumentDefinition {
         if !skip_markers {
             size += 1;
         }
+        let skip_tags = self.tags.is_empty();
+        if !skip_tags {
+            size += 1;
+        }
         let mut s = s.serialize_struct("ArgumentDefinition", size)?;
         s.serialize_field("argName", &self.arg_name)?;
         s.serialize_field("type", &self.type_)?;
@@ -151,6 +184,11 @@ impl ser::Serialize for ArgumentDefinition {
         } else {
             s.serialize_field("markers", &self.markers)?;
         }
+        if skip_tags {
+            s.skip_field("tags")?;
+        } else {
+            s.serialize_field("tags", &self.tags)?;
+        }
         s.end()
     }
 }
@@ -161,7 +199,7 @@ impl<'de> de::Deserialize<'de> for ArgumentDefinition {
     {
         d.deserialize_struct(
             "ArgumentDefinition",
-            &["argName", "type", "paramType", "docs", "markers"],
+            &["argName", "type", "paramType", "docs", "markers", "tags"],
             Visitor_,
         )
     }
@@ -181,6 +219,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
         let mut param_type = None;
         let mut docs = None;
         let mut markers = None;
+        let mut tags = None;
         while let Some(field_) = map_.next_key()? {
             match field_ {
                 Field_::ArgName => arg_name = Some(map_.next_value()?),
@@ -188,6 +227,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 Field_::ParamType => param_type = Some(map_.next_value()?),
                 Field_::Docs => docs = Some(map_.next_value()?),
                 Field_::Markers => markers = Some(map_.next_value()?),
+                Field_::Tags => tags = Some(map_.next_value()?),
                 Field_::Unknown_ => {
                     map_.next_value::<de::IgnoredAny>()?;
                 }
@@ -213,12 +253,17 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             Some(v) => v,
             None => Default::default(),
         };
+        let tags = match tags {
+            Some(v) => v,
+            None => Default::default(),
+        };
         Ok(ArgumentDefinition {
             arg_name,
             type_,
             param_type,
             docs,
             markers,
+            tags,
         })
     }
 }
@@ -228,6 +273,7 @@ enum Field_ {
     ParamType,
     Docs,
     Markers,
+    Tags,
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
@@ -254,6 +300,7 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
             "paramType" => Field_::ParamType,
             "docs" => Field_::Docs,
             "markers" => Field_::Markers,
+            "tags" => Field_::Tags,
             _ => Field_::Unknown_,
         };
         Ok(v)

--- a/conjure-codegen/src/types/endpoint_definition.rs
+++ b/conjure-codegen/src/types/endpoint_definition.rs
@@ -12,6 +12,7 @@ pub struct EndpointDefinition {
     docs: Option<super::Documentation>,
     deprecated: Option<super::Documentation>,
     markers: Vec<super::Type>,
+    tags: std::collections::BTreeSet<String>,
 }
 impl EndpointDefinition {
     #[doc = r" Returns a new builder."]
@@ -55,6 +56,10 @@ impl EndpointDefinition {
     pub fn markers(&self) -> &[super::Type] {
         &*self.markers
     }
+    #[inline]
+    pub fn tags(&self) -> &std::collections::BTreeSet<String> {
+        &self.tags
+    }
 }
 #[doc = "A builder for the `EndpointDefinition` type."]
 #[derive(Debug, Clone, Default)]
@@ -68,6 +73,7 @@ pub struct Builder {
     docs: Option<super::Documentation>,
     deprecated: Option<super::Documentation>,
     markers: Vec<super::Type>,
+    tags: std::collections::BTreeSet<String>,
 }
 impl Builder {
     #[doc = r""]
@@ -155,6 +161,27 @@ impl Builder {
         self.markers.push(value);
         self
     }
+    pub fn tags<T>(&mut self, tags: T) -> &mut Self
+    where
+        T: IntoIterator<Item = String>,
+    {
+        self.tags = tags.into_iter().collect();
+        self
+    }
+    pub fn extend_tags<T>(&mut self, tags: T) -> &mut Self
+    where
+        T: IntoIterator<Item = String>,
+    {
+        self.tags.extend(tags);
+        self
+    }
+    pub fn insert_tags<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<String>,
+    {
+        self.tags.insert(value.into());
+        self
+    }
     #[doc = r" Constructs a new instance of the type."]
     #[doc = r""]
     #[doc = r" # Panics"]
@@ -178,6 +205,7 @@ impl Builder {
             docs: self.docs.clone(),
             deprecated: self.deprecated.clone(),
             markers: self.markers.clone(),
+            tags: self.tags.clone(),
         }
     }
 }
@@ -194,6 +222,7 @@ impl From<EndpointDefinition> for Builder {
             docs: _v.docs,
             deprecated: _v.deprecated,
             markers: _v.markers,
+            tags: _v.tags,
         }
     }
 }
@@ -225,6 +254,10 @@ impl ser::Serialize for EndpointDefinition {
         }
         let skip_markers = self.markers.is_empty();
         if !skip_markers {
+            size += 1;
+        }
+        let skip_tags = self.tags.is_empty();
+        if !skip_tags {
             size += 1;
         }
         let mut s = s.serialize_struct("EndpointDefinition", size)?;
@@ -261,6 +294,11 @@ impl ser::Serialize for EndpointDefinition {
         } else {
             s.serialize_field("markers", &self.markers)?;
         }
+        if skip_tags {
+            s.skip_field("tags")?;
+        } else {
+            s.serialize_field("tags", &self.tags)?;
+        }
         s.end()
     }
 }
@@ -281,6 +319,7 @@ impl<'de> de::Deserialize<'de> for EndpointDefinition {
                 "docs",
                 "deprecated",
                 "markers",
+                "tags",
             ],
             Visitor_,
         )
@@ -305,6 +344,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
         let mut docs = None;
         let mut deprecated = None;
         let mut markers = None;
+        let mut tags = None;
         while let Some(field_) = map_.next_key()? {
             match field_ {
                 Field_::EndpointName => endpoint_name = Some(map_.next_value()?),
@@ -316,6 +356,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 Field_::Docs => docs = Some(map_.next_value()?),
                 Field_::Deprecated => deprecated = Some(map_.next_value()?),
                 Field_::Markers => markers = Some(map_.next_value()?),
+                Field_::Tags => tags = Some(map_.next_value()?),
                 Field_::Unknown_ => {
                     map_.next_value::<de::IgnoredAny>()?;
                 }
@@ -357,6 +398,10 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             Some(v) => v,
             None => Default::default(),
         };
+        let tags = match tags {
+            Some(v) => v,
+            None => Default::default(),
+        };
         Ok(EndpointDefinition {
             endpoint_name,
             http_method,
@@ -367,6 +412,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             docs,
             deprecated,
             markers,
+            tags,
         })
     }
 }
@@ -380,6 +426,7 @@ enum Field_ {
     Docs,
     Deprecated,
     Markers,
+    Tags,
     Unknown_,
 }
 impl<'de> de::Deserialize<'de> for Field_ {
@@ -410,6 +457,7 @@ impl<'de> de::Visitor<'de> for FieldVisitor_ {
             "docs" => Field_::Docs,
             "deprecated" => Field_::Deprecated,
             "markers" => Field_::Markers,
+            "tags" => Field_::Tags,
             _ => Field_::Unknown_,
         };
         Ok(v)

--- a/conjure-object/src/private.rs
+++ b/conjure-object/src/private.rs
@@ -20,10 +20,9 @@ pub fn valid_enum_variant(s: &str) -> bool {
         return false;
     }
 
-    s.as_bytes().iter().all(|b| match b {
-        b'A'..=b'Z' | b'0'..=b'9' | b'_' => true,
-        _ => false,
-    })
+    s.as_bytes()
+        .iter()
+        .all(|b| matches!(b, b'A'..=b'Z' | b'0'..=b'9' | b'_'))
 }
 
 pub enum UnionField_<T> {

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -8,6 +8,6 @@ rm -rf example-api
 rm -rf conjure-codegen/src/exmaple-types
 ./target/debug/conjure-rust generate --strip-prefix com.palantir conjure-codegen/example-types-ir.json conjure-codegen/src/example_types
 rm -rf conjure-codegen/src/types
-./target/debug/conjure-rust generate --strip-prefix com.palantir.conjure.spec --exhaustive conjure-codegen/conjure-api-4.8.0.conjure.json conjure-codegen/src/types
+./target/debug/conjure-rust generate --strip-prefix com.palantir.conjure.spec --exhaustive conjure-codegen/conjure-api-4.14.0.conjure.json conjure-codegen/src/types
 rm -rf conjure-error/src/types
 ./target/debug/conjure-rust generate --strip-prefix com.palantir.conjure.error --exhaustive conjure-error/error-types.conjure.json conjure-error/src/types


### PR DESCRIPTION
## Before this PR
Service argument safety was indicated by a marker corresponding to a Java `Safe` annotation.

## After this PR
==COMMIT_MSG==
Server endpoint arguments with the `safe` tag will be marked as safe.
==COMMIT_MSG==

We now support the newly-added `tags` API (https://github.com/palantir/conjure/pull/702) which bypasses the Java annotation bit in favor of a more language-agnostic approach. The old marker annotation is still supported to preserve back compat.

