### PR TITLE
Simplify staged builders

### DIFF
--- a/conjure-codegen/src/objects/mod.rs
+++ b/conjure-codegen/src/objects/mod.rs
@@ -47,7 +47,7 @@ fn fields(ctx: &Context, def: &ObjectDefinition) -> Vec<Ident> {
 }
 
 fn stage_name(ctx: &Context, def: &ObjectDefinition, stage: usize) -> Ident {
-    let mut name = format!("Stage{}", stage);
+    let mut name = format!("BuilderStage{}", stage);
     if ctx.type_name(def.type_name().name()) == name {
         name.push('_');
     }

--- a/conjure-codegen/src/objects/object.rs
+++ b/conjure-codegen/src/objects/object.rs
@@ -70,11 +70,12 @@ pub fn generate(ctx: &Context, def: &ObjectDefinition) -> TokenStream {
         quote!(builder)
     };
 
-    let mut builder_type = objects::builder_type(ctx, def);
-    if ctx.staged_builders() {
-        let stage0 = objects::stage_name(ctx, def, 0);
-        builder_type = quote!(#builder_type<#stage0>);
-    }
+    let builder_type = if ctx.staged_builders() {
+        let stage = objects::stage_name(ctx, def, 0);
+        quote!(#stage)
+    } else {
+        objects::builder_type(ctx, def)
+    };
 
     quote! {
         #docs

--- a/conjure-test/src/test/objects.rs
+++ b/conjure-test/src/test/objects.rs
@@ -339,7 +339,7 @@ fn staged_update_with_from() {
         .double(1.5)
         .string("hello world")
         .build();
-    let updated = staged_types::all_required_fields::Builder::from(original)
+    let updated = staged_types::all_required_fields::BuilderStage3::from(original)
         .string("foobar")
         .build();
     test_serde(&updated, json);


### PR DESCRIPTION
Previously, the staged builder API used a single `Builder` type parameterized over stage types which implemented traits to allow specific fields to be set. This approach confuses IDEs, which aren't able to filter method suggestions to the ones actually applicable to the current stage. Instead, we now just generate separate builder types for each stage with inherent impls.