### PR TITLE
Add smile support to conjure-serde

### DIFF
--- a/changelog/@unreleased/pr-193.v2.yml
+++ b/changelog/@unreleased/pr-193.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Added smile support to conjure-serde.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/193

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -12,7 +12,9 @@ readme = "../README.md"
 base64 = "0.13"
 serde = "1.0"
 serde_json = "1.0"
+serde-smile = "0.1"
 
 [dev-dependencies]
+conjure-object = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/conjure-serde/src/json/de/client.rs
+++ b/conjure-serde/src/json/de/client.rs
@@ -54,9 +54,6 @@ where
 }
 
 /// A serde JSON deserializer appropriate for use by Conjure clients.
-///
-/// In contrast to serde_json, the f32 and f64 types can be deserialized from the strings `"Infinity"`, `"-Infinity"`,
-/// and `"NaN"`, and bytes are deserialized from base64 encoded strings. Unknown object fields are ignored.
 pub struct ClientDeserializer<R>(serde_json::Deserializer<R>);
 
 impl<R> ClientDeserializer<IoRead<R>>

--- a/conjure-serde/src/json/mod.rs
+++ b/conjure-serde/src/json/mod.rs
@@ -18,6 +18,7 @@
 //! * serde_json serializes non-finite floating point values as `null`, while Conjure specifies `"Infinity"`,
 //!     `"-Infinity"`, and `"NaN"` as appropriate.
 //! * serde_json serializes byte sequences as arrays of numbers, while Conjure specifies Base64-encoded strings.
+//! * serde_json does not support binary, floating point, or boolean keys, while Conjure does.
 //!
 //! Additionally, Conjure clients should ignore unknown fields while Conjure servers should trigger errors.
 //!
@@ -32,7 +33,7 @@ pub use crate::json::de::server::{
 };
 pub use crate::json::ser::{to_string, to_vec, to_writer, Serializer};
 
-mod de;
-mod ser;
+pub(crate) mod de;
+pub(crate) mod ser;
 #[cfg(test)]
 mod test;

--- a/conjure-serde/src/json/ser.rs
+++ b/conjure-serde/src/json/ser.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use crate::ser::{Behavior, Override};
+use crate::ser::Behavior;
 use base64::display::Base64Display;
 use serde::ser;
 use serde_json::ser::{CompactFormatter, Formatter, PrettyFormatter};
@@ -50,9 +50,6 @@ where
 }
 
 /// A serde JSON serializer compatible with the Conjure specification.
-///
-/// In contrast to serde_json, the f32 and f64 types are serialized as the strings `"Infinity"`, `"-Infinity"`, and
-/// `"NaN"` when appropriate, and bytes are serialized as base64 encoded strings.
 pub struct Serializer<W, F = CompactFormatter>(serde_json::Serializer<W, F>);
 
 impl<W> Serializer<W>

--- a/conjure-serde/src/lib.rs
+++ b/conjure-serde/src/lib.rs
@@ -34,3 +34,4 @@ mod ser;
 mod de;
 
 pub mod json;
+pub mod smile;

--- a/conjure-serde/src/ser.rs
+++ b/conjure-serde/src/ser.rs
@@ -24,37 +24,37 @@ macro_rules! impl_serialize_body {
 
         type Error = <$inner as ser::Serializer>::Error;
 
-        type SerializeSeq = Override<
+        type SerializeSeq = $crate::ser::Override<
             <$inner as ser::Serializer>::SerializeSeq,
             ValueBehavior,
         >;
 
-        type SerializeTuple = Override<
+        type SerializeTuple = $crate::ser::Override<
             <$inner as ser::Serializer>::SerializeTuple,
             ValueBehavior,
         >;
 
-        type SerializeTupleStruct = Override<
+        type SerializeTupleStruct = $crate::ser::Override<
             <$inner as ser::Serializer>::SerializeTupleStruct,
             ValueBehavior,
         >;
 
-        type SerializeTupleVariant = Override<
+        type SerializeTupleVariant = $crate::ser::Override<
             <$inner as ser::Serializer>::SerializeTupleVariant,
             ValueBehavior,
         >;
 
-        type SerializeMap = Override<
+        type SerializeMap = $crate::ser::Override<
             <$inner as ser::Serializer>::SerializeMap,
             ValueBehavior,
         >;
 
-        type SerializeStruct = Override<
+        type SerializeStruct = $crate::ser::Override<
             <$inner as ser::Serializer>::SerializeStruct,
             ValueBehavior,
         >;
 
-        type SerializeStructVariant = Override<
+        type SerializeStructVariant = $crate::ser::Override<
             <$inner as ser::Serializer>::SerializeStructVariant,
             ValueBehavior,
         >;

--- a/conjure-serde/src/smile/de/client.rs
+++ b/conjure-serde/src/smile/de/client.rs
@@ -1,0 +1,108 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::de::Behavior;
+use crate::json::de::client::KeyBehavior;
+use serde::de;
+use serde_smile::de::{IoRead, MutSliceRead, Read, SliceRead};
+use serde_smile::Error;
+use std::io::BufRead;
+
+/// Deserializes a value from a reader of Smile data.
+pub fn client_from_reader<R, T>(reader: R) -> Result<T, Error>
+where
+    R: BufRead,
+    T: de::DeserializeOwned,
+{
+    let mut de = ClientDeserializer::from_reader(reader)?;
+    let value = T::deserialize(&mut de)?;
+    de.end()?;
+    Ok(value)
+}
+
+/// Deserializes a value from a slice of Smile data.
+pub fn client_from_slice<'a, T>(s: &'a [u8]) -> Result<T, Error>
+where
+    T: de::Deserialize<'a>,
+{
+    let mut de = ClientDeserializer::from_slice(s)?;
+    let value = T::deserialize(&mut de)?;
+    de.end()?;
+    Ok(value)
+}
+
+/// Deserializes a value from a mutable slice of Smile data.
+pub fn client_from_mut_slice<'a, T>(s: &'a mut [u8]) -> Result<T, Error>
+where
+    T: de::Deserialize<'a>,
+{
+    let mut de = ClientDeserializer::from_mut_slice(s)?;
+    let value = T::deserialize(&mut de)?;
+    de.end()?;
+    Ok(value)
+}
+
+/// A serde Smile deserializer appropriate for use by Conjure clients.
+pub struct ClientDeserializer<'de, R>(serde_smile::Deserializer<'de, R>);
+
+impl<'de, R> ClientDeserializer<'de, IoRead<R>>
+where
+    R: BufRead,
+{
+    /// Creates a Conjure Smile client deserializer from an `io::Read`.
+    pub fn from_reader(reader: R) -> Result<Self, Error> {
+        serde_smile::Deserializer::from_reader(reader).map(ClientDeserializer)
+    }
+}
+
+impl<'a> ClientDeserializer<'a, SliceRead<'a>> {
+    /// Creates a Conjure Smile client deserializer from a `&[u8]`.
+    pub fn from_slice(bytes: &'a [u8]) -> Result<Self, Error> {
+        serde_smile::Deserializer::from_slice(bytes).map(ClientDeserializer)
+    }
+}
+
+impl<'a> ClientDeserializer<'a, MutSliceRead<'a>> {
+    /// Creates a Conjure Smile client deserializer from a `&mut [u8]`.
+    pub fn from_mut_slice(bytes: &'a mut [u8]) -> Result<Self, Error> {
+        serde_smile::Deserializer::from_mut_slice(bytes).map(ClientDeserializer)
+    }
+}
+
+impl<'de, R> ClientDeserializer<'de, R>
+where
+    R: Read<'de>,
+{
+    /// Validates that the input stream is at the end or the Smile end of stream token.
+    pub fn end(&mut self) -> Result<(), Error> {
+        self.0.end()
+    }
+}
+
+impl<'a, 'de, R> de::Deserializer<'de> for &'a mut ClientDeserializer<'de, R>
+where
+    R: Read<'de>,
+{
+    impl_deserialize_body!(&'a mut serde_smile::Deserializer<'de, R>, ValueBehavior);
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+pub enum ValueBehavior {}
+
+impl Behavior for ValueBehavior {
+    // Smile uses the same key behavior as JSON
+    type KeyBehavior = KeyBehavior;
+}

--- a/conjure-serde/src/smile/de/mod.rs
+++ b/conjure-serde/src/smile/de/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pub mod client;
+pub mod server;

--- a/conjure-serde/src/smile/de/server.rs
+++ b/conjure-serde/src/smile/de/server.rs
@@ -1,0 +1,104 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::de::unknown_fields_behavior::UnknownFieldsBehavior;
+use crate::smile::de::client::ValueBehavior;
+use serde::de;
+use serde_smile::de::{IoRead, MutSliceRead, Read, SliceRead};
+use serde_smile::Error;
+use std::io::BufRead;
+
+/// Deserializes a value from a reader of Smile data.
+pub fn server_from_reader<R, T>(reader: R) -> Result<T, Error>
+where
+    R: BufRead,
+    T: de::DeserializeOwned,
+{
+    let mut de = ServerDeserializer::from_reader(reader)?;
+    let value = T::deserialize(&mut de)?;
+    de.end()?;
+    Ok(value)
+}
+
+/// Deserializes a value from a slice of Smile data.
+pub fn server_from_slice<'a, T>(s: &'a [u8]) -> Result<T, Error>
+where
+    T: de::Deserialize<'a>,
+{
+    let mut de = ServerDeserializer::from_slice(s)?;
+    let value = T::deserialize(&mut de)?;
+    de.end()?;
+    Ok(value)
+}
+
+/// Deserializes a value from a mutable slice of Smile data.
+pub fn server_from_mut_slice<'a, T>(s: &'a mut [u8]) -> Result<T, Error>
+where
+    T: de::Deserialize<'a>,
+{
+    let mut de = ServerDeserializer::from_mut_slice(s)?;
+    let value = T::deserialize(&mut de)?;
+    de.end()?;
+    Ok(value)
+}
+
+/// A serde Smile deserializer appropriate for use by Conjure servers.
+pub struct ServerDeserializer<'de, R>(serde_smile::Deserializer<'de, R>);
+
+impl<'de, R> ServerDeserializer<'de, IoRead<R>>
+where
+    R: BufRead,
+{
+    /// Creates a Conjure Smile server deserializer from an `io::Read`.
+    pub fn from_reader(reader: R) -> Result<Self, Error> {
+        serde_smile::Deserializer::from_reader(reader).map(ServerDeserializer)
+    }
+}
+
+impl<'a> ServerDeserializer<'a, SliceRead<'a>> {
+    /// Creates a Conjure Smile server deserializer from a `&[u8]`.
+    pub fn from_slice(bytes: &'a [u8]) -> Result<Self, Error> {
+        serde_smile::Deserializer::from_slice(bytes).map(ServerDeserializer)
+    }
+}
+
+impl<'a> ServerDeserializer<'a, MutSliceRead<'a>> {
+    /// Creates a Conjure Smile server deserializer from a `&mut [u8]`.
+    pub fn from_mut_slice(bytes: &'a mut [u8]) -> Result<Self, Error> {
+        serde_smile::Deserializer::from_mut_slice(bytes).map(ServerDeserializer)
+    }
+}
+
+impl<'de, R> ServerDeserializer<'de, R>
+where
+    R: Read<'de>,
+{
+    /// Validates that the input stream is at the end or the Smile end of stream token.
+    pub fn end(&mut self) -> Result<(), Error> {
+        self.0.end()
+    }
+}
+
+impl<'a, 'de, R> de::Deserializer<'de> for &'a mut ServerDeserializer<'de, R>
+where
+    R: Read<'de>,
+{
+    impl_deserialize_body!(
+        &'a mut serde_smile::Deserializer<'de, R>,
+        UnknownFieldsBehavior<ValueBehavior>
+    );
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}

--- a/conjure-serde/src/smile/mod.rs
+++ b/conjure-serde/src/smile/mod.rs
@@ -1,0 +1,35 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Smile serialization support.
+//!
+//! Conjure specifies behavior that differs from serde-smile's in a couple of ways:
+//!
+//! * serde-smile does not support binary, floating point, or boolean keys, while Conjure does.
+//!
+//! Additionally, Conjure clients should ignore unknown fields while Conjure servers should trigger errors.
+//!
+//! This module provides `Serializer` and `Deserializer` implementations which wrap serde-smile's and handle these
+//! special behaviors.
+pub use crate::smile::de::client::{
+    client_from_mut_slice, client_from_reader, client_from_slice, ClientDeserializer,
+};
+pub use crate::smile::de::server::{
+    server_from_mut_slice, server_from_reader, server_from_slice, ServerDeserializer,
+};
+pub use crate::smile::ser::{to_vec, to_writer, Serializer};
+
+mod de;
+mod ser;
+#[cfg(test)]
+mod test;

--- a/conjure-serde/src/smile/ser.rs
+++ b/conjure-serde/src/smile/ser.rs
@@ -1,0 +1,74 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use crate::json::ser::KeyBehavior;
+use crate::ser::Behavior;
+use serde::ser;
+use serde_smile::Error;
+use std::io::Write;
+
+/// Serializes a value as Smile into a byte buffer.
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>, Error>
+where
+    T: ?Sized + ser::Serialize,
+{
+    let mut buf = Vec::with_capacity(128);
+    let mut ser = Serializer::new(&mut buf)?;
+    value.serialize(&mut ser)?;
+    Ok(buf)
+}
+
+/// Serializes a value as Smile into a writer.
+pub fn to_writer<W, T>(writer: W, value: &T) -> Result<(), Error>
+where
+    W: Write,
+    T: ?Sized + ser::Serialize,
+{
+    let mut ser = Serializer::new(writer)?;
+    value.serialize(&mut ser)?;
+    Ok(())
+}
+
+/// A serde Smile serializer compatible with the Conjure specification.
+pub struct Serializer<W>(serde_smile::Serializer<W>);
+
+impl<W> Serializer<W>
+where
+    W: Write,
+{
+    /// Creates a new Conjure Smile serializer.
+    pub fn new(writer: W) -> Result<Serializer<W>, Error> {
+        serde_smile::Serializer::builder()
+            .raw_binary(true)
+            .build(writer)
+            .map(Serializer)
+    }
+}
+
+impl<'a, W> ser::Serializer for &'a mut Serializer<W>
+where
+    W: Write,
+{
+    impl_serialize_body!(&'a mut serde_smile::Serializer<W>, ValueBehavior);
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+pub enum ValueBehavior {}
+
+impl Behavior for ValueBehavior {
+    // Smile uses the same key behavior as JSON
+    type KeyBehavior = KeyBehavior;
+}

--- a/conjure-serde/src/smile/test.rs
+++ b/conjure-serde/src/smile/test.rs
@@ -1,0 +1,131 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use conjure_object::DoubleKey;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+fn serialize<T>(value: &T) -> Vec<u8>
+where
+    T: Serialize,
+{
+    crate::smile::to_vec(value).unwrap()
+}
+
+fn deserialize_client<T>(smile: &[u8]) -> T
+where
+    T: DeserializeOwned,
+{
+    crate::smile::client_from_slice(smile).unwrap()
+}
+
+fn deserialize_server<T>(smile: &[u8]) -> T
+where
+    T: DeserializeOwned,
+{
+    crate::smile::server_from_slice(smile).unwrap()
+}
+
+fn test_ser<T>(ty: &T, expected_smile: &[u8])
+where
+    T: Serialize,
+{
+    let actual_smile = serialize(ty);
+    let expected_value =
+        serde_smile::from_slice::<serde_smile::value::Value>(expected_smile).unwrap();
+    let actual_value = serde_smile::from_slice::<serde_smile::value::Value>(&actual_smile).unwrap();
+
+    assert_eq!(expected_value, actual_value);
+}
+
+fn test_de<T>(ty: &T, smile: &[u8])
+where
+    T: DeserializeOwned + PartialEq + Debug,
+{
+    let deserialized = deserialize_client(smile);
+    assert_eq!(*ty, deserialized);
+
+    let deserialized = deserialize_server(smile);
+    assert_eq!(*ty, deserialized);
+}
+
+fn test_serde<T>(ty: &T, expected_smile: &[u8])
+where
+    T: Serialize + DeserializeOwned + PartialEq + Debug,
+{
+    test_ser(ty, expected_smile);
+    test_de(ty, expected_smile);
+}
+
+#[test]
+fn binary_serde() {
+    test_serde(
+        &ByteBuf::from(b"foobar".to_vec()),
+        b":)\n\x05\xfd\x86foobar",
+    );
+}
+
+#[test]
+fn binary_keys() {
+    test_serde(
+        &BTreeMap::from([(ByteBuf::from(b"foobar".to_vec()), 0)]),
+        b":)\n\x05\xfa\x87Zm9vYmFy\xc0\xfb",
+    )
+}
+
+#[test]
+fn boolean_keys() {
+    test_serde(
+        &BTreeMap::from([(false, 0), (true, 1)]),
+        b":)\n\x05\xfa\x84false\xc0\x83true\xc2\xfb",
+    );
+}
+
+#[test]
+fn double_keys() {
+    test_serde(
+        &BTreeMap::from([
+            (DoubleKey(f64::NEG_INFINITY), 0),
+            (DoubleKey(-1.5), 1),
+            (DoubleKey(1.5), 2),
+            (DoubleKey(f64::INFINITY), 3),
+            (DoubleKey(f64::NAN), 4),
+        ]),
+        b":)\n\x05\xfa\x88-Infinity\xc0\x83-1.5\xc2\x821.5\xc4\x87Infinity\xc6\x82NaN\xc8\xfb",
+    )
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Foo {
+    foo: i32,
+}
+
+#[test]
+fn client_unknown_fields() {
+    let deserialized = deserialize_client::<Foo>(b":)\n\x05\xfa\x82foo\xc2\x84bogusDhello\xfb");
+    assert_eq!(Foo { foo: 1 }, deserialized);
+}
+
+#[test]
+fn server_unknown_fields() {
+    let smile = b":)\n\x05\xfa\x82foo\xc2\x84bogusDhello\xfb";
+
+    let e = crate::smile::server_from_slice::<Foo>(smile).err().unwrap();
+
+    assert!(e.to_string().contains("foo"));
+    assert!(e.to_string().contains("bogus"));
+}


### PR DESCRIPTION
The SMILE encoding is now specced out in Conjure (https://github.com/palantir/conjure/pull/957). This PR adds support in conjure-serde. Actually supporting SMILE over the wire will require changes to `Any` and conjure-http, but those will be handled in follow-ups.

This also includes some documentation and test fix-ups for the JSON side of things I noticed while working on this.