### PR TITLE
Fix handling of aliased optional request bodies

### DIFF
--- a/changelog/@unreleased/pr-183.v2.yml
+++ b/changelog/@unreleased/pr-183.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed handling of aliased optional request bodies.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/183

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ failure = "0.1"
 toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 
-conjure-object = { version = "1.0.0", path = "../conjure-object" }
-conjure-serde = { version = "1.0.0", path = "../conjure-serde" }
-conjure-error = { version = "1.0.0", optional = true, path = "../conjure-error" }
-conjure-http = { version = "1.0.0", optional = true, path = "../conjure-http" }
+conjure-object = { version = "1.1.0", path = "../conjure-object" }
+conjure-serde = { version = "1.1.0", path = "../conjure-serde" }
+conjure-error = { version = "1.1.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "1.1.0", optional = true, path = "../conjure-http" }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.12"
 serde = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 
-conjure-object = { version = "1.0.0", path = "../conjure-object" }
+conjure-object = { version = "1.1.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,6 +20,6 @@ percent-encoding = "2.1"
 pin-utils = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "1.0.0", path = "../conjure-error" }
-conjure-object = { version = "1.0.0", path = "../conjure-object" }
-conjure-serde = { version = "1.0.0", path = "../conjure-serde" }
+conjure-error = { version = "1.1.0", path = "../conjure-error" }
+conjure-object = { version = "1.1.0", path = "../conjure-object" }
+conjure-serde = { version = "1.1.0", path = "../conjure-serde" }

--- a/conjure-http/src/private/server.rs
+++ b/conjure-http/src/private/server.rs
@@ -290,33 +290,31 @@ fn check_deserializable_request_headers(parts: &request::Parts) -> Result<(), Er
 pub fn decode_optional_serializable_request<I, T>(
     parts: &request::Parts,
     body: I,
-) -> Result<Option<T>, Error>
+) -> Result<T, Error>
 where
     I: Iterator<Item = Result<Bytes, Error>>,
-    T: DeserializeOwned,
+    T: DeserializeOwned + Default,
 {
     if !parts.headers.contains_key(CONTENT_TYPE) {
-        return Ok(None);
+        return Ok(T::default());
     }
 
-    decode_serializable_request(parts, body).map(Some)
+    decode_serializable_request(parts, body)
 }
 
 pub async fn async_decode_optional_serializable_request<I, T>(
     parts: &request::Parts,
     body: I,
-) -> Result<Option<T>, Error>
+) -> Result<T, Error>
 where
     I: Stream<Item = Result<Bytes, Error>>,
-    T: DeserializeOwned,
+    T: DeserializeOwned + Default,
 {
     if !parts.headers.contains_key(CONTENT_TYPE) {
-        return Ok(None);
+        return Ok(T::default());
     }
 
-    async_decode_serializable_request(parts, body)
-        .await
-        .map(Some)
+    async_decode_serializable_request(parts, body).await
 }
 
 pub fn decode_binary_request<I>(parts: &request::Parts, body: I) -> Result<I, Error> {

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 structopt = "0.3"
 
-conjure-codegen = { version = "1.0.0", path = "../conjure-codegen" }
+conjure-codegen = { version = "1.1.0", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -118,6 +118,8 @@ test_service_handler! {
 
     fn optional_json_request(&self, body: Option<String>) -> Result<(), Error>;
 
+    fn optional_alias_request(&self, body: OptionalAlias) -> Result<(), Error>;
+
     fn streaming_request(&self, body: RemoteBody) -> Result<(), Error>;
 
     fn streaming_alias_request(&self, body: RemoteBody) -> Result<(), Error>;
@@ -459,6 +461,7 @@ fn optional_json_request() {
             Ok(())
         })
         .call()
+        .header("Content-Type", "application/json")
         .body(b"null")
         .send("optionalJsonRequest");
 
@@ -469,6 +472,37 @@ fn optional_json_request() {
         })
         .call()
         .send("optionalJsonRequest");
+}
+
+#[test]
+fn optional_alias_request() {
+    TestServiceHandler::new()
+        .optional_alias_request(|body| {
+            assert_eq!(body, OptionalAlias(Some(5)));
+            Ok(())
+        })
+        .call()
+        .header("Content-Type", "application/json")
+        .body(b"5")
+        .send("optionalAliasRequest");
+
+    TestServiceHandler::new()
+        .optional_alias_request(|body| {
+            assert_eq!(body, OptionalAlias(None));
+            Ok(())
+        })
+        .call()
+        .header("Content-Type", "application/json")
+        .body(b"null")
+        .send("optionalAliasRequest");
+
+    TestServiceHandler::new()
+        .optional_alias_request(|body| {
+            assert_eq!(body, OptionalAlias(None));
+            Ok(())
+        })
+        .call()
+        .send("optionalAliasRequest");
 }
 
 #[test]

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -1291,6 +1291,28 @@
       "markers" : [ ],
       "tags" : [ ]
     }, {
+      "endpointName" : "optionalAliasRequest",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/optionalAliasRequest",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "OptionalAlias",
+            "package" : "com.palantir.conjure"
+          }
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ],
+        "tags" : [ ]
+      } ],
+      "markers" : [ ],
+      "tags" : [ ]
+    }, {
       "endpointName" : "streamingRequest",
       "httpMethod" : "POST",
       "httpPath" : "/test/streamingRequest",

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -222,6 +222,10 @@ services:
         http: POST /optionalJsonRequest
         args:
           body: optional<string>
+      optionalAliasRequest:
+        http: POST /optionalAliasRequest
+        args:
+          body: OptionalAlias
       streamingRequest:
         http: POST /streamingRequest
         args:

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -4,6 +4,6 @@ version = '0.1.0'
 edition = '2018'
 
 [dependencies]
-conjure-error = '1.0.0'
-conjure-http = '1.0.0'
-conjure-object = '1.0.0'
+conjure-error = '1.1.0'
+conjure-http = '1.1.0'
+conjure-object = '1.1.0'


### PR DESCRIPTION
The deserialization logic previously didn't properly handle aliased optional request bodies.

