### PR TITLE
Add traits for client types

### DIFF
--- a/changelog/@unreleased/pr-121.v2.yml
+++ b/changelog/@unreleased/pr-121.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Generated service clients now implement the new `Service` and `AsyncService`
+    traits.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/121

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -70,7 +70,7 @@ fn generate_inner(ctx: &Context, def: &ServiceDefinition, style: Style) -> Token
         #[derive(Clone, Debug)]
         pub struct #name<T>(T);
 
-        impl<T> conjure_http::client::#service<T>
+        impl<T> conjure_http::client::#service<T> for #name<T>
         where
             T: conjure_http::client::#client_bound,
         {

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -33,14 +33,21 @@ pub struct Context {
     types: HashMap<TypeName, TypeContext>,
     exhaustive: bool,
     strip_prefix: Vec<String>,
+    version: Option<String>,
 }
 
 impl Context {
-    pub fn new(defs: &ConjureDefinition, exhaustive: bool, strip_prefix: Option<&str>) -> Context {
+    pub fn new(
+        defs: &ConjureDefinition,
+        exhaustive: bool,
+        strip_prefix: Option<&str>,
+        version: Option<&str>,
+    ) -> Context {
         let mut context = Context {
             types: HashMap::new(),
             exhaustive,
             strip_prefix: vec![],
+            version: version.map(str::to_owned),
         };
 
         if let Some(strip_prefix) = strip_prefix {
@@ -955,6 +962,10 @@ impl Context {
             }
             _ => false,
         }
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
     }
 }
 

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1,6 +1,17 @@
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceAsyncClient<T>(T);
+impl<T> conjure_http::client::AsyncService<T>
+where
+    T: conjure_http::client::AsyncClient,
+{
+    const NAME: &'static str = "TestService";
+    const VERSION: conjure_http::private::Option<&'static str> =
+        conjure_http::private::Option::None;
+    fn new(client: T) -> Self {
+        TestServiceAsyncClient(client)
+    }
+}
 impl<T> TestServiceAsyncClient<T>
 where
     T: conjure_http::client::AsyncClient,
@@ -548,6 +559,17 @@ where
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
+impl<T> conjure_http::client::Service<T>
+where
+    T: conjure_http::client::Client,
+{
+    const NAME: &'static str = "TestService";
+    const VERSION: conjure_http::private::Option<&'static str> =
+        conjure_http::private::Option::None;
+    fn new(client: T) -> Self {
+        TestServiceClient(client)
+    }
+}
 impl<T> TestServiceClient<T>
 where
     T: conjure_http::client::Client,

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1,7 +1,7 @@
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceAsyncClient<T>(T);
-impl<T> conjure_http::client::AsyncService<T>
+impl<T> conjure_http::client::AsyncService<T> for TestServiceAsyncClient<T>
 where
     T: conjure_http::client::AsyncClient,
 {
@@ -559,7 +559,7 @@ where
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
-impl<T> conjure_http::client::Service<T>
+impl<T> conjure_http::client::Service<T> for TestServiceClient<T>
 where
     T: conjure_http::client::Client,
 {

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -434,7 +434,12 @@ impl Config {
     }
 
     fn create_modules(&self, defs: &ConjureDefinition) -> ModuleTrie {
-        let context = Context::new(&defs, self.exhaustive, self.strip_prefix.as_deref());
+        let context = Context::new(
+            &defs,
+            self.exhaustive,
+            self.strip_prefix.as_deref(),
+            self.build_crate.as_ref().map(|v| &*v.version),
+        );
 
         let mut root = ModuleTrie::new();
 

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -72,8 +72,8 @@ pub trait AsyncService<C> {
     /// The name of the service.
     const NAME: &'static str;
 
-    /// The version of the Conjure definition defining the service.
-    const VERSION: &'static str;
+    /// The version of the Conjure definition defining the service, if known.
+    const VERSION: Option<&'static str>;
 
     /// Creates a new service wrapping an async HTTP client.
     fn new(client: C) -> Self;

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -24,6 +24,18 @@ use std::future::Future;
 use std::io::Write;
 use std::pin::Pin;
 
+/// A trait implemented by generated blocking client interfaces for a Conjure service.
+pub trait Service<C> {
+    /// The name of the service.
+    const NAME: &'static str;
+
+    /// The version of the Conjure definition defining the service, if known.
+    const VERSION: Option<&'static str>;
+
+    /// Creates a new service wrapping an HTTP client.
+    fn new(client: C) -> Self;
+}
+
 /// A trait implemented by HTTP client implementations.
 pub trait Client {
     /// The client's binary request body writer type.
@@ -53,6 +65,18 @@ pub trait Client {
     where
         T: RequestBody<'a, Self::BinaryWriter>,
         U: VisitResponse<Self::BinaryBody>;
+}
+
+/// A trait implemented by generated async client interfaces for a Conjure service.
+pub trait AsyncService<C> {
+    /// The name of the service.
+    const NAME: &'static str;
+
+    /// The version of the Conjure definition defining the service.
+    const VERSION: &'static str;
+
+    /// Creates a new service wrapping an async HTTP client.
+    fn new(client: C) -> Self;
 }
 
 /// A trait implemented by async HTTP client implementations.

--- a/conjure-http/src/private/mod.rs
+++ b/conjure-http/src/private/mod.rs
@@ -16,6 +16,7 @@ pub use conjure_error::Error;
 pub use conjure_serde::json;
 pub use http;
 pub use std::future::Future;
+pub use std::option::Option;
 pub use std::pin::Pin;
 
 pub use crate::private::client::*;

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -1,7 +1,7 @@
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceAsyncClient<T>(T);
-impl<T> conjure_http::client::AsyncService<T>
+impl<T> conjure_http::client::AsyncService<T> for TestServiceAsyncClient<T>
 where
     T: conjure_http::client::AsyncClient,
 {
@@ -559,7 +559,7 @@ where
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
-impl<T> conjure_http::client::Service<T>
+impl<T> conjure_http::client::Service<T> for TestServiceClient<T>
 where
     T: conjure_http::client::Client,
 {

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -1,6 +1,17 @@
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceAsyncClient<T>(T);
+impl<T> conjure_http::client::AsyncService<T>
+where
+    T: conjure_http::client::AsyncClient,
+{
+    const NAME: &'static str = "TestService";
+    const VERSION: conjure_http::private::Option<&'static str> =
+        conjure_http::private::Option::Some("0.1.0");
+    fn new(client: T) -> Self {
+        TestServiceAsyncClient(client)
+    }
+}
 impl<T> TestServiceAsyncClient<T>
 where
     T: conjure_http::client::AsyncClient,
@@ -548,6 +559,17 @@ where
 #[doc = "A Markdown description of the service."]
 #[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
+impl<T> conjure_http::client::Service<T>
+where
+    T: conjure_http::client::Client,
+{
+    const NAME: &'static str = "TestService";
+    const VERSION: conjure_http::private::Option<&'static str> =
+        conjure_http::private::Option::Some("0.1.0");
+    fn new(client: T) -> Self {
+        TestServiceClient(client)
+    }
+}
 impl<T> TestServiceClient<T>
 where
     T: conjure_http::client::Client,


### PR DESCRIPTION
These can be used to more ergonomically construct client instances with
integration in HTTP client impls.