### PR TITLE
Prepare for 1.0.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 executors:
   rust:
-    docker: [{ image: rust:1.56.1 }]
+    docker: [{ image: rust:1.59.0 }]
 
 commands:
   restore_target:
@@ -91,7 +91,7 @@ jobs:
     working_directory: /Users/distiller/root/project
     steps:
       - attach_workspace: { at: /Users/distiller }
-      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.56.1
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.59.0
       - run: sudo ln -s $CARGO_HOME/bin/* /usr/local/bin
       - restore_target: { job: dist-macos }
       - run: cargo build --release --target x86_64-apple-darwin -p conjure-rust
@@ -109,7 +109,7 @@ jobs:
       - run: |
           $progressPreference = "silentlyContinue"
           Invoke-WebRequest "https://win.rustup.rs/" -outfile rustup-init.exe
-      - run: .\rustup-init.exe -y --no-modify-path --default-toolchain 1.56.1
+      - run: .\rustup-init.exe -y --no-modify-path --default-toolchain 1.59.0
       - run: |
           $env:Path += ";C:\Users\circleci\.cargo\bin"
           cargo build --release --target x86_64-pc-windows-msvc -p conjure-rust

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "0.7.4"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ failure = "0.1"
 toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 
-conjure-object = { version = "0.7.4", path = "../conjure-object" }
-conjure-serde = { version = "0.7.4", path = "../conjure-serde" }
-conjure-error = { version = "0.7.4", optional = true, path = "../conjure-error" }
-conjure-http = { version = "0.7.4", optional = true, path = "../conjure-http" }
+conjure-object = { version = "1.0.0", path = "../conjure-object" }
+conjure-serde = { version = "1.0.0", path = "../conjure-serde" }
+conjure-error = { version = "1.0.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "1.0.0", optional = true, path = "../conjure-http" }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "0.7.4"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.12"
 serde = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 
-conjure-object = { version = "0.7.4", path = "../conjure-object" }
+conjure-object = { version = "1.0.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "0.7.4"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,6 +20,6 @@ percent-encoding = "2.1"
 pin-utils = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "0.7.4", path = "../conjure-error" }
-conjure-object = { version = "0.7.4", path = "../conjure-object" }
-conjure-serde = { version = "0.7.4", path = "../conjure-serde" }
+conjure-error = { version = "1.0.0", path = "../conjure-error" }
+conjure-object = { version = "1.0.0", path = "../conjure-object" }
+conjure-serde = { version = "1.0.0", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "0.7.4"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "0.7.4"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "0.7.4", path = "../conjure-codegen" }
+conjure-codegen = { version = "1.0.0", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "0.7.4"
+version = "1.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -4,6 +4,6 @@ version = '0.1.0'
 edition = '2018'
 
 [dependencies]
-conjure-error = '0.7.4'
-conjure-http = '0.7.4'
-conjure-object = '0.7.4'
+conjure-error = '1.0.0'
+conjure-http = '1.0.0'
+conjure-object = '1.0.0'


### PR DESCRIPTION
Waiting on #178.

0.x releases don't work well with Autorelease's semantics, so it's easier to just bump to 1.0.