### PR TITLE
Fix windows dist build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,16 +104,14 @@ jobs:
   dist-windows:
     executor: win/vs2019
     working_directory: C:\Users\circleci\root\project
-    environment:
-      CARGO_HOME: C:\Users\circleci\usr\local\cargo
     steps:
       - attach_workspace: { at: C:\Users\circleci }
       - run: |
           $progressPreference = "silentlyContinue"
-          Invoke-WebRequest "https://static.rust-lang.org/dist/rust-1.47.0-x86_64-pc-windows-msvc.exe" -outfile rust.exe
-      - run: .\rust.exe /VERYSILENT /NORESTART /DIR="C:\Program Files\Rust"
+          Invoke-WebRequest "https://win.rustup.rs/" -outfile rustup-init.exe
+      - run: .\rustup-init.exe -y --no-modify-path --default-toolchain 1.47.0
       - run: |
-          $env:Path += ";C:\Program Files\Rust\bin"
+          $env:Path += ";C:\Users\circleci\.cargo\bin"
           cargo build --release --target x86_64-pc-windows-msvc -p conjure-rust
       - persist_to_workspace:
           root: C:\Users\circleci

--- a/changelog/@unreleased/pr-125.v2.yml
+++ b/changelog/@unreleased/pr-125.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed the conjure-rust dist build.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/125

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ quote = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 
-conjure-object = { version = "0.7.3", path = "../conjure-object" }
-conjure-serde = { version = "0.7.3", path = "../conjure-serde" }
-conjure-error = { version = "0.7.3", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.7.3", optional = true, path = "../conjure-http" }
+conjure-object = { version = "0.7.4", path = "../conjure-object" }
+conjure-serde = { version = "0.7.4", path = "../conjure-serde" }
+conjure-error = { version = "0.7.4", optional = true, path = "../conjure-error" }
+conjure-http = { version = "0.7.4", optional = true, path = "../conjure-http" }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.11"
 serde = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 
-conjure-object = { version = "0.7.3", path = "../conjure-object" }
+conjure-object = { version = "0.7.4", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,6 +14,6 @@ bytes = "1.0"
 http = "0.2"
 serde = "1.0"
 
-conjure-error = { version = "0.7.3", path = "../conjure-error" }
-conjure-object = { version = "0.7.3", path = "../conjure-object" }
-conjure-serde = { version = "0.7.3", path = "../conjure-serde" }
+conjure-error = { version = "0.7.4", path = "../conjure-error" }
+conjure-object = { version = "0.7.4", path = "../conjure-object" }
+conjure-serde = { version = "0.7.4", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "0.7.3", path = "../conjure-codegen" }
+conjure-codegen = { version = "0.7.4", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -5,6 +5,6 @@ authors = []
 edition = "2018"
 
 [dependencies]
-conjure-object = "0.7.3"
-conjure-error = "0.7.3"
-conjure-http = "0.7.3"
+conjure-object = "0.7.4"
+conjure-error = "0.7.4"
+conjure-http = "0.7.4"


### PR DESCRIPTION
The old installer we were using for the Windows dist was moved/removed, so we should just go the actually supported route and install via rustup.