### PR TITLE
Build for ARM macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,13 +93,18 @@ jobs:
       - attach_workspace: { at: /Users/distiller }
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path --default-toolchain 1.59.0
       - run: sudo ln -s $CARGO_HOME/bin/* /usr/local/bin
+      - run: rustup target add aarch64-apple-darwin
       - restore_target: { job: dist-macos }
       - run: cargo build --release --target x86_64-apple-darwin -p conjure-rust
       - run: strip target/x86_64-apple-darwin/release/conjure-rust
+      - run: cargo build --release --target aarch64-apple-darwin -p conjure-rust
+      - run: strip target/aarch64-apple-darwin/release/conjure-rust
       - save_target: { job: dist-macos }
       - persist_to_workspace:
           root: /Users/distiller
-          paths: root/project/target/x86_64-apple-darwin/release/conjure-rust
+          paths:
+            - root/project/target/x86_64-apple-darwin/release/conjure-rust
+            - root/project/target/aarch64-apple-darwin/release/conjure-rust
 
   dist-windows:
     executor: win/vs2019
@@ -122,6 +127,9 @@ jobs:
     steps:
       - attach_workspace: { at: / }
       - run: ./gradlew publish
+      - store_artifacts:
+          path: build/distributions
+
 workflows:
   version: 2
   main:

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,12 @@ task distTar(type: Tar) {
         from 'dist'
     }
 
-    ['x86_64-unknown-linux-musl', 'x86_64-apple-darwin', 'x86_64-pc-windows-msvc'].each { target -> 
+    [
+        'x86_64-unknown-linux-musl',
+        'x86_64-apple-darwin',
+        'x86_64-pc-windows-msvc',
+        'aarch64-apple-darwin',
+    ].each { target -> 
         into ("bin/$target") {
             from "target/$target/release/conjure-rust"
             from "target/$target/release/conjure-rust.exe"

--- a/changelog/@unreleased/pr-192.v2.yml
+++ b/changelog/@unreleased/pr-192.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Added support for ARM macOS to the conjure-rust binary dist.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/192

--- a/dist/conjure-rust
+++ b/dist/conjure-rust
@@ -5,9 +5,12 @@ BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # determine target
 TARGET=""
-case "$(uname)" in
-  Darwin*)
+case "$(uname -sm)" in
+  "Darwin x86_64")
     TARGET=x86_64-apple-darwin
+    ;;
+  "Darwin arm64")
+    TARGET=aarch64-apple-darwin
     ;;
   Linux*)
     TARGET=x86_64-unknown-linux-musl


### PR DESCRIPTION
ARM macOS is more insistent about code signing, so for now you have to go through the "run this software anyway dance". In the future we can get a proper signing key, but this will at least allow you to use conjure-rust on ARM.