### PR TITLE
Use prettyplease for code formatting

### DIFF
--- a/changelog/@unreleased/pr-199.v2.yml
+++ b/changelog/@unreleased/pr-199.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Code generation now uses the `prettyplease` library for formatting
+    generated code rather than running `rustfmt`.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/199

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = ["quote/proc-macro", "proc-macro2/proc-macro"]
 [dependencies]
 heck = "0.4"
 quote = { version = "1.0", default-features = false }
-prettyplease = "0.1"
+prettyplease = "0.1.11"
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 toml = "0.5"

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -18,10 +18,12 @@ proc-macro = ["quote/proc-macro", "proc-macro2/proc-macro"]
 [dependencies]
 heck = "0.4"
 quote = { version = "1.0", default-features = false }
+prettyplease = "0.1"
 proc-macro2 = { version = "1.0", default-features = false }
 failure = "0.1"
 toml = "0.5"
 serde = { version = "1", features = ["derive"] }
+syn = "1"
 
 conjure-object = { version = "1.1.0", path = "../conjure-object" }
 conjure-serde = { version = "1.1.0", path = "../conjure-serde" }

--- a/conjure-codegen/src/example_types/another/different_package.rs
+++ b/conjure-codegen/src/example_types/another/different_package.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Different package."]
+///Different package.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct DifferentPackage {}
 impl DifferentPackage {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> DifferentPackage {
         DifferentPackage {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `DifferentPackage` type."]
+///A builder for the `DifferentPackage` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> DifferentPackage {
         DifferentPackage {}

--- a/conjure-codegen/src/example_types/another/mod.rs
+++ b/conjure-codegen/src/example_types/another/mod.rs
@@ -2,7 +2,8 @@
 pub use self::different_package::DifferentPackage;
 #[doc(inline)]
 pub use self::test_service::{
-    AsyncTestService, TestService, TestServiceAsyncClient, TestServiceClient, TestServiceEndpoints,
+    TestServiceClient, TestServiceAsyncClient, TestService, AsyncTestService,
+    TestServiceEndpoints,
 };
 pub mod different_package;
 pub mod test_service;

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1,4 +1,4 @@
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 #[derive(Clone, Debug)]
 pub struct TestServiceAsyncClient<T>(T);
 impl<T> conjure_http::client::AsyncService<T> for TestServiceAsyncClient<T>
@@ -13,14 +13,17 @@ impl<T> TestServiceAsyncClient<T>
 where
     T: conjure_http::client::AsyncClient,
 {
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     pub async fn get_file_systems(
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    > {
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -30,14 +33,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getFileSystems",
-                "/catalog/fileSystems",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getFileSystems",
+                    "/catalog/fileSystems",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn create_dataset(
         &self,
@@ -45,22 +51,30 @@ where
         request: &super::super::product::CreateDatasetRequest,
         test_header_arg: &str,
     ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&request);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &request,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets");
         *request_.uri_mut() = path_.build();
         conjure_http::private::encode_header_auth(&mut request_, auth_);
-        conjure_http::private::encode_header(&mut request_, "test-header", &test_header_arg)?;
+        conjure_http::private::encode_header(
+            &mut request_,
+            "test-header",
+            &test_header_arg,
+        )?;
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "createDataset",
-                "/catalog/datasets",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "createDataset",
+                    "/catalog/datasets",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -68,8 +82,10 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
-    {
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -80,14 +96,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getDataset",
-                "/catalog/datasets/{datasetRid}",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getDataset",
+                    "/catalog/datasets/{datasetRid}",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn get_raw_data(
         &self,
@@ -105,12 +124,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getRawData",
-                "/catalog/datasets/{datasetRid}/raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getRawData",
+                    "/catalog/datasets/{datasetRid}/raw",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -130,12 +151,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getAliasedRawData",
-                "/catalog/datasets/{datasetRid}/raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getAliasedRawData",
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -155,12 +178,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "maybeGetRawData",
-                "/catalog/datasets/{datasetRid}/raw-maybe",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "maybeGetRawData",
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::decode_optional_binary_response(response_)
     }
@@ -180,12 +205,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getAliasedString",
-                "/catalog/datasets/{datasetRid}/string-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getAliasedString",
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -198,7 +225,9 @@ where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
         conjure_http::private::pin_mut!(input);
-        let mut request_ = conjure_http::private::async_encode_binary_request(input as _);
+        let mut request_ = conjure_http::private::async_encode_binary_request(
+            input as _,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw");
@@ -207,12 +236,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "uploadRawData",
-                "/catalog/datasets/upload-raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "uploadRawData",
+                    "/catalog/datasets/upload-raw",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
@@ -225,7 +256,9 @@ where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
         conjure_http::private::pin_mut!(input);
-        let mut request_ = conjure_http::private::async_encode_binary_request(input as _);
+        let mut request_ = conjure_http::private::async_encode_binary_request(
+            input as _,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw-aliased");
@@ -234,12 +267,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "uploadAliasedRawData",
-                "/catalog/datasets/upload-raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "uploadAliasedRawData",
+                    "/catalog/datasets/upload-raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
@@ -259,16 +294,19 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getBranches",
-                "/catalog/datasets/{datasetRid}/branches",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getBranches",
+                    "/catalog/datasets/{datasetRid}/branches",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     #[deprecated(note = "use getBranches instead")]
     pub async fn get_branches_deprecated(
         &self,
@@ -286,14 +324,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getBranchesDeprecated",
-                "/catalog/datasets/{datasetRid}/branchesDeprecated",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getBranchesDeprecated",
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn resolve_branch(
         &self,
@@ -314,14 +355,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "resolveBranch",
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "resolveBranch",
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn test_param(
         &self,
@@ -339,14 +383,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testParam",
-                "/catalog/datasets/{datasetRid}/testParam",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testParam",
+                    "/catalog/datasets/{datasetRid}/testParam",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn test_query_params(
         &self,
@@ -358,7 +405,9 @@ where
         set_end: &std::collections::BTreeSet<String>,
         optional_end: Option<&conjure_object::ResourceIdentifier>,
     ) -> Result<i32, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&query);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &query,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/test-query-params");
@@ -372,12 +421,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testQueryParams",
-                "/catalog/test-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testQueryParams",
+                    "/catalog/test-query-params",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -391,7 +442,9 @@ where
         set_end: &std::collections::BTreeSet<String>,
         optional_end: Option<&conjure_object::ResourceIdentifier>,
     ) -> Result<(), conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&query);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &query,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/test-no-response-query-params");
@@ -405,12 +458,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testNoResponseQueryParams",
-                "/catalog/test-no-response-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testNoResponseQueryParams",
+                    "/catalog/test-no-response-query-params",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
@@ -427,12 +482,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testBoolean",
-                "/catalog/boolean",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testBoolean",
+                    "/catalog/boolean",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -449,12 +506,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testDouble",
-                "/catalog/double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testDouble",
+                    "/catalog/double",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -471,12 +530,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testInteger",
-                "/catalog/integer",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testInteger",
+                    "/catalog/integer",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -485,7 +546,9 @@ where
         auth_: &conjure_object::BearerToken,
         maybe_string: Option<&str>,
     ) -> Result<Option<String>, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&maybe_string);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &maybe_string,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/optional");
@@ -494,14 +557,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testPostOptional",
-                "/catalog/optional",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testPostOptional",
+                    "/catalog/optional",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn test_optional_integer_and_double(
         &self,
@@ -520,17 +586,19 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testOptionalIntegerAndDouble",
-                "/catalog/optional-integer-double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testOptionalIntegerAndDouble",
+                    "/catalog/optional-integer-double",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
 }
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 #[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
 impl<T> conjure_http::client::Service<T> for TestServiceClient<T>
@@ -545,14 +613,17 @@ impl<T> TestServiceClient<T>
 where
     T: conjure_http::client::Client,
 {
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     pub fn get_file_systems(
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    > {
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -562,12 +633,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getFileSystems",
-                "/catalog/fileSystems",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getFileSystems",
+                    "/catalog/fileSystems",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -583,16 +656,22 @@ where
         path_.push_literal("/catalog/datasets");
         *request_.uri_mut() = path_.build();
         conjure_http::private::encode_header_auth(&mut request_, auth_);
-        conjure_http::private::encode_header(&mut request_, "test-header", &test_header_arg)?;
+        conjure_http::private::encode_header(
+            &mut request_,
+            "test-header",
+            &test_header_arg,
+        )?;
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "createDataset",
-                "/catalog/datasets",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "createDataset",
+                    "/catalog/datasets",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -600,8 +679,10 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
-    {
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -612,12 +693,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getDataset",
-                "/catalog/datasets/{datasetRid}",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getDataset",
+                    "/catalog/datasets/{datasetRid}",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -637,12 +720,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getRawData",
-                "/catalog/datasets/{datasetRid}/raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getRawData",
+                    "/catalog/datasets/{datasetRid}/raw",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -662,12 +747,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getAliasedRawData",
-                "/catalog/datasets/{datasetRid}/raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getAliasedRawData",
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -687,12 +774,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "maybeGetRawData",
-                "/catalog/datasets/{datasetRid}/raw-maybe",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "maybeGetRawData",
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_optional_binary_response(response_)
     }
@@ -712,12 +801,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getAliasedString",
-                "/catalog/datasets/{datasetRid}/string-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getAliasedString",
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -739,12 +830,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "uploadRawData",
-                "/catalog/datasets/upload-raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "uploadRawData",
+                    "/catalog/datasets/upload-raw",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
@@ -766,12 +859,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "uploadAliasedRawData",
-                "/catalog/datasets/upload-raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "uploadAliasedRawData",
+                    "/catalog/datasets/upload-raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
@@ -791,16 +886,18 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getBranches",
-                "/catalog/datasets/{datasetRid}/branches",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getBranches",
+                    "/catalog/datasets/{datasetRid}/branches",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     #[deprecated(note = "use getBranches instead")]
     pub fn get_branches_deprecated(
         &self,
@@ -818,12 +915,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "getBranchesDeprecated",
-                "/catalog/datasets/{datasetRid}/branchesDeprecated",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "getBranchesDeprecated",
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -846,12 +945,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "resolveBranch",
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "resolveBranch",
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -871,12 +972,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testParam",
-                "/catalog/datasets/{datasetRid}/testParam",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testParam",
+                    "/catalog/datasets/{datasetRid}/testParam",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -904,12 +1007,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testQueryParams",
-                "/catalog/test-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testQueryParams",
+                    "/catalog/test-query-params",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -937,12 +1042,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testNoResponseQueryParams",
-                "/catalog/test-no-response-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testNoResponseQueryParams",
+                    "/catalog/test-no-response-query-params",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
@@ -959,12 +1066,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testBoolean",
-                "/catalog/boolean",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testBoolean",
+                    "/catalog/boolean",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -981,12 +1090,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testDouble",
-                "/catalog/double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testDouble",
+                    "/catalog/double",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -1003,12 +1114,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testInteger",
-                "/catalog/integer",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testInteger",
+                    "/catalog/integer",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -1017,7 +1130,9 @@ where
         auth_: &conjure_object::BearerToken,
         maybe_string: Option<&str>,
     ) -> Result<Option<String>, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::encode_serializable_request(&maybe_string);
+        let mut request_ = conjure_http::private::encode_serializable_request(
+            &maybe_string,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/optional");
@@ -1026,12 +1141,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testPostOptional",
-                "/catalog/optional",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testPostOptional",
+                    "/catalog/optional",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -1052,32 +1169,37 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::None,
-                "testOptionalIntegerAndDouble",
-                "/catalog/optional-integer-double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::None,
+                    "testOptionalIntegerAndDouble",
+                    "/catalog/optional-integer-double",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
 }
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 pub trait TestService<I, O> {
-    #[doc = "The body type returned by the `get_raw_data` method."]
+    ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
-    #[doc = "The body type returned by the `get_aliased_raw_data` method."]
+    ///The body type returned by the `get_aliased_raw_data` method.
     type GetAliasedRawDataBody: conjure_http::server::WriteBody<O> + 'static;
-    #[doc = "The body type returned by the `maybe_get_raw_data` method."]
+    ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     fn get_file_systems(
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    >;
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        >;
     fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1088,7 +1210,10 @@ pub trait TestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>;
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        >;
     fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1124,7 +1249,7 @@ pub trait TestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     fn get_branches_deprecated(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1185,23 +1310,26 @@ pub trait TestService<I, O> {
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error>;
 }
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 #[conjure_http::private::async_trait]
 pub trait AsyncTestService<I, O> {
-    #[doc = "The body type returned by the `get_raw_data` method."]
+    ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
-    #[doc = "The body type returned by the `get_aliased_raw_data` method."]
+    ///The body type returned by the `get_aliased_raw_data` method.
     type GetAliasedRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
-    #[doc = "The body type returned by the `maybe_get_raw_data` method."]
+    ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     async fn get_file_systems(
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    >;
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        >;
     async fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1212,7 +1340,10 @@ pub trait AsyncTestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>;
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        >;
     async fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1248,7 +1379,7 @@ pub trait AsyncTestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     async fn get_branches_deprecated(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1311,7 +1442,7 @@ pub trait AsyncTestService<I, O> {
 }
 pub struct TestServiceEndpoints<T>(conjure_http::private::Arc<T>);
 impl<T> TestServiceEndpoints<T> {
-    #[doc = r" Creates a new resource."]
+    /// Creates a new resource.
     pub fn new(handler: T) -> TestServiceEndpoints<T> {
         TestServiceEndpoints(conjure_http::private::Arc::new(handler))
     }
@@ -1319,9 +1450,13 @@ impl<T> TestServiceEndpoints<T> {
 impl<T, I, O> conjure_http::server::Service<I, O> for TestServiceEndpoints<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
-    fn endpoints(&self) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
+    fn endpoints(
+        &self,
+    ) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),
             Box::new(CreateDatasetEndpoint_(self.0.clone())),
@@ -1351,10 +1486,11 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
-    fn endpoints(&self) -> Vec<Box<dyn conjure_http::server::AsyncEndpoint<I, O> + Sync + Send>> {
+    fn endpoints(
+        &self,
+    ) -> Vec<Box<dyn conjure_http::server::AsyncEndpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),
             Box::new(CreateDatasetEndpoint_(self.0.clone())),
@@ -1386,12 +1522,12 @@ impl<T> conjure_http::server::EndpointMetadata for GetFileSystemsEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "fileSystems",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("fileSystems"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1410,23 +1546,23 @@ impl<T> conjure_http::server::EndpointMetadata for GetFileSystemsEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetFileSystemsEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_file_systems(auth_)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1435,17 +1571,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -1463,12 +1598,12 @@ impl<T> conjure_http::server::EndpointMetadata for CreateDatasetEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1487,25 +1622,31 @@ impl<T> conjure_http::server::EndpointMetadata for CreateDatasetEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for CreateDatasetEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
-        let request = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let test_header_arg =
-            conjure_http::private::parse_required_header(&parts_, "testHeaderArg", "Test-Header")?;
+        let request = conjure_http::private::decode_serializable_request(
+            &parts_,
+            body_,
+        )?;
+        let test_header_arg = conjure_http::private::parse_required_header(
+            &parts_,
+            "testHeaderArg",
+            "Test-Header",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.create_dataset(auth_, request, test_header_arg)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1514,33 +1655,33 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
-        let request =
-            conjure_http::private::async_decode_serializable_request(&parts_, body_).await?;
-        let test_header_arg =
-            conjure_http::private::parse_required_header(&parts_, "testHeaderArg", "Test-Header")?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self
-            .0
-            .create_dataset(auth_, request, test_header_arg)
+        let request = conjure_http::private::async_decode_serializable_request(
+                &parts_,
+                body_,
+            )
             .await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        let test_header_arg = conjure_http::private::parse_required_header(
+            &parts_,
+            "testHeaderArg",
+            "Test-Header",
+        )?;
+        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
+        let response_ = self.0.create_dataset(auth_, request, test_header_arg).await?;
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct GetDatasetEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1550,12 +1691,12 @@ impl<T> conjure_http::server::EndpointMetadata for GetDatasetEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
@@ -1578,24 +1719,27 @@ impl<T> conjure_http::server::EndpointMetadata for GetDatasetEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetDatasetEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_dataset(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1604,23 +1748,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_dataset(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -1633,17 +1779,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetRawDataEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed("raw")),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("raw"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1662,19 +1810,24 @@ impl<T> conjure_http::server::EndpointMetadata for GetRawDataEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_raw_data(auth_, dataset_rid)?;
         Ok(conjure_http::private::encode_binary_response(response_))
@@ -1686,28 +1839,28 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(
-            response_,
-        ))
+        Ok(conjure_http::private::async_encode_binary_response(response_))
     }
 }
 struct GetAliasedRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1717,19 +1870,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedRawDataEndpoint_<T>
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "raw-aliased",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("raw-aliased"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1748,19 +1901,24 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedRawDataEndpoint_<T>
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid)?;
         Ok(conjure_http::private::encode_binary_response(response_))
@@ -1772,28 +1930,28 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(
-            response_,
-        ))
+        Ok(conjure_http::private::async_encode_binary_response(response_))
     }
 }
 struct MaybeGetRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1803,19 +1961,19 @@ impl<T> conjure_http::server::EndpointMetadata for MaybeGetRawDataEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "raw-maybe",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("raw-maybe"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1834,24 +1992,27 @@ impl<T> conjure_http::server::EndpointMetadata for MaybeGetRawDataEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for MaybeGetRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_optional_binary_response(
-            response_,
-        ))
+        Ok(conjure_http::private::encode_optional_binary_response(response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1860,23 +2021,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_optional_binary_response(response_))
@@ -1889,19 +2052,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedStringEndpoint_<T> 
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "string-aliased",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("string-aliased"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1920,24 +2083,27 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedStringEndpoint_<T> 
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedStringEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_string(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1946,28 +2112,28 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_string(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct UploadRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1977,15 +2143,15 @@ impl<T> conjure_http::server::EndpointMetadata for UploadRawDataEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "upload-raw",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("upload-raw"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2004,16 +2170,18 @@ impl<T> conjure_http::server::EndpointMetadata for UploadRawDataEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2027,17 +2195,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2055,15 +2222,15 @@ impl<T> conjure_http::server::EndpointMetadata for UploadAliasedRawDataEndpoint_
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "upload-raw-aliased",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("upload-raw-aliased"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2082,16 +2249,18 @@ impl<T> conjure_http::server::EndpointMetadata for UploadAliasedRawDataEndpoint_
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadAliasedRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2100,22 +2269,22 @@ where
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for UploadAliasedRawDataEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for UploadAliasedRawDataEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2133,19 +2302,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "branches",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("branches"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2164,24 +2333,27 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2190,23 +2362,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -2219,19 +2393,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesDeprecatedEndpoint
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "branchesDeprecated",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("branchesDeprecated"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2250,49 +2424,55 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesDeprecatedEndpoint
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesDeprecatedEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches_deprecated(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetBranchesDeprecatedEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for GetBranchesDeprecatedEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches_deprecated(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -2305,26 +2485,26 @@ impl<T> conjure_http::server::EndpointMetadata for ResolveBranchEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "branches",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("branches"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("branch"),
                 regex: Some(conjure_http::private::Cow::Borrowed(".+")),
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "resolve",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("resolve"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2343,25 +2523,28 @@ impl<T> conjure_http::server::EndpointMetadata for ResolveBranchEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for ResolveBranchEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.resolve_branch(auth_, dataset_rid, branch)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2370,23 +2553,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.resolve_branch(auth_, dataset_rid, branch).await?;
@@ -2400,19 +2585,19 @@ impl<T> conjure_http::server::EndpointMetadata for TestParamEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "testParam",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("testParam"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2431,24 +2616,27 @@ impl<T> conjure_http::server::EndpointMetadata for TestParamEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestParamEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_param(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2457,23 +2645,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_param(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -2486,12 +2676,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestQueryParamsEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "test-query-params",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("test-query-params"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2510,21 +2700,26 @@ impl<T> conjure_http::server::EndpointMetadata for TestQueryParamsEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestQueryParamsEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2532,8 +2727,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2549,18 +2747,18 @@ where
             &mut optional_end,
         )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.test_query_params(
-            auth_,
-            query,
-            something,
-            optional_middle,
-            implicit,
-            set_end,
-            optional_end,
-        )?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        let response_ = self
+            .0
+            .test_query_params(
+                auth_,
+                query,
+                something,
+                optional_middle,
+                implicit,
+                set_end,
+                optional_end,
+            )?;
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2569,26 +2767,31 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query =
-            conjure_http::private::async_decode_serializable_request(&parts_, body_).await?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let query = conjure_http::private::async_decode_serializable_request(
+                &parts_,
+                body_,
+            )
+            .await?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2596,8 +2799,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2625,24 +2831,23 @@ where
                 optional_end,
             )
             .await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestNoResponseQueryParamsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestNoResponseQueryParamsEndpoint_<T> {
+impl<T> conjure_http::server::EndpointMetadata
+for TestNoResponseQueryParamsEndpoint_<T> {
     fn method(&self) -> conjure_http::private::Method {
         conjure_http::private::Method::POST
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "test-no-response-query-params",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("test-no-response-query-params"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2658,24 +2863,30 @@ impl<T> conjure_http::server::EndpointMetadata for TestNoResponseQueryParamsEndp
         None
     }
 }
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestNoResponseQueryParamsEndpoint_<T>
+impl<T, I, O> conjure_http::server::Endpoint<I, O>
+for TestNoResponseQueryParamsEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2683,8 +2894,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2700,44 +2914,51 @@ where
             &mut optional_end,
         )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.test_no_response_query_params(
-            auth_,
-            query,
-            something,
-            optional_middle,
-            implicit,
-            set_end,
-            optional_end,
-        )?;
+        self.0
+            .test_no_response_query_params(
+                auth_,
+                query,
+                something,
+                optional_middle,
+                implicit,
+                set_end,
+                optional_end,
+            )?;
         Ok(conjure_http::private::encode_empty_response())
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestNoResponseQueryParamsEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for TestNoResponseQueryParamsEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query =
-            conjure_http::private::async_decode_serializable_request(&parts_, body_).await?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let query = conjure_http::private::async_decode_serializable_request(
+                &parts_,
+                body_,
+            )
+            .await?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2745,8 +2966,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2783,12 +3007,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestBooleanEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "boolean",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("boolean"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2807,23 +3031,23 @@ impl<T> conjure_http::server::EndpointMetadata for TestBooleanEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestBooleanEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_boolean(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2832,17 +3056,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2850,9 +3073,7 @@ where
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_boolean(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -2862,12 +3083,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestDoubleEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "double",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("double"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2886,23 +3107,23 @@ impl<T> conjure_http::server::EndpointMetadata for TestDoubleEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestDoubleEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_double(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2911,17 +3132,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2929,9 +3149,7 @@ where
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_double(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestIntegerEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -2941,12 +3159,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestIntegerEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "integer",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("integer"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2965,23 +3183,23 @@ impl<T> conjure_http::server::EndpointMetadata for TestIntegerEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestIntegerEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_integer(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2990,17 +3208,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -3008,9 +3225,7 @@ where
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_integer(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestPostOptionalEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -3020,12 +3235,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestPostOptionalEndpoint_<T> 
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "optional",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("optional"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -3044,24 +3259,26 @@ impl<T> conjure_http::server::EndpointMetadata for TestPostOptionalEndpoint_<T> 
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestPostOptionalEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
-        let maybe_string =
-            conjure_http::private::decode_optional_serializable_request(&parts_, body_)?;
+        let maybe_string = conjure_http::private::decode_optional_serializable_request(
+            &parts_,
+            body_,
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_post_optional(auth_, maybe_string)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -3070,42 +3287,44 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
-        let maybe_string =
-            conjure_http::private::async_decode_optional_serializable_request(&parts_, body_)
-                .await?;
+        let maybe_string = conjure_http::private::async_decode_optional_serializable_request(
+                &parts_,
+                body_,
+            )
+            .await?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_post_optional(auth_, maybe_string).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
     }
 }
 struct TestOptionalIntegerAndDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestOptionalIntegerAndDoubleEndpoint_<T> {
+impl<T> conjure_http::server::EndpointMetadata
+for TestOptionalIntegerAndDoubleEndpoint_<T> {
     fn method(&self) -> conjure_http::private::Method {
         conjure_http::private::Method::GET
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "optional-integer-double",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("optional-integer-double"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -3121,19 +3340,22 @@ impl<T> conjure_http::server::EndpointMetadata for TestOptionalIntegerAndDoubleE
         None
     }
 }
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestOptionalIntegerAndDoubleEndpoint_<T>
+impl<T, I, O> conjure_http::server::Endpoint<I, O>
+for TestOptionalIntegerAndDoubleEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         conjure_http::private::decode_empty_request(&parts_, body_)?;
@@ -3152,28 +3374,27 @@ where
             &mut maybe_double,
         )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0
-            .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
+        self.0.test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
         Ok(conjure_http::private::encode_empty_response())
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestOptionalIntegerAndDoubleEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for TestOptionalIntegerAndDoubleEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -18,12 +18,12 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        > {
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -83,9 +83,9 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        > {
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -618,12 +618,12 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        > {
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -680,9 +680,9 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        > {
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -1194,12 +1194,12 @@ pub trait TestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        >;
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    >;
     fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1211,9 +1211,9 @@ pub trait TestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        >;
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    >;
     fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1324,12 +1324,12 @@ pub trait AsyncTestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        >;
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    >;
     async fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1341,9 +1341,9 @@ pub trait AsyncTestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        >;
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    >;
     async fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1555,9 +1555,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -1578,9 +1578,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1631,9 +1631,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let request = conjure_http::private::decode_serializable_request(
             &parts_,
@@ -1662,9 +1662,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1728,9 +1728,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -1755,9 +1755,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1819,9 +1819,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -1846,9 +1846,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1910,9 +1910,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -1937,9 +1937,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2001,9 +2001,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2028,9 +2028,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2092,9 +2092,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2119,9 +2119,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2179,9 +2179,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2202,9 +2202,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2258,9 +2258,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2282,9 +2282,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2342,9 +2342,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2369,9 +2369,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2433,9 +2433,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2461,9 +2461,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2532,9 +2532,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2560,9 +2560,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2625,9 +2625,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2652,9 +2652,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2709,9 +2709,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
@@ -2774,9 +2774,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2876,9 +2876,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
@@ -2941,9 +2941,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3040,9 +3040,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -3063,9 +3063,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3116,9 +3116,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -3139,9 +3139,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3192,9 +3192,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -3215,9 +3215,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3268,9 +3268,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let maybe_string = conjure_http::private::decode_optional_serializable_request(
             &parts_,
@@ -3294,9 +3294,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3353,9 +3353,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         conjure_http::private::decode_empty_request(&parts_, body_)?;
@@ -3392,9 +3392,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {

--- a/conjure-codegen/src/example_types/product/alias_as_map_key_example.rs
+++ b/conjure-codegen/src/example_types/product/alias_as_map_key_example.rs
@@ -1,19 +1,33 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct AliasAsMapKeyExample {
-    strings: std::collections::BTreeMap<super::StringAliasExample, super::ManyFieldExample>,
+    strings: std::collections::BTreeMap<
+        super::StringAliasExample,
+        super::ManyFieldExample,
+    >,
     rids: std::collections::BTreeMap<super::RidAliasExample, super::ManyFieldExample>,
-    bearertokens:
-        std::collections::BTreeMap<super::BearerTokenAliasExample, super::ManyFieldExample>,
-    integers: std::collections::BTreeMap<super::IntegerAliasExample, super::ManyFieldExample>,
-    safelongs: std::collections::BTreeMap<super::SafeLongAliasExample, super::ManyFieldExample>,
-    datetimes: std::collections::BTreeMap<super::DateTimeAliasExample, super::ManyFieldExample>,
+    bearertokens: std::collections::BTreeMap<
+        super::BearerTokenAliasExample,
+        super::ManyFieldExample,
+    >,
+    integers: std::collections::BTreeMap<
+        super::IntegerAliasExample,
+        super::ManyFieldExample,
+    >,
+    safelongs: std::collections::BTreeMap<
+        super::SafeLongAliasExample,
+        super::ManyFieldExample,
+    >,
+    datetimes: std::collections::BTreeMap<
+        super::DateTimeAliasExample,
+        super::ManyFieldExample,
+    >,
     uuids: std::collections::BTreeMap<super::UuidAliasExample, super::ManyFieldExample>,
 }
 impl AliasAsMapKeyExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,7 +35,10 @@ impl AliasAsMapKeyExample {
     #[inline]
     pub fn strings(
         &self,
-    ) -> &std::collections::BTreeMap<super::StringAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::StringAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.strings
     }
     #[inline]
@@ -33,25 +50,37 @@ impl AliasAsMapKeyExample {
     #[inline]
     pub fn bearertokens(
         &self,
-    ) -> &std::collections::BTreeMap<super::BearerTokenAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::BearerTokenAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.bearertokens
     }
     #[inline]
     pub fn integers(
         &self,
-    ) -> &std::collections::BTreeMap<super::IntegerAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::IntegerAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.integers
     }
     #[inline]
     pub fn safelongs(
         &self,
-    ) -> &std::collections::BTreeMap<super::SafeLongAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::SafeLongAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.safelongs
     }
     #[inline]
     pub fn datetimes(
         &self,
-    ) -> &std::collections::BTreeMap<super::DateTimeAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::DateTimeAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.datetimes
     }
     #[inline]
@@ -61,16 +90,30 @@ impl AliasAsMapKeyExample {
         &self.uuids
     }
 }
-#[doc = "A builder for the `AliasAsMapKeyExample` type."]
+///A builder for the `AliasAsMapKeyExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
-    strings: std::collections::BTreeMap<super::StringAliasExample, super::ManyFieldExample>,
+    strings: std::collections::BTreeMap<
+        super::StringAliasExample,
+        super::ManyFieldExample,
+    >,
     rids: std::collections::BTreeMap<super::RidAliasExample, super::ManyFieldExample>,
-    bearertokens:
-        std::collections::BTreeMap<super::BearerTokenAliasExample, super::ManyFieldExample>,
-    integers: std::collections::BTreeMap<super::IntegerAliasExample, super::ManyFieldExample>,
-    safelongs: std::collections::BTreeMap<super::SafeLongAliasExample, super::ManyFieldExample>,
-    datetimes: std::collections::BTreeMap<super::DateTimeAliasExample, super::ManyFieldExample>,
+    bearertokens: std::collections::BTreeMap<
+        super::BearerTokenAliasExample,
+        super::ManyFieldExample,
+    >,
+    integers: std::collections::BTreeMap<
+        super::IntegerAliasExample,
+        super::ManyFieldExample,
+    >,
+    safelongs: std::collections::BTreeMap<
+        super::SafeLongAliasExample,
+        super::ManyFieldExample,
+    >,
+    datetimes: std::collections::BTreeMap<
+        super::DateTimeAliasExample,
+        super::ManyFieldExample,
+    >,
     uuids: std::collections::BTreeMap<super::UuidAliasExample, super::ManyFieldExample>,
 }
 impl Builder {
@@ -127,7 +170,9 @@ impl Builder {
     #[inline]
     pub fn bearertokens<T>(&mut self, bearertokens: T) -> &mut Self
     where
-        T: IntoIterator<Item = (super::BearerTokenAliasExample, super::ManyFieldExample)>,
+        T: IntoIterator<
+            Item = (super::BearerTokenAliasExample, super::ManyFieldExample),
+        >,
     {
         self.bearertokens = bearertokens.into_iter().collect();
         self
@@ -135,7 +180,9 @@ impl Builder {
     #[inline]
     pub fn extend_bearertokens<T>(&mut self, bearertokens: T) -> &mut Self
     where
-        T: IntoIterator<Item = (super::BearerTokenAliasExample, super::ManyFieldExample)>,
+        T: IntoIterator<
+            Item = (super::BearerTokenAliasExample, super::ManyFieldExample),
+        >,
     {
         self.bearertokens.extend(bearertokens);
         self
@@ -249,11 +296,11 @@ impl Builder {
         self.uuids.insert(key, value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> AliasAsMapKeyExample {
         AliasAsMapKeyExample {

--- a/conjure-codegen/src/example_types/product/alias_as_map_key_example.rs
+++ b/conjure-codegen/src/example_types/product/alias_as_map_key_example.rs
@@ -36,9 +36,9 @@ impl AliasAsMapKeyExample {
     pub fn strings(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::StringAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::StringAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.strings
     }
     #[inline]
@@ -51,36 +51,36 @@ impl AliasAsMapKeyExample {
     pub fn bearertokens(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::BearerTokenAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::BearerTokenAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.bearertokens
     }
     #[inline]
     pub fn integers(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::IntegerAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::IntegerAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.integers
     }
     #[inline]
     pub fn safelongs(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::SafeLongAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::SafeLongAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.safelongs
     }
     #[inline]
     pub fn datetimes(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::DateTimeAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::DateTimeAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.datetimes
     }
     #[inline]

--- a/conjure-codegen/src/example_types/product/aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/aliased_binary.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct AliasedBinary(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for AliasedBinary {

--- a/conjure-codegen/src/example_types/product/aliased_string.rs
+++ b/conjure-codegen/src/example_types/product/aliased_string.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct AliasedString(pub String);
 impl std::fmt::Display for AliasedString {

--- a/conjure-codegen/src/example_types/product/any_example.rs
+++ b/conjure-codegen/src/example_types/product/any_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct AnyExample {
     any: conjure_object::Any,
 }
 impl AnyExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(any: T) -> AnyExample
     where
@@ -16,7 +16,7 @@ impl AnyExample {
             any: conjure_object::Any::new(any).expect("value failed to serialize"),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,27 +26,30 @@ impl AnyExample {
         &self.any
     }
 }
-#[doc = "A builder for the `AnyExample` type."]
+///A builder for the `AnyExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     any: Option<conjure_object::Any>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn any<T>(&mut self, any: T) -> &mut Self
     where
         T: conjure_object::serde::Serialize,
     {
-        self.any = Some(conjure_object::Any::new(any).expect("value failed to serialize"));
+        self
+            .any = Some(
+            conjure_object::Any::new(any).expect("value failed to serialize"),
+        );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> AnyExample {
         AnyExample {

--- a/conjure-codegen/src/example_types/product/any_map_example.rs
+++ b/conjure-codegen/src/example_types/product/any_map_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct AnyMapExample {
     items: std::collections::BTreeMap<String, conjure_object::Any>,
 }
 impl AnyMapExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(items: T) -> AnyMapExample
     where
@@ -16,7 +16,7 @@ impl AnyMapExample {
             items: items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl AnyMapExample {
         &self.items
     }
 }
-#[doc = "A builder for the `AnyMapExample` type."]
+///A builder for the `AnyMapExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: std::collections::BTreeMap<String, conjure_object::Any>,
@@ -54,17 +54,18 @@ impl Builder {
         K: Into<String>,
         V: conjure_object::serde::Serialize,
     {
-        self.items.insert(
-            key.into(),
-            conjure_object::Any::new(value).expect("value failed to serialize"),
-        );
+        self.items
+            .insert(
+                key.into(),
+                conjure_object::Any::new(value).expect("value failed to serialize"),
+            );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> AnyMapExample {
         AnyMapExample {

--- a/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BearerTokenAliasExample(pub conjure_object::BearerToken);
 impl conjure_object::Plain for BearerTokenAliasExample {

--- a/conjure-codegen/src/example_types/product/bearer_token_example.rs
+++ b/conjure-codegen/src/example_types/product/bearer_token_example.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BearerTokenExample {
     bearer_token_value: conjure_object::BearerToken,
 }
 impl BearerTokenExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(bearer_token_value: conjure_object::BearerToken) -> BearerTokenExample {
         BearerTokenExample {
             bearer_token_value: bearer_token_value,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,14 +23,14 @@ impl BearerTokenExample {
         &self.bearer_token_value
     }
 }
-#[doc = "A builder for the `BearerTokenExample` type."]
+///A builder for the `BearerTokenExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     bearer_token_value: Option<conjure_object::BearerToken>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn bearer_token_value(
         &mut self,
@@ -39,11 +39,11 @@ impl Builder {
         self.bearer_token_value = Some(bearer_token_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BearerTokenExample {
         BearerTokenExample {
@@ -104,7 +104,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             Some(v) => v,
             None => return Err(de::Error::missing_field("bearerTokenValue")),
         };
-        Ok(BearerTokenExample { bearer_token_value })
+        Ok(BearerTokenExample {
+            bearer_token_value,
+        })
     }
 }
 enum Field_ {

--- a/conjure-codegen/src/example_types/product/binary_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct BinaryAliasExample(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for BinaryAliasExample {

--- a/conjure-codegen/src/example_types/product/binary_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BinaryExample {
     binary: conjure_object::ByteBuf,
 }
 impl BinaryExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(binary: T) -> BinaryExample
     where
@@ -16,7 +16,7 @@ impl BinaryExample {
             binary: conjure_object::ByteBuf::from(binary),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,14 +26,14 @@ impl BinaryExample {
         &**self.binary
     }
 }
-#[doc = "A builder for the `BinaryExample` type."]
+///A builder for the `BinaryExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     binary: Option<conjure_object::ByteBuf>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn binary<T>(&mut self, binary: T) -> &mut Self
     where
@@ -42,11 +42,11 @@ impl Builder {
         self.binary = Some(conjure_object::ByteBuf::from(binary));
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BinaryExample {
         BinaryExample {
@@ -57,9 +57,7 @@ impl Builder {
 impl From<BinaryExample> for Builder {
     #[inline]
     fn from(_v: BinaryExample) -> Builder {
-        Builder {
-            binary: Some(_v.binary),
-        }
+        Builder { binary: Some(_v.binary) }
     }
 }
 impl ser::Serialize for BinaryExample {

--- a/conjure-codegen/src/example_types/product/boolean_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/boolean_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
 pub struct BooleanAliasExample(pub bool);
 impl std::fmt::Display for BooleanAliasExample {

--- a/conjure-codegen/src/example_types/product/boolean_example.rs
+++ b/conjure-codegen/src/example_types/product/boolean_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct BooleanExample {
     coin: bool,
 }
 impl BooleanExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(coin: bool) -> BooleanExample {
         BooleanExample { coin: coin }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl BooleanExample {
         self.coin
     }
 }
-#[doc = "A builder for the `BooleanExample` type."]
+///A builder for the `BooleanExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     coin: Option<bool>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn coin(&mut self, coin: bool) -> &mut Self {
         self.coin = Some(coin);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BooleanExample {
         BooleanExample {
@@ -49,9 +49,7 @@ impl Builder {
 impl From<BooleanExample> for Builder {
     #[inline]
     fn from(_v: BooleanExample) -> Builder {
-        Builder {
-            coin: Some(_v.coin),
-        }
+        Builder { coin: Some(_v.coin) }
     }
 }
 impl ser::Serialize for BooleanExample {

--- a/conjure-codegen/src/example_types/product/covariant_list_example.rs
+++ b/conjure-codegen/src/example_types/product/covariant_list_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct CovariantListExample {
@@ -7,7 +7,7 @@ pub struct CovariantListExample {
     external_items: Vec<String>,
 }
 impl CovariantListExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(items: T, external_items: U) -> CovariantListExample
     where
@@ -19,7 +19,7 @@ impl CovariantListExample {
             external_items: external_items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -33,7 +33,7 @@ impl CovariantListExample {
         &*self.external_items
     }
 }
-#[doc = "A builder for the `CovariantListExample` type."]
+///A builder for the `CovariantListExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: Vec<conjure_object::Any>,
@@ -89,11 +89,11 @@ impl Builder {
         self.external_items.push(value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> CovariantListExample {
         CovariantListExample {

--- a/conjure-codegen/src/example_types/product/covariant_optional_example.rs
+++ b/conjure-codegen/src/example_types/product/covariant_optional_example.rs
@@ -1,22 +1,24 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct CovariantOptionalExample {
     item: Option<conjure_object::Any>,
 }
 impl CovariantOptionalExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(item: T) -> CovariantOptionalExample
     where
         T: conjure_object::serde::Serialize,
     {
         CovariantOptionalExample {
-            item: Some(conjure_object::Any::new(item).expect("value failed to serialize")),
+            item: Some(
+                conjure_object::Any::new(item).expect("value failed to serialize"),
+            ),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +28,7 @@ impl CovariantOptionalExample {
         self.item.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `CovariantOptionalExample` type."]
+///A builder for the `CovariantOptionalExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     item: Option<conjure_object::Any>,
@@ -40,11 +42,11 @@ impl Builder {
         self.item = item.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> CovariantOptionalExample {
         CovariantOptionalExample {

--- a/conjure-codegen/src/example_types/product/create_dataset_request.rs
+++ b/conjure-codegen/src/example_types/product/create_dataset_request.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct CreateDatasetRequest {
@@ -7,7 +7,7 @@ pub struct CreateDatasetRequest {
     path: String,
 }
 impl CreateDatasetRequest {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(file_system_id: T, path: U) -> CreateDatasetRequest
     where
@@ -19,7 +19,7 @@ impl CreateDatasetRequest {
             path: path.into(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -33,15 +33,15 @@ impl CreateDatasetRequest {
         &*self.path
     }
 }
-#[doc = "A builder for the `CreateDatasetRequest` type."]
+///A builder for the `CreateDatasetRequest` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     file_system_id: Option<String>,
     path: Option<String>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
     where
@@ -50,8 +50,8 @@ impl Builder {
         self.file_system_id = Some(file_system_id.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn path<T>(&mut self, path: T) -> &mut Self
     where
@@ -60,11 +60,11 @@ impl Builder {
         self.path = Some(path.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> CreateDatasetRequest {
         CreateDatasetRequest {

--- a/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
+++ b/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BackingFileSystem {
@@ -8,9 +8,13 @@ pub struct BackingFileSystem {
     configuration: std::collections::BTreeMap<String, String>,
 }
 impl BackingFileSystem {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
-    pub fn new<T, U, V>(file_system_id: T, base_uri: U, configuration: V) -> BackingFileSystem
+    pub fn new<T, U, V>(
+        file_system_id: T,
+        base_uri: U,
+        configuration: V,
+    ) -> BackingFileSystem
     where
         T: Into<String>,
         U: Into<String>,
@@ -22,12 +26,12 @@ impl BackingFileSystem {
             configuration: configuration.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "The name by which this file system is identified."]
+    ///The name by which this file system is identified.
     #[inline]
     pub fn file_system_id(&self) -> &str {
         &*self.file_system_id
@@ -41,7 +45,7 @@ impl BackingFileSystem {
         &self.configuration
     }
 }
-#[doc = "A builder for the `BackingFileSystem` type."]
+///A builder for the `BackingFileSystem` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     file_system_id: Option<String>,
@@ -49,9 +53,9 @@ pub struct Builder {
     configuration: std::collections::BTreeMap<String, String>,
 }
 impl Builder {
-    #[doc = "The name by which this file system is identified."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///The name by which this file system is identified.
+    ///
+    /// Required.
     #[inline]
     pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
     where
@@ -60,8 +64,8 @@ impl Builder {
         self.file_system_id = Some(file_system_id.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn base_uri<T>(&mut self, base_uri: T) -> &mut Self
     where
@@ -95,11 +99,11 @@ impl Builder {
         self.configuration.insert(key.into(), value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BackingFileSystem {
         BackingFileSystem {

--- a/conjure-codegen/src/example_types/product/datasets/dataset.rs
+++ b/conjure-codegen/src/example_types/product/datasets/dataset.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Dataset {
@@ -7,7 +7,7 @@ pub struct Dataset {
     rid: conjure_object::ResourceIdentifier,
 }
 impl Dataset {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(file_system_id: T, rid: conjure_object::ResourceIdentifier) -> Dataset
     where
@@ -18,7 +18,7 @@ impl Dataset {
             rid: rid,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -27,21 +27,21 @@ impl Dataset {
     pub fn file_system_id(&self) -> &str {
         &*self.file_system_id
     }
-    #[doc = "Uniquely identifies this dataset."]
+    ///Uniquely identifies this dataset.
     #[inline]
     pub fn rid(&self) -> &conjure_object::ResourceIdentifier {
         &self.rid
     }
 }
-#[doc = "A builder for the `Dataset` type."]
+///A builder for the `Dataset` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     file_system_id: Option<String>,
     rid: Option<conjure_object::ResourceIdentifier>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
     where
@@ -50,19 +50,19 @@ impl Builder {
         self.file_system_id = Some(file_system_id.into());
         self
     }
-    #[doc = "Uniquely identifies this dataset."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///Uniquely identifies this dataset.
+    ///
+    /// Required.
     #[inline]
     pub fn rid(&mut self, rid: conjure_object::ResourceIdentifier) -> &mut Self {
         self.rid = Some(rid);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> Dataset {
         Dataset {
@@ -132,10 +132,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             Some(v) => v,
             None => return Err(de::Error::missing_field("rid")),
         };
-        Ok(Dataset {
-            file_system_id,
-            rid,
-        })
+        Ok(Dataset { file_system_id, rid })
     }
 }
 enum Field_ {

--- a/conjure-codegen/src/example_types/product/datasets/mod.rs
+++ b/conjure-codegen/src/example_types/product/datasets/mod.rs
@@ -1,6 +1,6 @@
 #[doc(inline)]
-pub use self::backing_file_system::BackingFileSystem;
-#[doc(inline)]
 pub use self::dataset::Dataset;
-pub mod backing_file_system;
+#[doc(inline)]
+pub use self::backing_file_system::BackingFileSystem;
 pub mod dataset;
+pub mod backing_file_system;

--- a/conjure-codegen/src/example_types/product/date_time_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/date_time_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
 pub struct DateTimeAliasExample(pub conjure_object::DateTime<conjure_object::Utc>);
 impl std::fmt::Display for DateTimeAliasExample {
@@ -12,7 +12,9 @@ impl conjure_object::Plain for DateTimeAliasExample {
     }
 }
 impl conjure_object::FromPlain for DateTimeAliasExample {
-    type Err = <conjure_object::DateTime<conjure_object::Utc> as conjure_object::FromPlain>::Err;
+    type Err = <conjure_object::DateTime<
+        conjure_object::Utc,
+    > as conjure_object::FromPlain>::Err;
     #[inline]
     fn from_plain(s: &str) -> Result<DateTimeAliasExample, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(DateTimeAliasExample)

--- a/conjure-codegen/src/example_types/product/date_time_example.rs
+++ b/conjure-codegen/src/example_types/product/date_time_example.rs
@@ -1,17 +1,21 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct DateTimeExample {
     datetime: conjure_object::DateTime<conjure_object::Utc>,
 }
 impl DateTimeExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
-    pub fn new(datetime: conjure_object::DateTime<conjure_object::Utc>) -> DateTimeExample {
-        DateTimeExample { datetime: datetime }
+    pub fn new(
+        datetime: conjure_object::DateTime<conjure_object::Utc>,
+    ) -> DateTimeExample {
+        DateTimeExample {
+            datetime: datetime,
+        }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,14 +25,14 @@ impl DateTimeExample {
         self.datetime
     }
 }
-#[doc = "A builder for the `DateTimeExample` type."]
+///A builder for the `DateTimeExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     datetime: Option<conjure_object::DateTime<conjure_object::Utc>>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn datetime(
         &mut self,
@@ -37,11 +41,11 @@ impl Builder {
         self.datetime = Some(datetime);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> DateTimeExample {
         DateTimeExample {

--- a/conjure-codegen/src/example_types/product/double_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/double_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Default)]
 pub struct DoubleAliasExample(pub f64);
 impl std::fmt::Display for DoubleAliasExample {

--- a/conjure-codegen/src/example_types/product/double_example.rs
+++ b/conjure-codegen/src/example_types/product/double_example.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy)]
 pub struct DoubleExample {
     double_value: f64,
 }
 impl DoubleExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(double_value: f64) -> DoubleExample {
         DoubleExample {
             double_value: double_value,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +23,24 @@ impl DoubleExample {
         self.double_value
     }
 }
-#[doc = "A builder for the `DoubleExample` type."]
+///A builder for the `DoubleExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     double_value: Option<f64>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn double_value(&mut self, double_value: f64) -> &mut Self {
         self.double_value = Some(double_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> DoubleExample {
         DoubleExample {

--- a/conjure-codegen/src/example_types/product/empty_object_example.rs
+++ b/conjure-codegen/src/example_types/product/empty_object_example.rs
@@ -1,29 +1,29 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct EmptyObjectExample {}
 impl EmptyObjectExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> EmptyObjectExample {
         EmptyObjectExample {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `EmptyObjectExample` type."]
+///A builder for the `EmptyObjectExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> EmptyObjectExample {
         EmptyObjectExample {}

--- a/conjure-codegen/src/example_types/product/enum_example.rs
+++ b/conjure-codegen/src/example_types/product/enum_example.rs
@@ -1,16 +1,16 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 use std::fmt;
 use std::str;
-#[doc = "This enumerates the numbers 1:2."]
+///This enumerates the numbers 1:2.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum EnumExample {
     One,
     Two,
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl EnumExample {
-    #[doc = r" Returns the string representation of the enum."]
+    /// Returns the string representation of the enum.
     #[inline]
     pub fn as_str(&self) -> &str {
         match self {
@@ -39,9 +39,7 @@ impl str::FromStr for EnumExample {
             "TWO" => Ok(EnumExample::Two),
             v => {
                 if conjure_object::private::valid_enum_variant(v) {
-                    Ok(EnumExample::Unknown(Unknown(
-                        v.to_string().into_boxed_str(),
-                    )))
+                    Ok(EnumExample::Unknown(Unknown(v.to_string().into_boxed_str())))
                 } else {
                     Err(conjure_object::plain::ParseEnumError::new())
                 }
@@ -52,7 +50,9 @@ impl str::FromStr for EnumExample {
 impl conjure_object::FromPlain for EnumExample {
     type Err = conjure_object::plain::ParseEnumError;
     #[inline]
-    fn from_plain(v: &str) -> Result<EnumExample, conjure_object::plain::ParseEnumError> {
+    fn from_plain(
+        v: &str,
+    ) -> Result<EnumExample, conjure_object::plain::ParseEnumError> {
         v.parse()
     }
 }
@@ -88,7 +88,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
         }
     }
 }
-#[doc = "An unknown variant of the EnumExample enum."]
+///An unknown variant of the EnumExample enum.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown(Box<str>);
 impl std::ops::Deref for Unknown {

--- a/conjure-codegen/src/example_types/product/enum_field_example.rs
+++ b/conjure-codegen/src/example_types/product/enum_field_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct EnumFieldExample {
     enum_: super::EnumExample,
 }
 impl EnumFieldExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(enum_: super::EnumExample) -> EnumFieldExample {
         EnumFieldExample { enum_: enum_ }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl EnumFieldExample {
         &self.enum_
     }
 }
-#[doc = "A builder for the `EnumFieldExample` type."]
+///A builder for the `EnumFieldExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     enum_: Option<super::EnumExample>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn enum_(&mut self, enum_: super::EnumExample) -> &mut Self {
         self.enum_ = Some(enum_);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> EnumFieldExample {
         EnumFieldExample {
@@ -49,9 +49,7 @@ impl Builder {
 impl From<EnumFieldExample> for Builder {
     #[inline]
     fn from(_v: EnumFieldExample) -> Builder {
-        Builder {
-            enum_: Some(_v.enum_),
-        }
+        Builder { enum_: Some(_v.enum_) }
     }
 }
 impl ser::Serialize for EnumFieldExample {

--- a/conjure-codegen/src/example_types/product/integer_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/integer_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
 pub struct IntegerAliasExample(pub i32);
 impl std::fmt::Display for IntegerAliasExample {

--- a/conjure-codegen/src/example_types/product/integer_example.rs
+++ b/conjure-codegen/src/example_types/product/integer_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct IntegerExample {
     integer: i32,
 }
 impl IntegerExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(integer: i32) -> IntegerExample {
         IntegerExample { integer: integer }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl IntegerExample {
         self.integer
     }
 }
-#[doc = "A builder for the `IntegerExample` type."]
+///A builder for the `IntegerExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     integer: Option<i32>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn integer(&mut self, integer: i32) -> &mut Self {
         self.integer = Some(integer);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> IntegerExample {
         IntegerExample {

--- a/conjure-codegen/src/example_types/product/invalid_service_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_service_definition.rs
@@ -1,14 +1,14 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Invalid Conjure service definition."]
+///Invalid Conjure service definition.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct InvalidServiceDefinition {
     service_name: String,
     service_def: conjure_object::Any,
 }
 impl InvalidServiceDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(service_name: T, service_def: U) -> InvalidServiceDefinition
     where
@@ -17,35 +17,36 @@ impl InvalidServiceDefinition {
     {
         InvalidServiceDefinition {
             service_name: service_name.into(),
-            service_def: conjure_object::Any::new(service_def).expect("value failed to serialize"),
+            service_def: conjure_object::Any::new(service_def)
+                .expect("value failed to serialize"),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "Name of the invalid service definition."]
+    ///Name of the invalid service definition.
     #[inline]
     pub fn service_name(&self) -> &str {
         &*self.service_name
     }
-    #[doc = "Details of the invalid service definition."]
+    ///Details of the invalid service definition.
     #[inline]
     pub fn service_def(&self) -> &conjure_object::Any {
         &self.service_def
     }
 }
-#[doc = "A builder for the `InvalidServiceDefinition` type."]
+///A builder for the `InvalidServiceDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     service_name: Option<String>,
     service_def: Option<conjure_object::Any>,
 }
 impl Builder {
-    #[doc = "Name of the invalid service definition."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///Name of the invalid service definition.
+    ///
+    /// Required.
     #[inline]
     pub fn service_name<T>(&mut self, service_name: T) -> &mut Self
     where
@@ -54,23 +55,25 @@ impl Builder {
         self.service_name = Some(service_name.into());
         self
     }
-    #[doc = "Details of the invalid service definition."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///Details of the invalid service definition.
+    ///
+    /// Required.
     #[inline]
     pub fn service_def<T>(&mut self, service_def: T) -> &mut Self
     where
         T: conjure_object::serde::Serialize,
     {
-        self.service_def =
-            Some(conjure_object::Any::new(service_def).expect("value failed to serialize"));
+        self
+            .service_def = Some(
+            conjure_object::Any::new(service_def).expect("value failed to serialize"),
+        );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> InvalidServiceDefinition {
         InvalidServiceDefinition {
@@ -78,10 +81,7 @@ impl Builder {
                 .service_name
                 .clone()
                 .expect("field service_name was not set"),
-            service_def: self
-                .service_def
-                .clone()
-                .expect("field service_def was not set"),
+            service_def: self.service_def.clone().expect("field service_def was not set"),
         }
     }
 }

--- a/conjure-codegen/src/example_types/product/invalid_type_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_type_definition.rs
@@ -1,14 +1,14 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Invalid Conjure type definition."]
+///Invalid Conjure type definition.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct InvalidTypeDefinition {
     type_name: String,
     type_def: conjure_object::Any,
 }
 impl InvalidTypeDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(type_name: T, type_def: U) -> InvalidTypeDefinition
     where
@@ -17,10 +17,11 @@ impl InvalidTypeDefinition {
     {
         InvalidTypeDefinition {
             type_name: type_name.into(),
-            type_def: conjure_object::Any::new(type_def).expect("value failed to serialize"),
+            type_def: conjure_object::Any::new(type_def)
+                .expect("value failed to serialize"),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -34,15 +35,15 @@ impl InvalidTypeDefinition {
         &self.type_def
     }
 }
-#[doc = "A builder for the `InvalidTypeDefinition` type."]
+///A builder for the `InvalidTypeDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     type_name: Option<String>,
     type_def: Option<conjure_object::Any>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_name<T>(&mut self, type_name: T) -> &mut Self
     where
@@ -51,22 +52,24 @@ impl Builder {
         self.type_name = Some(type_name.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_def<T>(&mut self, type_def: T) -> &mut Self
     where
         T: conjure_object::serde::Serialize,
     {
-        self.type_def =
-            Some(conjure_object::Any::new(type_def).expect("value failed to serialize"));
+        self
+            .type_def = Some(
+            conjure_object::Any::new(type_def).expect("value failed to serialize"),
+        );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> InvalidTypeDefinition {
         InvalidTypeDefinition {

--- a/conjure-codegen/src/example_types/product/java_compilation_failed.rs
+++ b/conjure-codegen/src/example_types/product/java_compilation_failed.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Failed to compile Conjure definition to Java code."]
+///Failed to compile Conjure definition to Java code.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct JavaCompilationFailed {}
 impl JavaCompilationFailed {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> JavaCompilationFailed {
         JavaCompilationFailed {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `JavaCompilationFailed` type."]
+///A builder for the `JavaCompilationFailed` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> JavaCompilationFailed {
         JavaCompilationFailed {}

--- a/conjure-codegen/src/example_types/product/list_example.rs
+++ b/conjure-codegen/src/example_types/product/list_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct ListExample {
@@ -8,7 +8,7 @@ pub struct ListExample {
     double_items: Vec<f64>,
 }
 impl ListExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U, V>(items: T, primitive_items: U, double_items: V) -> ListExample
     where
@@ -22,7 +22,7 @@ impl ListExample {
             double_items: double_items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -40,7 +40,7 @@ impl ListExample {
         &*self.double_items
     }
 }
-#[doc = "A builder for the `ListExample` type."]
+///A builder for the `ListExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: Vec<String>,
@@ -114,11 +114,11 @@ impl Builder {
         self.double_items.push(value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ListExample {
         ListExample {

--- a/conjure-codegen/src/example_types/product/many_field_example.rs
+++ b/conjure-codegen/src/example_types/product/many_field_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct ManyFieldExample {
@@ -13,53 +13,53 @@ pub struct ManyFieldExample {
     alias: super::StringAliasExample,
 }
 impl ManyFieldExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "docs for string field"]
+    ///docs for string field
     #[inline]
     pub fn string(&self) -> &str {
         &*self.string
     }
-    #[doc = "docs for integer field"]
+    ///docs for integer field
     #[inline]
     pub fn integer(&self) -> i32 {
         self.integer
     }
-    #[doc = "docs for doubleValue field"]
+    ///docs for doubleValue field
     #[inline]
     pub fn double_value(&self) -> f64 {
         self.double_value
     }
-    #[doc = "docs for optionalItem field"]
+    ///docs for optionalItem field
     #[inline]
     pub fn optional_item(&self) -> Option<&str> {
         self.optional_item.as_ref().map(|o| &**o)
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn items(&self) -> &[String] {
         &*self.items
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn set(&self) -> &std::collections::BTreeSet<String> {
         &self.set
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn map(&self) -> &std::collections::BTreeMap<String, String> {
         &self.map
     }
-    #[doc = "docs for alias field"]
+    ///docs for alias field
     #[inline]
     pub fn alias(&self) -> &super::StringAliasExample {
         &self.alias
     }
 }
-#[doc = "A builder for the `ManyFieldExample` type."]
+///A builder for the `ManyFieldExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     string: Option<String>,
@@ -72,9 +72,9 @@ pub struct Builder {
     alias: Option<super::StringAliasExample>,
 }
 impl Builder {
-    #[doc = "docs for string field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for string field
+    ///
+    /// Required.
     #[inline]
     pub fn string<T>(&mut self, string: T) -> &mut Self
     where
@@ -83,23 +83,23 @@ impl Builder {
         self.string = Some(string.into());
         self
     }
-    #[doc = "docs for integer field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for integer field
+    ///
+    /// Required.
     #[inline]
     pub fn integer(&mut self, integer: i32) -> &mut Self {
         self.integer = Some(integer);
         self
     }
-    #[doc = "docs for doubleValue field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for doubleValue field
+    ///
+    /// Required.
     #[inline]
     pub fn double_value(&mut self, double_value: f64) -> &mut Self {
         self.double_value = Some(double_value);
         self
     }
-    #[doc = "docs for optionalItem field"]
+    ///docs for optionalItem field
     #[inline]
     pub fn optional_item<T>(&mut self, optional_item: T) -> &mut Self
     where
@@ -108,7 +108,7 @@ impl Builder {
         self.optional_item = optional_item.into();
         self
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
@@ -117,7 +117,7 @@ impl Builder {
         self.items = items.into_iter().collect();
         self
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn extend_items<T>(&mut self, items: T) -> &mut Self
     where
@@ -126,7 +126,7 @@ impl Builder {
         self.items.extend(items);
         self
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn push_items<T>(&mut self, value: T) -> &mut Self
     where
@@ -135,7 +135,7 @@ impl Builder {
         self.items.push(value.into());
         self
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn set<T>(&mut self, set: T) -> &mut Self
     where
@@ -144,7 +144,7 @@ impl Builder {
         self.set = set.into_iter().collect();
         self
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn extend_set<T>(&mut self, set: T) -> &mut Self
     where
@@ -153,7 +153,7 @@ impl Builder {
         self.set.extend(set);
         self
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn insert_set<T>(&mut self, value: T) -> &mut Self
     where
@@ -162,7 +162,7 @@ impl Builder {
         self.set.insert(value.into());
         self
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn map<T>(&mut self, map: T) -> &mut Self
     where
@@ -171,7 +171,7 @@ impl Builder {
         self.map = map.into_iter().collect();
         self
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn extend_map<T>(&mut self, map: T) -> &mut Self
     where
@@ -180,7 +180,7 @@ impl Builder {
         self.map.extend(map);
         self
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn insert_map<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
@@ -190,19 +190,19 @@ impl Builder {
         self.map.insert(key.into(), value.into());
         self
     }
-    #[doc = "docs for alias field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for alias field
+    ///
+    /// Required.
     #[inline]
     pub fn alias(&mut self, alias: super::StringAliasExample) -> &mut Self {
         self.alias = Some(alias);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ManyFieldExample {
         ManyFieldExample {

--- a/conjure-codegen/src/example_types/product/map_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/map_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct MapAliasExample(pub std::collections::BTreeMap<String, conjure_object::Any>);
 impl std::ops::Deref for MapAliasExample {
@@ -10,7 +10,9 @@ impl std::ops::Deref for MapAliasExample {
 }
 impl std::ops::DerefMut for MapAliasExample {
     #[inline]
-    fn deref_mut(&mut self) -> &mut std::collections::BTreeMap<String, conjure_object::Any> {
+    fn deref_mut(
+        &mut self,
+    ) -> &mut std::collections::BTreeMap<String, conjure_object::Any> {
         &mut self.0
     }
 }

--- a/conjure-codegen/src/example_types/product/map_example.rs
+++ b/conjure-codegen/src/example_types/product/map_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct MapExample {
     items: std::collections::BTreeMap<String, String>,
 }
 impl MapExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(items: T) -> MapExample
     where
@@ -16,7 +16,7 @@ impl MapExample {
             items: items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl MapExample {
         &self.items
     }
 }
-#[doc = "A builder for the `MapExample` type."]
+///A builder for the `MapExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: std::collections::BTreeMap<String, String>,
@@ -57,11 +57,11 @@ impl Builder {
         self.items.insert(key.into(), value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> MapExample {
         MapExample {

--- a/conjure-codegen/src/example_types/product/mod.rs
+++ b/conjure-codegen/src/example_types/product/mod.rs
@@ -1,145 +1,145 @@
 #[doc(inline)]
-pub use self::alias_as_map_key_example::AliasAsMapKeyExample;
-#[doc(inline)]
-pub use self::aliased_binary::AliasedBinary;
-#[doc(inline)]
 pub use self::aliased_string::AliasedString;
-#[doc(inline)]
-pub use self::any_example::AnyExample;
-#[doc(inline)]
-pub use self::any_map_example::AnyMapExample;
-#[doc(inline)]
-pub use self::bearer_token_alias_example::BearerTokenAliasExample;
-#[doc(inline)]
-pub use self::bearer_token_example::BearerTokenExample;
-#[doc(inline)]
-pub use self::binary_alias_example::BinaryAliasExample;
-#[doc(inline)]
-pub use self::binary_example::BinaryExample;
-#[doc(inline)]
-pub use self::boolean_alias_example::BooleanAliasExample;
-#[doc(inline)]
-pub use self::boolean_example::BooleanExample;
-#[doc(inline)]
-pub use self::covariant_list_example::CovariantListExample;
-#[doc(inline)]
-pub use self::covariant_optional_example::CovariantOptionalExample;
 #[doc(inline)]
 pub use self::create_dataset_request::CreateDatasetRequest;
 #[doc(inline)]
-pub use self::date_time_alias_example::DateTimeAliasExample;
-#[doc(inline)]
-pub use self::date_time_example::DateTimeExample;
-#[doc(inline)]
-pub use self::double_alias_example::DoubleAliasExample;
-#[doc(inline)]
-pub use self::double_example::DoubleExample;
-#[doc(inline)]
-pub use self::empty_object_example::EmptyObjectExample;
-#[doc(inline)]
-pub use self::enum_example::EnumExample;
-#[doc(inline)]
-pub use self::enum_field_example::EnumFieldExample;
-#[doc(inline)]
-pub use self::integer_alias_example::IntegerAliasExample;
-#[doc(inline)]
-pub use self::integer_example::IntegerExample;
-#[doc(inline)]
-pub use self::invalid_service_definition::InvalidServiceDefinition;
-#[doc(inline)]
-pub use self::invalid_type_definition::InvalidTypeDefinition;
-#[doc(inline)]
-pub use self::java_compilation_failed::JavaCompilationFailed;
-#[doc(inline)]
-pub use self::list_example::ListExample;
-#[doc(inline)]
-pub use self::many_field_example::ManyFieldExample;
-#[doc(inline)]
-pub use self::map_alias_example::MapAliasExample;
-#[doc(inline)]
-pub use self::map_example::MapExample;
+pub use self::aliased_binary::AliasedBinary;
 #[doc(inline)]
 pub use self::nested_aliased_binary::NestedAliasedBinary;
 #[doc(inline)]
-pub use self::nested_string_alias_example::NestedStringAliasExample;
+pub use self::integer_example::IntegerExample;
 #[doc(inline)]
-pub use self::optional_example::OptionalExample;
+pub use self::boolean_example::BooleanExample;
+#[doc(inline)]
+pub use self::any_example::AnyExample;
+#[doc(inline)]
+pub use self::map_alias_example::MapAliasExample;
 #[doc(inline)]
 pub use self::primitive_optionals_example::PrimitiveOptionalsExample;
 #[doc(inline)]
-pub use self::reference_alias_example::ReferenceAliasExample;
+pub use self::empty_object_example::EmptyObjectExample;
 #[doc(inline)]
-pub use self::reserved_key_example::ReservedKeyExample;
-#[doc(inline)]
-pub use self::rid_alias_example::RidAliasExample;
-#[doc(inline)]
-pub use self::rid_example::RidExample;
-#[doc(inline)]
-pub use self::safe_long_alias_example::SafeLongAliasExample;
+pub use self::boolean_alias_example::BooleanAliasExample;
 #[doc(inline)]
 pub use self::safe_long_example::SafeLongExample;
 #[doc(inline)]
-pub use self::set_example::SetExample;
-#[doc(inline)]
 pub use self::single_union::SingleUnion;
 #[doc(inline)]
-pub use self::string_alias_example::StringAliasExample;
+pub use self::date_time_example::DateTimeExample;
 #[doc(inline)]
-pub use self::string_example::StringExample;
+pub use self::bearer_token_alias_example::BearerTokenAliasExample;
 #[doc(inline)]
-pub use self::union_::Union;
+pub use self::set_example::SetExample;
+#[doc(inline)]
+pub use self::rid_example::RidExample;
+#[doc(inline)]
+pub use self::enum_field_example::EnumFieldExample;
+#[doc(inline)]
+pub use self::covariant_list_example::CovariantListExample;
+#[doc(inline)]
+pub use self::reserved_key_example::ReservedKeyExample;
+#[doc(inline)]
+pub use self::reference_alias_example::ReferenceAliasExample;
+#[doc(inline)]
+pub use self::binary_example::BinaryExample;
+#[doc(inline)]
+pub use self::date_time_alias_example::DateTimeAliasExample;
+#[doc(inline)]
+pub use self::any_map_example::AnyMapExample;
+#[doc(inline)]
+pub use self::binary_alias_example::BinaryAliasExample;
+#[doc(inline)]
+pub use self::nested_string_alias_example::NestedStringAliasExample;
+#[doc(inline)]
+pub use self::many_field_example::ManyFieldExample;
+#[doc(inline)]
+pub use self::alias_as_map_key_example::AliasAsMapKeyExample;
+#[doc(inline)]
+pub use self::bearer_token_example::BearerTokenExample;
 #[doc(inline)]
 pub use self::union_type_example::UnionTypeExample;
 #[doc(inline)]
+pub use self::list_example::ListExample;
+#[doc(inline)]
+pub use self::string_alias_example::StringAliasExample;
+#[doc(inline)]
+pub use self::rid_alias_example::RidAliasExample;
+#[doc(inline)]
+pub use self::double_alias_example::DoubleAliasExample;
+#[doc(inline)]
+pub use self::integer_alias_example::IntegerAliasExample;
+#[doc(inline)]
+pub use self::covariant_optional_example::CovariantOptionalExample;
+#[doc(inline)]
+pub use self::map_example::MapExample;
+#[doc(inline)]
+pub use self::double_example::DoubleExample;
+#[doc(inline)]
+pub use self::safe_long_alias_example::SafeLongAliasExample;
+#[doc(inline)]
+pub use self::optional_example::OptionalExample;
+#[doc(inline)]
+pub use self::enum_example::EnumExample;
+#[doc(inline)]
+pub use self::union_::Union;
+#[doc(inline)]
 pub use self::uuid_alias_example::UuidAliasExample;
 #[doc(inline)]
+pub use self::string_example::StringExample;
+#[doc(inline)]
 pub use self::uuid_example::UuidExample;
-pub mod alias_as_map_key_example;
-pub mod aliased_binary;
+#[doc(inline)]
+pub use self::invalid_type_definition::InvalidTypeDefinition;
+#[doc(inline)]
+pub use self::invalid_service_definition::InvalidServiceDefinition;
+#[doc(inline)]
+pub use self::java_compilation_failed::JavaCompilationFailed;
 pub mod aliased_string;
-pub mod any_example;
-pub mod any_map_example;
-pub mod bearer_token_alias_example;
-pub mod bearer_token_example;
-pub mod binary_alias_example;
-pub mod binary_example;
-pub mod boolean_alias_example;
-pub mod boolean_example;
-pub mod covariant_list_example;
-pub mod covariant_optional_example;
 pub mod create_dataset_request;
-pub mod datasets;
-pub mod date_time_alias_example;
-pub mod date_time_example;
-pub mod double_alias_example;
-pub mod double_example;
-pub mod empty_object_example;
-pub mod enum_example;
-pub mod enum_field_example;
-pub mod integer_alias_example;
-pub mod integer_example;
-pub mod invalid_service_definition;
-pub mod invalid_type_definition;
-pub mod java_compilation_failed;
-pub mod list_example;
-pub mod many_field_example;
-pub mod map_alias_example;
-pub mod map_example;
+pub mod aliased_binary;
 pub mod nested_aliased_binary;
-pub mod nested_string_alias_example;
-pub mod optional_example;
+pub mod integer_example;
+pub mod boolean_example;
+pub mod any_example;
+pub mod map_alias_example;
 pub mod primitive_optionals_example;
-pub mod reference_alias_example;
-pub mod reserved_key_example;
-pub mod rid_alias_example;
-pub mod rid_example;
-pub mod safe_long_alias_example;
+pub mod empty_object_example;
+pub mod boolean_alias_example;
 pub mod safe_long_example;
-pub mod set_example;
 pub mod single_union;
-pub mod string_alias_example;
-pub mod string_example;
-pub mod union_;
+pub mod date_time_example;
+pub mod bearer_token_alias_example;
+pub mod set_example;
+pub mod rid_example;
+pub mod enum_field_example;
+pub mod covariant_list_example;
+pub mod reserved_key_example;
+pub mod reference_alias_example;
+pub mod binary_example;
+pub mod date_time_alias_example;
+pub mod any_map_example;
+pub mod binary_alias_example;
+pub mod nested_string_alias_example;
+pub mod many_field_example;
+pub mod alias_as_map_key_example;
+pub mod bearer_token_example;
 pub mod union_type_example;
+pub mod list_example;
+pub mod string_alias_example;
+pub mod rid_alias_example;
+pub mod double_alias_example;
+pub mod integer_alias_example;
+pub mod covariant_optional_example;
+pub mod map_example;
+pub mod double_example;
+pub mod safe_long_alias_example;
+pub mod optional_example;
+pub mod enum_example;
+pub mod union_;
 pub mod uuid_alias_example;
+pub mod string_example;
 pub mod uuid_example;
+pub mod invalid_type_definition;
+pub mod invalid_service_definition;
+pub mod java_compilation_failed;
+pub mod datasets;

--- a/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct NestedAliasedBinary(pub super::AliasedBinary);
 impl conjure_object::Plain for NestedAliasedBinary {

--- a/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct NestedStringAliasExample(pub super::StringAliasExample);
 impl std::fmt::Display for NestedStringAliasExample {

--- a/conjure-codegen/src/example_types/product/optional_example.rs
+++ b/conjure-codegen/src/example_types/product/optional_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct OptionalExample {
     item: Option<String>,
 }
 impl OptionalExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(item: T) -> OptionalExample
     where
@@ -16,7 +16,7 @@ impl OptionalExample {
             item: Some(item.into()),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl OptionalExample {
         self.item.as_ref().map(|o| &**o)
     }
 }
-#[doc = "A builder for the `OptionalExample` type."]
+///A builder for the `OptionalExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     item: Option<String>,
@@ -40,11 +40,11 @@ impl Builder {
         self.item = item.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> OptionalExample {
         OptionalExample {

--- a/conjure-codegen/src/example_types/product/primitive_optionals_example.rs
+++ b/conjure-codegen/src/example_types/product/primitive_optionals_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct PrimitiveOptionalsExample {
@@ -12,7 +12,7 @@ pub struct PrimitiveOptionalsExample {
     uuid: Option<conjure_object::Uuid>,
 }
 impl PrimitiveOptionalsExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -46,7 +46,7 @@ impl PrimitiveOptionalsExample {
         self.uuid.as_ref().map(|o| *o)
     }
 }
-#[doc = "A builder for the `PrimitiveOptionalsExample` type."]
+///A builder for the `PrimitiveOptionalsExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     num: Option<f64>,
@@ -114,11 +114,11 @@ impl Builder {
         self.uuid = uuid.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> PrimitiveOptionalsExample {
         PrimitiveOptionalsExample {
@@ -226,15 +226,7 @@ impl<'de> de::Deserialize<'de> for PrimitiveOptionalsExample {
     {
         d.deserialize_struct(
             "PrimitiveOptionalsExample",
-            &[
-                "num",
-                "bool",
-                "integer",
-                "safelong",
-                "rid",
-                "bearertoken",
-                "uuid",
-            ],
+            &["num", "bool", "integer", "safelong", "rid", "bearertoken", "uuid"],
             Visitor_,
         )
     }

--- a/conjure-codegen/src/example_types/product/reference_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/reference_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ReferenceAliasExample(pub super::AnyExample);
 impl std::ops::Deref for ReferenceAliasExample {

--- a/conjure-codegen/src/example_types/product/reserved_key_example.rs
+++ b/conjure-codegen/src/example_types/product/reserved_key_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ReservedKeyExample {
@@ -10,7 +10,7 @@ pub struct ReservedKeyExample {
     memoized_hash_code: i32,
 }
 impl ReservedKeyExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -36,7 +36,7 @@ impl ReservedKeyExample {
         self.memoized_hash_code
     }
 }
-#[doc = "A builder for the `ReservedKeyExample` type."]
+///A builder for the `ReservedKeyExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     package: Option<String>,
@@ -46,8 +46,8 @@ pub struct Builder {
     memoized_hash_code: Option<i32>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn package<T>(&mut self, package: T) -> &mut Self
     where
@@ -56,8 +56,8 @@ impl Builder {
         self.package = Some(package.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn interface<T>(&mut self, interface: T) -> &mut Self
     where
@@ -66,8 +66,8 @@ impl Builder {
         self.interface = Some(interface.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn field_name_with_dashes<T>(&mut self, field_name_with_dashes: T) -> &mut Self
     where
@@ -76,8 +76,8 @@ impl Builder {
         self.field_name_with_dashes = Some(field_name_with_dashes.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn primitve_field_name_with_dashes(
         &mut self,
@@ -86,18 +86,18 @@ impl Builder {
         self.primitve_field_name_with_dashes = Some(primitve_field_name_with_dashes);
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn memoized_hash_code(&mut self, memoized_hash_code: i32) -> &mut Self {
         self.memoized_hash_code = Some(memoized_hash_code);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ReservedKeyExample {
         ReservedKeyExample {
@@ -185,9 +185,11 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             match field_ {
                 Field_::Package => package = Some(map_.next_value()?),
                 Field_::Interface => interface = Some(map_.next_value()?),
-                Field_::FieldNameWithDashes => field_name_with_dashes = Some(map_.next_value()?),
+                Field_::FieldNameWithDashes => {
+                    field_name_with_dashes = Some(map_.next_value()?);
+                }
                 Field_::PrimitveFieldNameWithDashes => {
-                    primitve_field_name_with_dashes = Some(map_.next_value()?)
+                    primitve_field_name_with_dashes = Some(map_.next_value()?);
                 }
                 Field_::MemoizedHashCode => memoized_hash_code = Some(map_.next_value()?),
                 Field_::Unknown_ => {
@@ -209,7 +211,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
         };
         let primitve_field_name_with_dashes = match primitve_field_name_with_dashes {
             Some(v) => v,
-            None => return Err(de::Error::missing_field("primitve-field-name-with-dashes")),
+            None => {
+                return Err(de::Error::missing_field("primitve-field-name-with-dashes"));
+            }
         };
         let memoized_hash_code = match memoized_hash_code {
             Some(v) => v,

--- a/conjure-codegen/src/example_types/product/rid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/rid_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct RidAliasExample(pub conjure_object::ResourceIdentifier);
 impl std::fmt::Display for RidAliasExample {

--- a/conjure-codegen/src/example_types/product/rid_example.rs
+++ b/conjure-codegen/src/example_types/product/rid_example.rs
@@ -1,19 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct RidExample {
     rid_value: conjure_object::ResourceIdentifier,
 }
 impl RidExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(rid_value: conjure_object::ResourceIdentifier) -> RidExample {
-        RidExample {
-            rid_value: rid_value,
-        }
+        RidExample { rid_value: rid_value }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +21,27 @@ impl RidExample {
         &self.rid_value
     }
 }
-#[doc = "A builder for the `RidExample` type."]
+///A builder for the `RidExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     rid_value: Option<conjure_object::ResourceIdentifier>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
-    pub fn rid_value(&mut self, rid_value: conjure_object::ResourceIdentifier) -> &mut Self {
+    pub fn rid_value(
+        &mut self,
+        rid_value: conjure_object::ResourceIdentifier,
+    ) -> &mut Self {
         self.rid_value = Some(rid_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> RidExample {
         RidExample {

--- a/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
 pub struct SafeLongAliasExample(pub conjure_object::SafeLong);
 impl std::fmt::Display for SafeLongAliasExample {

--- a/conjure-codegen/src/example_types/product/safe_long_example.rs
+++ b/conjure-codegen/src/example_types/product/safe_long_example.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct SafeLongExample {
     safe_long_value: conjure_object::SafeLong,
 }
 impl SafeLongExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(safe_long_value: conjure_object::SafeLong) -> SafeLongExample {
         SafeLongExample {
             safe_long_value: safe_long_value,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +23,27 @@ impl SafeLongExample {
         self.safe_long_value
     }
 }
-#[doc = "A builder for the `SafeLongExample` type."]
+///A builder for the `SafeLongExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     safe_long_value: Option<conjure_object::SafeLong>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
-    pub fn safe_long_value(&mut self, safe_long_value: conjure_object::SafeLong) -> &mut Self {
+    pub fn safe_long_value(
+        &mut self,
+        safe_long_value: conjure_object::SafeLong,
+    ) -> &mut Self {
         self.safe_long_value = Some(safe_long_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> SafeLongExample {
         SafeLongExample {

--- a/conjure-codegen/src/example_types/product/set_example.rs
+++ b/conjure-codegen/src/example_types/product/set_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct SetExample {
     items: std::collections::BTreeSet<String>,
 }
 impl SetExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(items: T) -> SetExample
     where
@@ -16,7 +16,7 @@ impl SetExample {
             items: items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl SetExample {
         &self.items
     }
 }
-#[doc = "A builder for the `SetExample` type."]
+///A builder for the `SetExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: std::collections::BTreeSet<String>,
@@ -56,11 +56,11 @@ impl Builder {
         self.items.insert(value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> SetExample {
         SetExample {

--- a/conjure-codegen/src/example_types/product/single_union.rs
+++ b/conjure-codegen/src/example_types/product/single_union.rs
@@ -1,11 +1,11 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SingleUnion {
     Foo(String),
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl ser::Serialize for SingleUnion {
@@ -59,19 +59,22 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                             let value = map.next_value()?;
                             SingleUnion::Unknown(Unknown { type_, value })
                         } else {
-                            return Err(de::Error::invalid_value(
-                                de::Unexpected::Str(&type_),
-                                &&*b,
-                            ));
+                            return Err(
+                                de::Error::invalid_value(de::Unexpected::Str(&type_), &&*b),
+                            )
                         }
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -93,10 +96,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -146,14 +151,14 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
         Ok(v)
     }
 }
-#[doc = "An unknown variant of the SingleUnion union."]
+///An unknown variant of the SingleUnion union.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown {
     type_: Box<str>,
     value: conjure_object::Any,
 }
 impl Unknown {
-    #[doc = r" Returns the unknown variant's type name."]
+    /// Returns the unknown variant's type name.
     #[inline]
     pub fn type_(&self) -> &str {
         &self.type_

--- a/conjure-codegen/src/example_types/product/string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/string_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct StringAliasExample(pub String);
 impl std::fmt::Display for StringAliasExample {

--- a/conjure-codegen/src/example_types/product/string_example.rs
+++ b/conjure-codegen/src/example_types/product/string_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct StringExample {
     string: String,
 }
 impl StringExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(string: T) -> StringExample
     where
@@ -16,7 +16,7 @@ impl StringExample {
             string: string.into(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,14 +26,14 @@ impl StringExample {
         &*self.string
     }
 }
-#[doc = "A builder for the `StringExample` type."]
+///A builder for the `StringExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     string: Option<String>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn string<T>(&mut self, string: T) -> &mut Self
     where
@@ -42,11 +42,11 @@ impl Builder {
         self.string = Some(string.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> StringExample {
         StringExample {
@@ -57,9 +57,7 @@ impl Builder {
 impl From<StringExample> for Builder {
     #[inline]
     fn from(_v: StringExample) -> Builder {
-        Builder {
-            string: Some(_v.string),
-        }
+        Builder { string: Some(_v.string) }
     }
 }
 impl ser::Serialize for StringExample {

--- a/conjure-codegen/src/example_types/product/union_.rs
+++ b/conjure-codegen/src/example_types/product/union_.rs
@@ -1,12 +1,12 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum Union {
     Foo(String),
     Bar(i32),
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl ser::Serialize for Union {
@@ -68,19 +68,22 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                             let value = map.next_value()?;
                             Union::Unknown(Unknown { type_, value })
                         } else {
-                            return Err(de::Error::invalid_value(
-                                de::Unexpected::Str(&type_),
-                                &&*b,
-                            ));
+                            return Err(
+                                de::Error::invalid_value(de::Unexpected::Str(&type_), &&*b),
+                            )
                         }
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -106,10 +109,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -162,14 +167,14 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
         Ok(v)
     }
 }
-#[doc = "An unknown variant of the Union union."]
+///An unknown variant of the Union union.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown {
     type_: Box<str>,
     value: conjure_object::Any,
 }
 impl Unknown {
-    #[doc = r" Returns the unknown variant's type name."]
+    /// Returns the unknown variant's type name.
     #[inline]
     pub fn type_(&self) -> &str {
         &self.type_

--- a/conjure-codegen/src/example_types/product/union_type_example.rs
+++ b/conjure-codegen/src/example_types/product/union_type_example.rs
@@ -1,10 +1,10 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum UnionTypeExample {
-    #[doc = "Docs for when UnionTypeExample is of type StringExample."]
+    ///Docs for when UnionTypeExample is of type StringExample.
     StringExample(super::StringExample),
     Set(std::collections::BTreeSet<String>),
     ThisFieldIsAnInteger(i32),
@@ -12,7 +12,7 @@ pub enum UnionTypeExample {
     If(i32),
     New(i32),
     Interface(i32),
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl ser::Serialize for UnionTypeExample {
@@ -89,7 +89,10 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                         let value = map.next_value()?;
                         UnionTypeExample::Set(value)
                     }
-                    (Variant_::ThisFieldIsAnInteger, Some(Variant_::ThisFieldIsAnInteger)) => {
+                    (
+                        Variant_::ThisFieldIsAnInteger,
+                        Some(Variant_::ThisFieldIsAnInteger),
+                    ) => {
                         let value = map.next_value()?;
                         UnionTypeExample::ThisFieldIsAnInteger(value)
                     }
@@ -114,19 +117,22 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                             let value = map.next_value()?;
                             UnionTypeExample::Unknown(Unknown { type_, value })
                         } else {
-                            return Err(de::Error::invalid_value(
-                                de::Unexpected::Str(&type_),
-                                &&*b,
-                            ));
+                            return Err(
+                                de::Error::invalid_value(de::Unexpected::Str(&type_), &&*b),
+                            )
                         }
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -172,10 +178,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -243,14 +251,14 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
         Ok(v)
     }
 }
-#[doc = "An unknown variant of the UnionTypeExample union."]
+///An unknown variant of the UnionTypeExample union.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown {
     type_: Box<str>,
     value: conjure_object::Any,
 }
 impl Unknown {
-    #[doc = r" Returns the unknown variant's type name."]
+    /// Returns the unknown variant's type name.
     #[inline]
     pub fn type_(&self) -> &str {
         &self.type_

--- a/conjure-codegen/src/example_types/product/uuid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/uuid_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
 pub struct UuidAliasExample(pub conjure_object::Uuid);
 impl std::fmt::Display for UuidAliasExample {

--- a/conjure-codegen/src/example_types/product/uuid_example.rs
+++ b/conjure-codegen/src/example_types/product/uuid_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct UuidExample {
     uuid: conjure_object::Uuid,
 }
 impl UuidExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(uuid: conjure_object::Uuid) -> UuidExample {
         UuidExample { uuid: uuid }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl UuidExample {
         self.uuid
     }
 }
-#[doc = "A builder for the `UuidExample` type."]
+///A builder for the `UuidExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     uuid: Option<conjure_object::Uuid>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn uuid(&mut self, uuid: conjure_object::Uuid) -> &mut Self {
         self.uuid = Some(uuid);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> UuidExample {
         UuidExample {
@@ -49,9 +49,7 @@ impl Builder {
 impl From<UuidExample> for Builder {
     #[inline]
     fn from(_v: UuidExample) -> Builder {
-        Builder {
-            uuid: Some(_v.uuid),
-        }
+        Builder { uuid: Some(_v.uuid) }
     }
 }
 impl ser::Serialize for UuidExample {

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -279,10 +279,9 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::BTreeMap;
 use std::env;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 mod aliases;
 mod cargo_toml;
@@ -311,7 +310,6 @@ struct CrateInfo {
 
 /// Codegen configuration.
 pub struct Config {
-    rustfmt: OsString,
     run_rustfmt: bool,
     exhaustive: bool,
     staged_builders: bool,
@@ -329,7 +327,6 @@ impl Config {
     /// Creates a new `Config` with default settings.
     pub fn new() -> Config {
         Config {
-            rustfmt: env::var_os("RUSTFMT").unwrap_or_else(|| OsString::from("rustfmt")),
             run_rustfmt: true,
             exhaustive: false,
             staged_builders: false,
@@ -367,14 +364,12 @@ impl Config {
         self
     }
 
-    /// Sets the name of the binary used to format source code.
-    ///
-    /// Defaults to the value of the `RUSTFMT` environment variable, or `rustfmt` if not set.
-    pub fn rustfmt<T>(&mut self, rustfmt: T) -> &mut Config
+    /// No longer used.
+    #[deprecated(note = "no longer used", since = "1.2.0")]
+    pub fn rustfmt<T>(&mut self, _rustfmt: T) -> &mut Config
     where
         T: AsRef<OsStr>,
     {
-        self.rustfmt = rustfmt.as_ref().to_owned();
         self
     }
 
@@ -428,17 +423,6 @@ impl Config {
         }
 
         modules.render(self, &src_dir, lib_root)?;
-
-        // rustfmt sometimes takes 2 runs to converge (?!)
-        for _ in 0..2 {
-            if self.run_rustfmt {
-                let file_name = if lib_root { "lib.rs" } else { "mod.rs" };
-                let _ = Command::new(&self.rustfmt)
-                    .arg("--edition=2018")
-                    .arg(&src_dir.join(file_name))
-                    .status();
-            }
-        }
 
         Ok(())
     }
@@ -636,7 +620,10 @@ impl ModuleTrie {
     }
 
     fn write_module(&self, path: &Path, contents: &TokenStream) -> Result<(), Error> {
-        fs::write(path, contents.to_string())
+        let file = syn::parse2(contents.clone())?;
+        let formatted = prettyplease::unparse(&file);
+
+        fs::write(path, &formatted)
             .with_context(|_| format!("error writing module {}", path.display()))?;
         Ok(())
     }

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -293,6 +293,7 @@ mod http_paths;
 mod objects;
 mod servers;
 #[allow(dead_code, clippy::all)]
+#[rustfmt::skip]
 mod types;
 mod unions;
 
@@ -301,6 +302,7 @@ mod unions;
 /// This module is only intended to be present in documentation; it shouldn't be relied on by any library code.
 #[cfg(feature = "example-types")]
 #[allow(warnings)]
+#[rustfmt::skip]
 pub mod example_types;
 
 struct CrateInfo {

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -310,7 +310,6 @@ struct CrateInfo {
 
 /// Codegen configuration.
 pub struct Config {
-    run_rustfmt: bool,
     exhaustive: bool,
     staged_builders: bool,
     strip_prefix: Option<String>,
@@ -327,7 +326,6 @@ impl Config {
     /// Creates a new `Config` with default settings.
     pub fn new() -> Config {
         Config {
-            run_rustfmt: true,
             exhaustive: false,
             staged_builders: false,
             strip_prefix: None,
@@ -356,11 +354,9 @@ impl Config {
         self
     }
 
-    /// Controls the use of rustfmt to format generated source code.
-    ///
-    /// Defaults to `true`.
-    pub fn run_rustfmt(&mut self, run_rustfmt: bool) -> &mut Config {
-        self.run_rustfmt = run_rustfmt;
+    /// No longer used.
+    #[deprecated(note = "no longer used", since = "1.2.0")]
+    pub fn run_rustfmt(&mut self, _run_rustfmt: bool) -> &mut Config {
         self
     }
 

--- a/conjure-codegen/src/types/alias_definition.rs
+++ b/conjure-codegen/src/types/alias_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct AliasDefinition {
@@ -8,7 +8,7 @@ pub struct AliasDefinition {
     docs: Option<super::Documentation>,
 }
 impl AliasDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(
         type_name: super::TypeName,
@@ -21,7 +21,7 @@ impl AliasDefinition {
             docs: Some(docs),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -39,7 +39,7 @@ impl AliasDefinition {
         self.docs.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `AliasDefinition` type."]
+///A builder for the `AliasDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     type_name: Option<Box<super::TypeName>>,
@@ -47,15 +47,15 @@ pub struct Builder {
     docs: Option<super::Documentation>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_name(&mut self, type_name: super::TypeName) -> &mut Self {
         self.type_name = Some(Box::new(type_name));
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn alias(&mut self, alias: super::Type) -> &mut Self {
         self.alias = Some(Box::new(alias));
@@ -69,11 +69,11 @@ impl Builder {
         self.docs = docs.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> AliasDefinition {
         AliasDefinition {

--- a/conjure-codegen/src/types/argument_definition.rs
+++ b/conjure-codegen/src/types/argument_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ArgumentDefinition {
@@ -11,7 +11,7 @@ pub struct ArgumentDefinition {
     tags: Vec<String>,
 }
 impl ArgumentDefinition {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -41,7 +41,7 @@ impl ArgumentDefinition {
         &*self.tags
     }
 }
-#[doc = "A builder for the `ArgumentDefinition` type."]
+///A builder for the `ArgumentDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     arg_name: Option<super::ArgumentName>,
@@ -52,22 +52,22 @@ pub struct Builder {
     tags: Vec<String>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn arg_name(&mut self, arg_name: super::ArgumentName) -> &mut Self {
         self.arg_name = Some(arg_name);
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_(&mut self, type_: super::Type) -> &mut Self {
         self.type_ = Some(Box::new(type_));
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn param_type(&mut self, param_type: super::ParameterType) -> &mut Self {
         self.param_type = Some(Box::new(param_type));
@@ -126,20 +126,17 @@ impl Builder {
         self.tags.push(value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ArgumentDefinition {
         ArgumentDefinition {
             arg_name: self.arg_name.clone().expect("field arg_name was not set"),
             type_: self.type_.clone().expect("field type_ was not set"),
-            param_type: self
-                .param_type
-                .clone()
-                .expect("field param_type was not set"),
+            param_type: self.param_type.clone().expect("field param_type was not set"),
             docs: self.docs.clone(),
             markers: self.markers.clone(),
             tags: self.tags.clone(),

--- a/conjure-codegen/src/types/argument_name.rs
+++ b/conjure-codegen/src/types/argument_name.rs
@@ -1,5 +1,5 @@
-use conjure_object::serde::{de, ser};
-#[doc = "Must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed argument names: \"fooBar\", \"build2Request\". Disallowed names: \"FooBar\", \"2BuildRequest\"."]
+use conjure_object::serde::{ser, de};
+///Must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed argument names: "fooBar", "build2Request". Disallowed names: "FooBar", "2BuildRequest".
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct ArgumentName(pub String);
 impl std::fmt::Display for ArgumentName {

--- a/conjure-codegen/src/types/auth_type.rs
+++ b/conjure-codegen/src/types/auth_type.rs
@@ -1,6 +1,6 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum AuthType {
@@ -58,12 +58,16 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                         AuthType::Cookie(value)
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -82,10 +86,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }

--- a/conjure-codegen/src/types/body_parameter_type.rs
+++ b/conjure-codegen/src/types/body_parameter_type.rs
@@ -1,29 +1,29 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct BodyParameterType {}
 impl BodyParameterType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> BodyParameterType {
         BodyParameterType {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `BodyParameterType` type."]
+///A builder for the `BodyParameterType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BodyParameterType {
         BodyParameterType {}

--- a/conjure-codegen/src/types/conjure_definition.rs
+++ b/conjure-codegen/src/types/conjure_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ConjureDefinition {
@@ -10,7 +10,7 @@ pub struct ConjureDefinition {
     extensions: std::collections::BTreeMap<String, conjure_object::Any>,
 }
 impl ConjureDefinition {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -32,11 +32,13 @@ impl ConjureDefinition {
         &*self.services
     }
     #[inline]
-    pub fn extensions(&self) -> &std::collections::BTreeMap<String, conjure_object::Any> {
+    pub fn extensions(
+        &self,
+    ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.extensions
     }
 }
-#[doc = "A builder for the `ConjureDefinition` type."]
+///A builder for the `ConjureDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     version: Option<i32>,
@@ -46,8 +48,8 @@ pub struct Builder {
     extensions: std::collections::BTreeMap<String, conjure_object::Any>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn version(&mut self, version: i32) -> &mut Self {
         self.version = Some(version);
@@ -138,17 +140,18 @@ impl Builder {
         K: Into<String>,
         V: conjure_object::serde::Serialize,
     {
-        self.extensions.insert(
-            key.into(),
-            conjure_object::Any::new(value).expect("value failed to serialize"),
-        );
+        self.extensions
+            .insert(
+                key.into(),
+                conjure_object::Any::new(value).expect("value failed to serialize"),
+            );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ConjureDefinition {
         ConjureDefinition {

--- a/conjure-codegen/src/types/cookie_auth_type.rs
+++ b/conjure-codegen/src/types/cookie_auth_type.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct CookieAuthType {
     cookie_name: String,
 }
 impl CookieAuthType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(cookie_name: T) -> CookieAuthType
     where
@@ -16,7 +16,7 @@ impl CookieAuthType {
             cookie_name: cookie_name.into(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,14 +26,14 @@ impl CookieAuthType {
         &*self.cookie_name
     }
 }
-#[doc = "A builder for the `CookieAuthType` type."]
+///A builder for the `CookieAuthType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     cookie_name: Option<String>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn cookie_name<T>(&mut self, cookie_name: T) -> &mut Self
     where
@@ -42,18 +42,15 @@ impl Builder {
         self.cookie_name = Some(cookie_name.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> CookieAuthType {
         CookieAuthType {
-            cookie_name: self
-                .cookie_name
-                .clone()
-                .expect("field cookie_name was not set"),
+            cookie_name: self.cookie_name.clone().expect("field cookie_name was not set"),
         }
     }
 }

--- a/conjure-codegen/src/types/documentation.rs
+++ b/conjure-codegen/src/types/documentation.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct Documentation(pub String);
 impl std::fmt::Display for Documentation {

--- a/conjure-codegen/src/types/endpoint_definition.rs
+++ b/conjure-codegen/src/types/endpoint_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct EndpointDefinition {
@@ -15,7 +15,7 @@ pub struct EndpointDefinition {
     tags: std::collections::BTreeSet<String>,
 }
 impl EndpointDefinition {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -61,7 +61,7 @@ impl EndpointDefinition {
         &self.tags
     }
 }
-#[doc = "A builder for the `EndpointDefinition` type."]
+///A builder for the `EndpointDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     endpoint_name: Option<super::EndpointName>,
@@ -76,22 +76,22 @@ pub struct Builder {
     tags: std::collections::BTreeSet<String>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn endpoint_name(&mut self, endpoint_name: super::EndpointName) -> &mut Self {
         self.endpoint_name = Some(endpoint_name);
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn http_method(&mut self, http_method: super::HttpMethod) -> &mut Self {
         self.http_method = Some(http_method);
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn http_path(&mut self, http_path: super::HttpPath) -> &mut Self {
         self.http_path = Some(http_path);
@@ -195,11 +195,11 @@ impl Builder {
         self.tags.insert(value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> EndpointDefinition {
         EndpointDefinition {

--- a/conjure-codegen/src/types/endpoint_name.rs
+++ b/conjure-codegen/src/types/endpoint_name.rs
@@ -1,5 +1,5 @@
-use conjure_object::serde::{de, ser};
-#[doc = "Should be in lowerCamelCase."]
+use conjure_object::serde::{ser, de};
+///Should be in lowerCamelCase.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct EndpointName(pub String);
 impl std::fmt::Display for EndpointName {

--- a/conjure-codegen/src/types/enum_definition.rs
+++ b/conjure-codegen/src/types/enum_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct EnumDefinition {
@@ -8,7 +8,7 @@ pub struct EnumDefinition {
     docs: Option<super::Documentation>,
 }
 impl EnumDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(
         type_name: super::TypeName,
@@ -24,7 +24,7 @@ impl EnumDefinition {
             docs: Some(docs),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -42,7 +42,7 @@ impl EnumDefinition {
         self.docs.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `EnumDefinition` type."]
+///A builder for the `EnumDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     type_name: Option<Box<super::TypeName>>,
@@ -50,8 +50,8 @@ pub struct Builder {
     docs: Option<super::Documentation>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_name(&mut self, type_name: super::TypeName) -> &mut Self {
         self.type_name = Some(Box::new(type_name));
@@ -86,11 +86,11 @@ impl Builder {
         self.docs = docs.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> EnumDefinition {
         EnumDefinition {

--- a/conjure-codegen/src/types/enum_value_definition.rs
+++ b/conjure-codegen/src/types/enum_value_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct EnumValueDefinition {
@@ -8,7 +8,7 @@ pub struct EnumValueDefinition {
     deprecated: Option<super::Documentation>,
 }
 impl EnumValueDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(
         value: T,
@@ -24,7 +24,7 @@ impl EnumValueDefinition {
             deprecated: Some(deprecated),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -42,7 +42,7 @@ impl EnumValueDefinition {
         self.deprecated.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `EnumValueDefinition` type."]
+///A builder for the `EnumValueDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     value: Option<String>,
@@ -50,8 +50,8 @@ pub struct Builder {
     deprecated: Option<super::Documentation>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn value<T>(&mut self, value: T) -> &mut Self
     where
@@ -76,11 +76,11 @@ impl Builder {
         self.deprecated = deprecated.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> EnumValueDefinition {
         EnumValueDefinition {

--- a/conjure-codegen/src/types/error_code.rs
+++ b/conjure-codegen/src/types/error_code.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 use std::fmt;
 use std::str;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -15,7 +15,7 @@ pub enum ErrorCode {
     CustomServer,
 }
 impl ErrorCode {
-    #[doc = r" Returns the string representation of the enum."]
+    /// Returns the string representation of the enum.
     #[inline]
     pub fn as_str(&self) -> &str {
         match self {
@@ -96,21 +96,25 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     {
         match v.parse() {
             Ok(e) => Ok(e),
-            Err(_) => Err(de::Error::unknown_variant(
-                v,
-                &[
-                    "PERMISSION_DENIED",
-                    "INVALID_ARGUMENT",
-                    "NOT_FOUND",
-                    "CONFLICT",
-                    "REQUEST_ENTITY_TOO_LARGE",
-                    "FAILED_PRECONDITION",
-                    "INTERNAL",
-                    "TIMEOUT",
-                    "CUSTOM_CLIENT",
-                    "CUSTOM_SERVER",
-                ],
-            )),
+            Err(_) => {
+                Err(
+                    de::Error::unknown_variant(
+                        v,
+                        &[
+                            "PERMISSION_DENIED",
+                            "INVALID_ARGUMENT",
+                            "NOT_FOUND",
+                            "CONFLICT",
+                            "REQUEST_ENTITY_TOO_LARGE",
+                            "FAILED_PRECONDITION",
+                            "INTERNAL",
+                            "TIMEOUT",
+                            "CUSTOM_CLIENT",
+                            "CUSTOM_SERVER",
+                        ],
+                    ),
+                )
+            }
         }
     }
 }

--- a/conjure-codegen/src/types/error_definition.rs
+++ b/conjure-codegen/src/types/error_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ErrorDefinition {
@@ -11,7 +11,7 @@ pub struct ErrorDefinition {
     unsafe_args: Vec<super::FieldDefinition>,
 }
 impl ErrorDefinition {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -41,7 +41,7 @@ impl ErrorDefinition {
         &*self.unsafe_args
     }
 }
-#[doc = "A builder for the `ErrorDefinition` type."]
+///A builder for the `ErrorDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     error_name: Option<Box<super::TypeName>>,
@@ -52,8 +52,8 @@ pub struct Builder {
     unsafe_args: Vec<super::FieldDefinition>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn error_name(&mut self, error_name: super::TypeName) -> &mut Self {
         self.error_name = Some(Box::new(error_name));
@@ -67,15 +67,15 @@ impl Builder {
         self.docs = docs.into();
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn namespace(&mut self, namespace: super::ErrorNamespace) -> &mut Self {
         self.namespace = Some(namespace);
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn code(&mut self, code: super::ErrorCode) -> &mut Self {
         self.code = Some(code);
@@ -123,18 +123,15 @@ impl Builder {
         self.unsafe_args.push(value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ErrorDefinition {
         ErrorDefinition {
-            error_name: self
-                .error_name
-                .clone()
-                .expect("field error_name was not set"),
+            error_name: self.error_name.clone().expect("field error_name was not set"),
             docs: self.docs.clone(),
             namespace: self.namespace.clone().expect("field namespace was not set"),
             code: self.code.clone().expect("field code was not set"),
@@ -203,14 +200,7 @@ impl<'de> de::Deserialize<'de> for ErrorDefinition {
     {
         d.deserialize_struct(
             "ErrorDefinition",
-            &[
-                "errorName",
-                "docs",
-                "namespace",
-                "code",
-                "safeArgs",
-                "unsafeArgs",
-            ],
+            &["errorName", "docs", "namespace", "code", "safeArgs", "unsafeArgs"],
             Visitor_,
         )
     }

--- a/conjure-codegen/src/types/error_namespace.rs
+++ b/conjure-codegen/src/types/error_namespace.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct ErrorNamespace(pub String);
 impl std::fmt::Display for ErrorNamespace {

--- a/conjure-codegen/src/types/external_reference.rs
+++ b/conjure-codegen/src/types/external_reference.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ExternalReference {
@@ -7,58 +7,64 @@ pub struct ExternalReference {
     fallback: Box<super::Type>,
 }
 impl ExternalReference {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
-    pub fn new(external_reference: super::TypeName, fallback: super::Type) -> ExternalReference {
+    pub fn new(
+        external_reference: super::TypeName,
+        fallback: super::Type,
+    ) -> ExternalReference {
         ExternalReference {
             external_reference: Box::new(external_reference),
             fallback: Box::new(fallback),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "An identifier for a non-Conjure type which is already defined in a different language (e.g. Java)."]
+    ///An identifier for a non-Conjure type which is already defined in a different language (e.g. Java).
     #[inline]
     pub fn external_reference(&self) -> &super::TypeName {
         &*self.external_reference
     }
-    #[doc = "Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable."]
+    ///Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable.
     #[inline]
     pub fn fallback(&self) -> &super::Type {
         &*self.fallback
     }
 }
-#[doc = "A builder for the `ExternalReference` type."]
+///A builder for the `ExternalReference` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     external_reference: Option<Box<super::TypeName>>,
     fallback: Option<Box<super::Type>>,
 }
 impl Builder {
-    #[doc = "An identifier for a non-Conjure type which is already defined in a different language (e.g. Java)."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///An identifier for a non-Conjure type which is already defined in a different language (e.g. Java).
+    ///
+    /// Required.
     #[inline]
-    pub fn external_reference(&mut self, external_reference: super::TypeName) -> &mut Self {
+    pub fn external_reference(
+        &mut self,
+        external_reference: super::TypeName,
+    ) -> &mut Self {
         self.external_reference = Some(Box::new(external_reference));
         self
     }
-    #[doc = "Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable.
+    ///
+    /// Required.
     #[inline]
     pub fn fallback(&mut self, fallback: super::Type) -> &mut Self {
         self.fallback = Some(Box::new(fallback));
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ExternalReference {
         ExternalReference {
@@ -117,7 +123,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
         let mut fallback = None;
         while let Some(field_) = map_.next_key()? {
             match field_ {
-                Field_::ExternalReference => external_reference = Some(map_.next_value()?),
+                Field_::ExternalReference => {
+                    external_reference = Some(map_.next_value()?);
+                }
                 Field_::Fallback => fallback = Some(map_.next_value()?),
                 Field_::Unknown_ => {
                     map_.next_value::<de::IgnoredAny>()?;

--- a/conjure-codegen/src/types/field_definition.rs
+++ b/conjure-codegen/src/types/field_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct FieldDefinition {
@@ -9,7 +9,7 @@ pub struct FieldDefinition {
     deprecated: Option<super::Documentation>,
 }
 impl FieldDefinition {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -31,7 +31,7 @@ impl FieldDefinition {
         self.deprecated.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `FieldDefinition` type."]
+///A builder for the `FieldDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     field_name: Option<super::FieldName>,
@@ -40,15 +40,15 @@ pub struct Builder {
     deprecated: Option<super::Documentation>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn field_name(&mut self, field_name: super::FieldName) -> &mut Self {
         self.field_name = Some(field_name);
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_(&mut self, type_: super::Type) -> &mut Self {
         self.type_ = Some(Box::new(type_));
@@ -70,18 +70,15 @@ impl Builder {
         self.deprecated = deprecated.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> FieldDefinition {
         FieldDefinition {
-            field_name: self
-                .field_name
-                .clone()
-                .expect("field field_name was not set"),
+            field_name: self.field_name.clone().expect("field field_name was not set"),
             type_: self.type_.clone().expect("field type_ was not set"),
             docs: self.docs.clone(),
             deprecated: self.deprecated.clone(),

--- a/conjure-codegen/src/types/field_name.rs
+++ b/conjure-codegen/src/types/field_name.rs
@@ -1,5 +1,5 @@
-use conjure_object::serde::{de, ser};
-#[doc = "Should be in lowerCamelCase, but kebab-case and snake_case are also permitted."]
+use conjure_object::serde::{ser, de};
+///Should be in lowerCamelCase, but kebab-case and snake_case are also permitted.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct FieldName(pub String);
 impl std::fmt::Display for FieldName {

--- a/conjure-codegen/src/types/header_auth_type.rs
+++ b/conjure-codegen/src/types/header_auth_type.rs
@@ -1,29 +1,29 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct HeaderAuthType {}
 impl HeaderAuthType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> HeaderAuthType {
         HeaderAuthType {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `HeaderAuthType` type."]
+///A builder for the `HeaderAuthType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> HeaderAuthType {
         HeaderAuthType {}

--- a/conjure-codegen/src/types/header_parameter_type.rs
+++ b/conjure-codegen/src/types/header_parameter_type.rs
@@ -1,17 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct HeaderParameterType {
     param_id: super::ParameterId,
 }
 impl HeaderParameterType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(param_id: super::ParameterId) -> HeaderParameterType {
-        HeaderParameterType { param_id: param_id }
+        HeaderParameterType {
+            param_id: param_id,
+        }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +23,24 @@ impl HeaderParameterType {
         &self.param_id
     }
 }
-#[doc = "A builder for the `HeaderParameterType` type."]
+///A builder for the `HeaderParameterType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     param_id: Option<super::ParameterId>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn param_id(&mut self, param_id: super::ParameterId) -> &mut Self {
         self.param_id = Some(param_id);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> HeaderParameterType {
         HeaderParameterType {

--- a/conjure-codegen/src/types/http_method.rs
+++ b/conjure-codegen/src/types/http_method.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 use std::fmt;
 use std::str;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -9,7 +9,7 @@ pub enum HttpMethod {
     Delete,
 }
 impl HttpMethod {
-    #[doc = r" Returns the string representation of the enum."]
+    /// Returns the string representation of the enum.
     #[inline]
     pub fn as_str(&self) -> &str {
         match self {
@@ -78,10 +78,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     {
         match v.parse() {
             Ok(e) => Ok(e),
-            Err(_) => Err(de::Error::unknown_variant(
-                v,
-                &["GET", "POST", "PUT", "DELETE"],
-            )),
+            Err(_) => {
+                Err(de::Error::unknown_variant(v, &["GET", "POST", "PUT", "DELETE"]))
+            }
         }
     }
 }

--- a/conjure-codegen/src/types/http_path.rs
+++ b/conjure-codegen/src/types/http_path.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct HttpPath(pub String);
 impl std::fmt::Display for HttpPath {

--- a/conjure-codegen/src/types/list_type.rs
+++ b/conjure-codegen/src/types/list_type.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ListType {
     item_type: Box<super::Type>,
 }
 impl ListType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(item_type: super::Type) -> ListType {
         ListType {
             item_type: Box::new(item_type),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +23,24 @@ impl ListType {
         &*self.item_type
     }
 }
-#[doc = "A builder for the `ListType` type."]
+///A builder for the `ListType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     item_type: Option<Box<super::Type>>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn item_type(&mut self, item_type: super::Type) -> &mut Self {
         self.item_type = Some(Box::new(item_type));
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ListType {
         ListType {

--- a/conjure-codegen/src/types/map_type.rs
+++ b/conjure-codegen/src/types/map_type.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct MapType {
@@ -7,7 +7,7 @@ pub struct MapType {
     value_type: Box<super::Type>,
 }
 impl MapType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(key_type: super::Type, value_type: super::Type) -> MapType {
         MapType {
@@ -15,7 +15,7 @@ impl MapType {
             value_type: Box::new(value_type),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -29,40 +29,37 @@ impl MapType {
         &*self.value_type
     }
 }
-#[doc = "A builder for the `MapType` type."]
+///A builder for the `MapType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     key_type: Option<Box<super::Type>>,
     value_type: Option<Box<super::Type>>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn key_type(&mut self, key_type: super::Type) -> &mut Self {
         self.key_type = Some(Box::new(key_type));
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn value_type(&mut self, value_type: super::Type) -> &mut Self {
         self.value_type = Some(Box::new(value_type));
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> MapType {
         MapType {
             key_type: self.key_type.clone().expect("field key_type was not set"),
-            value_type: self
-                .value_type
-                .clone()
-                .expect("field value_type was not set"),
+            value_type: self.value_type.clone().expect("field value_type was not set"),
         }
     }
 }
@@ -124,10 +121,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             Some(v) => v,
             None => return Err(de::Error::missing_field("valueType")),
         };
-        Ok(MapType {
-            key_type,
-            value_type,
-        })
+        Ok(MapType { key_type, value_type })
     }
 }
 enum Field_ {

--- a/conjure-codegen/src/types/object_definition.rs
+++ b/conjure-codegen/src/types/object_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ObjectDefinition {
@@ -8,7 +8,7 @@ pub struct ObjectDefinition {
     docs: Option<super::Documentation>,
 }
 impl ObjectDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(
         type_name: super::TypeName,
@@ -24,7 +24,7 @@ impl ObjectDefinition {
             docs: Some(docs),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -42,7 +42,7 @@ impl ObjectDefinition {
         self.docs.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `ObjectDefinition` type."]
+///A builder for the `ObjectDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     type_name: Option<Box<super::TypeName>>,
@@ -50,8 +50,8 @@ pub struct Builder {
     docs: Option<super::Documentation>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_name(&mut self, type_name: super::TypeName) -> &mut Self {
         self.type_name = Some(Box::new(type_name));
@@ -86,11 +86,11 @@ impl Builder {
         self.docs = docs.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ObjectDefinition {
         ObjectDefinition {

--- a/conjure-codegen/src/types/optional_type.rs
+++ b/conjure-codegen/src/types/optional_type.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct OptionalType {
     item_type: Box<super::Type>,
 }
 impl OptionalType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(item_type: super::Type) -> OptionalType {
         OptionalType {
             item_type: Box::new(item_type),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +23,24 @@ impl OptionalType {
         &*self.item_type
     }
 }
-#[doc = "A builder for the `OptionalType` type."]
+///A builder for the `OptionalType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     item_type: Option<Box<super::Type>>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn item_type(&mut self, item_type: super::Type) -> &mut Self {
         self.item_type = Some(Box::new(item_type));
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> OptionalType {
         OptionalType {

--- a/conjure-codegen/src/types/parameter_id.rs
+++ b/conjure-codegen/src/types/parameter_id.rs
@@ -1,5 +1,5 @@
-use conjure_object::serde::{de, ser};
-#[doc = "For header parameters, the parameter id must be in Upper-Kebab-Case. For query parameters, the parameter id must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word."]
+use conjure_object::serde::{ser, de};
+///For header parameters, the parameter id must be in Upper-Kebab-Case. For query parameters, the parameter id must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct ParameterId(pub String);
 impl std::fmt::Display for ParameterId {

--- a/conjure-codegen/src/types/parameter_type.rs
+++ b/conjure-codegen/src/types/parameter_type.rs
@@ -1,6 +1,6 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum ParameterType {
@@ -76,12 +76,16 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                         ParameterType::Query(value)
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -108,10 +112,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -164,10 +170,12 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
             "path" => Variant_::Path,
             "query" => Variant_::Query,
             value => {
-                return Err(de::Error::unknown_variant(
-                    value,
-                    &["body", "header", "path", "query"],
-                ))
+                return Err(
+                    de::Error::unknown_variant(
+                        value,
+                        &["body", "header", "path", "query"],
+                    ),
+                );
             }
         };
         Ok(v)

--- a/conjure-codegen/src/types/path_parameter_type.rs
+++ b/conjure-codegen/src/types/path_parameter_type.rs
@@ -1,29 +1,29 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct PathParameterType {}
 impl PathParameterType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> PathParameterType {
         PathParameterType {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `PathParameterType` type."]
+///A builder for the `PathParameterType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> PathParameterType {
         PathParameterType {}

--- a/conjure-codegen/src/types/primitive_type.rs
+++ b/conjure-codegen/src/types/primitive_type.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 use std::fmt;
 use std::str;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -16,7 +16,7 @@ pub enum PrimitiveType {
     Bearertoken,
 }
 impl PrimitiveType {
-    #[doc = r" Returns the string representation of the enum."]
+    /// Returns the string representation of the enum.
     #[inline]
     pub fn as_str(&self) -> &str {
         match self {
@@ -47,7 +47,9 @@ impl conjure_object::Plain for PrimitiveType {
 impl str::FromStr for PrimitiveType {
     type Err = conjure_object::plain::ParseEnumError;
     #[inline]
-    fn from_str(v: &str) -> Result<PrimitiveType, conjure_object::plain::ParseEnumError> {
+    fn from_str(
+        v: &str,
+    ) -> Result<PrimitiveType, conjure_object::plain::ParseEnumError> {
         match v {
             "STRING" => Ok(PrimitiveType::String),
             "DATETIME" => Ok(PrimitiveType::Datetime),
@@ -67,7 +69,9 @@ impl str::FromStr for PrimitiveType {
 impl conjure_object::FromPlain for PrimitiveType {
     type Err = conjure_object::plain::ParseEnumError;
     #[inline]
-    fn from_plain(v: &str) -> Result<PrimitiveType, conjure_object::plain::ParseEnumError> {
+    fn from_plain(
+        v: &str,
+    ) -> Result<PrimitiveType, conjure_object::plain::ParseEnumError> {
         v.parse()
     }
 }
@@ -99,22 +103,26 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     {
         match v.parse() {
             Ok(e) => Ok(e),
-            Err(_) => Err(de::Error::unknown_variant(
-                v,
-                &[
-                    "STRING",
-                    "DATETIME",
-                    "INTEGER",
-                    "DOUBLE",
-                    "SAFELONG",
-                    "BINARY",
-                    "ANY",
-                    "BOOLEAN",
-                    "UUID",
-                    "RID",
-                    "BEARERTOKEN",
-                ],
-            )),
+            Err(_) => {
+                Err(
+                    de::Error::unknown_variant(
+                        v,
+                        &[
+                            "STRING",
+                            "DATETIME",
+                            "INTEGER",
+                            "DOUBLE",
+                            "SAFELONG",
+                            "BINARY",
+                            "ANY",
+                            "BOOLEAN",
+                            "UUID",
+                            "RID",
+                            "BEARERTOKEN",
+                        ],
+                    ),
+                )
+            }
         }
     }
 }

--- a/conjure-codegen/src/types/query_parameter_type.rs
+++ b/conjure-codegen/src/types/query_parameter_type.rs
@@ -1,17 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct QueryParameterType {
     param_id: super::ParameterId,
 }
 impl QueryParameterType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(param_id: super::ParameterId) -> QueryParameterType {
-        QueryParameterType { param_id: param_id }
+        QueryParameterType {
+            param_id: param_id,
+        }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +23,24 @@ impl QueryParameterType {
         &self.param_id
     }
 }
-#[doc = "A builder for the `QueryParameterType` type."]
+///A builder for the `QueryParameterType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     param_id: Option<super::ParameterId>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn param_id(&mut self, param_id: super::ParameterId) -> &mut Self {
         self.param_id = Some(param_id);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> QueryParameterType {
         QueryParameterType {

--- a/conjure-codegen/src/types/service_definition.rs
+++ b/conjure-codegen/src/types/service_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ServiceDefinition {
@@ -8,7 +8,7 @@ pub struct ServiceDefinition {
     docs: Option<super::Documentation>,
 }
 impl ServiceDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(
         service_name: super::TypeName,
@@ -24,7 +24,7 @@ impl ServiceDefinition {
             docs: Some(docs),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -42,7 +42,7 @@ impl ServiceDefinition {
         self.docs.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `ServiceDefinition` type."]
+///A builder for the `ServiceDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     service_name: Option<Box<super::TypeName>>,
@@ -50,8 +50,8 @@ pub struct Builder {
     docs: Option<super::Documentation>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn service_name(&mut self, service_name: super::TypeName) -> &mut Self {
         self.service_name = Some(Box::new(service_name));
@@ -86,11 +86,11 @@ impl Builder {
         self.docs = docs.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ServiceDefinition {
         ServiceDefinition {

--- a/conjure-codegen/src/types/set_type.rs
+++ b/conjure-codegen/src/types/set_type.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct SetType {
     item_type: Box<super::Type>,
 }
 impl SetType {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(item_type: super::Type) -> SetType {
         SetType {
             item_type: Box::new(item_type),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +23,24 @@ impl SetType {
         &*self.item_type
     }
 }
-#[doc = "A builder for the `SetType` type."]
+///A builder for the `SetType` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     item_type: Option<Box<super::Type>>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn item_type(&mut self, item_type: super::Type) -> &mut Self {
         self.item_type = Some(Box::new(item_type));
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> SetType {
         SetType {

--- a/conjure-codegen/src/types/type_definition.rs
+++ b/conjure-codegen/src/types/type_definition.rs
@@ -1,6 +1,6 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum TypeDefinition {
@@ -76,12 +76,16 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                         TypeDefinition::Union(value)
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -108,10 +112,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -164,10 +170,12 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
             "object" => Variant_::Object,
             "union" => Variant_::Union,
             value => {
-                return Err(de::Error::unknown_variant(
-                    value,
-                    &["alias", "enum", "object", "union"],
-                ))
+                return Err(
+                    de::Error::unknown_variant(
+                        value,
+                        &["alias", "enum", "object", "union"],
+                    ),
+                );
             }
         };
         Ok(v)

--- a/conjure-codegen/src/types/type_name.rs
+++ b/conjure-codegen/src/types/type_name.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct TypeName {
@@ -7,7 +7,7 @@ pub struct TypeName {
     package: String,
 }
 impl TypeName {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(name: T, package: U) -> TypeName
     where
@@ -19,32 +19,32 @@ impl TypeName {
             package: package.into(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: \"FooBar\", \"XYCoordinate\", \"Build2Request\". Disallowed names: \"fooBar\", \"2BuildRequest\"."]
+    ///The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: "FooBar", "XYCoordinate", "Build2Request". Disallowed names: "fooBar", "2BuildRequest".
     #[inline]
     pub fn name(&self) -> &str {
         &*self.name
     }
-    #[doc = "A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: \"foo\", \"com.palantir.bar\", \"com.palantir.foo.thing2\". Disallowed packages: \"Foo\", \"com.palantir.foo.2thing\"."]
+    ///A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: "foo", "com.palantir.bar", "com.palantir.foo.thing2". Disallowed packages: "Foo", "com.palantir.foo.2thing".
     #[inline]
     pub fn package(&self) -> &str {
         &*self.package
     }
 }
-#[doc = "A builder for the `TypeName` type."]
+///A builder for the `TypeName` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     name: Option<String>,
     package: Option<String>,
 }
 impl Builder {
-    #[doc = "The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: \"FooBar\", \"XYCoordinate\", \"Build2Request\". Disallowed names: \"fooBar\", \"2BuildRequest\"."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: "FooBar", "XYCoordinate", "Build2Request". Disallowed names: "fooBar", "2BuildRequest".
+    ///
+    /// Required.
     #[inline]
     pub fn name<T>(&mut self, name: T) -> &mut Self
     where
@@ -53,9 +53,9 @@ impl Builder {
         self.name = Some(name.into());
         self
     }
-    #[doc = "A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: \"foo\", \"com.palantir.bar\", \"com.palantir.foo.thing2\". Disallowed packages: \"Foo\", \"com.palantir.foo.2thing\"."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: "foo", "com.palantir.bar", "com.palantir.foo.thing2". Disallowed packages: "Foo", "com.palantir.foo.2thing".
+    ///
+    /// Required.
     #[inline]
     pub fn package<T>(&mut self, package: T) -> &mut Self
     where
@@ -64,11 +64,11 @@ impl Builder {
         self.package = Some(package.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> TypeName {
         TypeName {

--- a/conjure-codegen/src/types/union_definition.rs
+++ b/conjure-codegen/src/types/union_definition.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct UnionDefinition {
@@ -8,7 +8,7 @@ pub struct UnionDefinition {
     docs: Option<super::Documentation>,
 }
 impl UnionDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(
         type_name: super::TypeName,
@@ -24,7 +24,7 @@ impl UnionDefinition {
             docs: Some(docs),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -42,7 +42,7 @@ impl UnionDefinition {
         self.docs.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `UnionDefinition` type."]
+///A builder for the `UnionDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     type_name: Option<Box<super::TypeName>>,
@@ -50,8 +50,8 @@ pub struct Builder {
     docs: Option<super::Documentation>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_name(&mut self, type_name: super::TypeName) -> &mut Self {
         self.type_name = Some(Box::new(type_name));
@@ -86,11 +86,11 @@ impl Builder {
         self.docs = docs.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> UnionDefinition {
         UnionDefinition {

--- a/conjure-error/src/lib.rs
+++ b/conjure-error/src/lib.rs
@@ -33,6 +33,7 @@ use serde::de::DeserializeSeed;
 mod error;
 mod ser;
 #[allow(clippy::all, missing_docs)]
+#[rustfmt::skip]
 mod types;
 
 impl ErrorCode {

--- a/conjure-error/src/types/conflict.rs
+++ b/conjure-error/src/types/conflict.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `CONFLICT` error."]
+///A generic `CONFLICT` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct Conflict {}
 impl Conflict {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> Conflict {
         Conflict {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `Conflict` type."]
+///A builder for the `Conflict` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> Conflict {
         Conflict {}

--- a/conjure-error/src/types/error_code.rs
+++ b/conjure-error/src/types/error_code.rs
@@ -1,9 +1,9 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 use std::fmt;
 use std::str;
-#[doc = "The broad category of a Conjure error."]
-#[doc = ""]
-#[doc = "When an error is transmitted over HTTP, this determines the response's status code."]
+///The broad category of a Conjure error.
+///
+///When an error is transmitted over HTTP, this determines the response's status code.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ErrorCode {
     PermissionDenied,
@@ -18,7 +18,7 @@ pub enum ErrorCode {
     CustomServer,
 }
 impl ErrorCode {
-    #[doc = r" Returns the string representation of the enum."]
+    /// Returns the string representation of the enum.
     #[inline]
     pub fn as_str(&self) -> &str {
         match self {
@@ -99,21 +99,25 @@ impl<'de> de::Visitor<'de> for Visitor_ {
     {
         match v.parse() {
             Ok(e) => Ok(e),
-            Err(_) => Err(de::Error::unknown_variant(
-                v,
-                &[
-                    "PERMISSION_DENIED",
-                    "INVALID_ARGUMENT",
-                    "NOT_FOUND",
-                    "CONFLICT",
-                    "REQUEST_ENTITY_TOO_LARGE",
-                    "FAILED_PRECONDITION",
-                    "INTERNAL",
-                    "TIMEOUT",
-                    "CUSTOM_CLIENT",
-                    "CUSTOM_SERVER",
-                ],
-            )),
+            Err(_) => {
+                Err(
+                    de::Error::unknown_variant(
+                        v,
+                        &[
+                            "PERMISSION_DENIED",
+                            "INVALID_ARGUMENT",
+                            "NOT_FOUND",
+                            "CONFLICT",
+                            "REQUEST_ENTITY_TOO_LARGE",
+                            "FAILED_PRECONDITION",
+                            "INTERNAL",
+                            "TIMEOUT",
+                            "CUSTOM_CLIENT",
+                            "CUSTOM_SERVER",
+                        ],
+                    ),
+                )
+            }
         }
     }
 }

--- a/conjure-error/src/types/failed_precondition.rs
+++ b/conjure-error/src/types/failed_precondition.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `FAILED_PRECONDITION` error."]
+///A generic `FAILED_PRECONDITION` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct FailedPrecondition {}
 impl FailedPrecondition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> FailedPrecondition {
         FailedPrecondition {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `FailedPrecondition` type."]
+///A builder for the `FailedPrecondition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> FailedPrecondition {
         FailedPrecondition {}

--- a/conjure-error/src/types/internal.rs
+++ b/conjure-error/src/types/internal.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `INTERNAL` error."]
+///A generic `INTERNAL` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct Internal {}
 impl Internal {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> Internal {
         Internal {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `Internal` type."]
+///A builder for the `Internal` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> Internal {
         Internal {}

--- a/conjure-error/src/types/invalid_argument.rs
+++ b/conjure-error/src/types/invalid_argument.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `INVALID_ARGUMENT` error."]
+///A generic `INVALID_ARGUMENT` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct InvalidArgument {}
 impl InvalidArgument {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> InvalidArgument {
         InvalidArgument {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `InvalidArgument` type."]
+///A builder for the `InvalidArgument` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> InvalidArgument {
         InvalidArgument {}

--- a/conjure-error/src/types/mod.rs
+++ b/conjure-error/src/types/mod.rs
@@ -1,30 +1,30 @@
 #[doc(inline)]
-pub use self::conflict::Conflict;
-#[doc(inline)]
 pub use self::error_code::ErrorCode;
 #[doc(inline)]
-pub use self::failed_precondition::FailedPrecondition;
+pub use self::serializable_error::SerializableError;
 #[doc(inline)]
-pub use self::internal::Internal;
+pub use self::permission_denied::PermissionDenied;
 #[doc(inline)]
 pub use self::invalid_argument::InvalidArgument;
 #[doc(inline)]
 pub use self::not_found::NotFound;
 #[doc(inline)]
-pub use self::permission_denied::PermissionDenied;
+pub use self::conflict::Conflict;
 #[doc(inline)]
 pub use self::request_entity_too_large::RequestEntityTooLarge;
 #[doc(inline)]
-pub use self::serializable_error::SerializableError;
+pub use self::failed_precondition::FailedPrecondition;
+#[doc(inline)]
+pub use self::internal::Internal;
 #[doc(inline)]
 pub use self::timeout::Timeout;
-pub mod conflict;
 pub mod error_code;
-pub mod failed_precondition;
-pub mod internal;
+pub mod serializable_error;
+pub mod permission_denied;
 pub mod invalid_argument;
 pub mod not_found;
-pub mod permission_denied;
+pub mod conflict;
 pub mod request_entity_too_large;
-pub mod serializable_error;
+pub mod failed_precondition;
+pub mod internal;
 pub mod timeout;

--- a/conjure-error/src/types/not_found.rs
+++ b/conjure-error/src/types/not_found.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `NOT_FOUND` error."]
+///A generic `NOT_FOUND` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct NotFound {}
 impl NotFound {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> NotFound {
         NotFound {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `NotFound` type."]
+///A builder for the `NotFound` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> NotFound {
         NotFound {}

--- a/conjure-error/src/types/permission_denied.rs
+++ b/conjure-error/src/types/permission_denied.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `PERMISSION_DENIED` error."]
+///A generic `PERMISSION_DENIED` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct PermissionDenied {}
 impl PermissionDenied {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> PermissionDenied {
         PermissionDenied {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `PermissionDenied` type."]
+///A builder for the `PermissionDenied` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> PermissionDenied {
         PermissionDenied {}

--- a/conjure-error/src/types/request_entity_too_large.rs
+++ b/conjure-error/src/types/request_entity_too_large.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `REQUEST_ENTITY_TOO_LARGE` error."]
+///A generic `REQUEST_ENTITY_TOO_LARGE` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct RequestEntityTooLarge {}
 impl RequestEntityTooLarge {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> RequestEntityTooLarge {
         RequestEntityTooLarge {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `RequestEntityTooLarge` type."]
+///A builder for the `RequestEntityTooLarge` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> RequestEntityTooLarge {
         RequestEntityTooLarge {}

--- a/conjure-error/src/types/serializable_error.rs
+++ b/conjure-error/src/types/serializable_error.rs
@@ -1,7 +1,7 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "The JSON-serializable representation of an error."]
+///The JSON-serializable representation of an error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct SerializableError {
     error_code: super::ErrorCode,
@@ -10,40 +10,40 @@ pub struct SerializableError {
     parameters: std::collections::BTreeMap<String, String>,
 }
 impl SerializableError {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "The broad category of the error."]
-    #[doc = ""]
-    #[doc = "When transmitted over HTTP, this determines the response's status code."]
+    ///The broad category of the error.
+    ///
+    ///When transmitted over HTTP, this determines the response's status code.
     #[inline]
     pub fn error_code(&self) -> &super::ErrorCode {
         &self.error_code
     }
-    #[doc = "The error's name."]
-    #[doc = ""]
-    #[doc = "The name is made up of a namespace and more specific error name, separated by a `:`."]
+    ///The error's name.
+    ///
+    ///The name is made up of a namespace and more specific error name, separated by a `:`.
     #[inline]
     pub fn error_name(&self) -> &str {
         &*self.error_name
     }
-    #[doc = "A unique identifier for this error instance."]
-    #[doc = ""]
-    #[doc = "This can be used to correlate reporting about the error as it transfers between components of a"]
-    #[doc = "distributed system."]
+    ///A unique identifier for this error instance.
+    ///
+    ///This can be used to correlate reporting about the error as it transfers between components of a
+    ///distributed system.
     #[inline]
     pub fn error_instance_id(&self) -> conjure_object::Uuid {
         self.error_instance_id
     }
-    #[doc = "Parameters providing more information about the error."]
+    ///Parameters providing more information about the error.
     #[inline]
     pub fn parameters(&self) -> &std::collections::BTreeMap<String, String> {
         &self.parameters
     }
 }
-#[doc = "A builder for the `SerializableError` type."]
+///A builder for the `SerializableError` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     error_code: Option<super::ErrorCode>,
@@ -52,21 +52,21 @@ pub struct Builder {
     parameters: std::collections::BTreeMap<String, String>,
 }
 impl Builder {
-    #[doc = "The broad category of the error."]
-    #[doc = ""]
-    #[doc = "When transmitted over HTTP, this determines the response's status code."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///The broad category of the error.
+    ///
+    ///When transmitted over HTTP, this determines the response's status code.
+    ///
+    /// Required.
     #[inline]
     pub fn error_code(&mut self, error_code: super::ErrorCode) -> &mut Self {
         self.error_code = Some(error_code);
         self
     }
-    #[doc = "The error's name."]
-    #[doc = ""]
-    #[doc = "The name is made up of a namespace and more specific error name, separated by a `:`."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///The error's name.
+    ///
+    ///The name is made up of a namespace and more specific error name, separated by a `:`.
+    ///
+    /// Required.
     #[inline]
     pub fn error_name<T>(&mut self, error_name: T) -> &mut Self
     where
@@ -75,18 +75,21 @@ impl Builder {
         self.error_name = Some(error_name.into());
         self
     }
-    #[doc = "A unique identifier for this error instance."]
-    #[doc = ""]
-    #[doc = "This can be used to correlate reporting about the error as it transfers between components of a"]
-    #[doc = "distributed system."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///A unique identifier for this error instance.
+    ///
+    ///This can be used to correlate reporting about the error as it transfers between components of a
+    ///distributed system.
+    ///
+    /// Required.
     #[inline]
-    pub fn error_instance_id(&mut self, error_instance_id: conjure_object::Uuid) -> &mut Self {
+    pub fn error_instance_id(
+        &mut self,
+        error_instance_id: conjure_object::Uuid,
+    ) -> &mut Self {
         self.error_instance_id = Some(error_instance_id);
         self
     }
-    #[doc = "Parameters providing more information about the error."]
+    ///Parameters providing more information about the error.
     #[inline]
     pub fn parameters<T>(&mut self, parameters: T) -> &mut Self
     where
@@ -95,7 +98,7 @@ impl Builder {
         self.parameters = parameters.into_iter().collect();
         self
     }
-    #[doc = "Parameters providing more information about the error."]
+    ///Parameters providing more information about the error.
     #[inline]
     pub fn extend_parameters<T>(&mut self, parameters: T) -> &mut Self
     where
@@ -104,7 +107,7 @@ impl Builder {
         self.parameters.extend(parameters);
         self
     }
-    #[doc = "Parameters providing more information about the error."]
+    ///Parameters providing more information about the error.
     #[inline]
     pub fn insert_parameters<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
@@ -114,22 +117,16 @@ impl Builder {
         self.parameters.insert(key.into(), value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> SerializableError {
         SerializableError {
-            error_code: self
-                .error_code
-                .clone()
-                .expect("field error_code was not set"),
-            error_name: self
-                .error_name
-                .clone()
-                .expect("field error_name was not set"),
+            error_code: self.error_code.clone().expect("field error_code was not set"),
+            error_name: self.error_name.clone().expect("field error_name was not set"),
             error_instance_id: self
                 .error_instance_id
                 .clone()

--- a/conjure-error/src/types/timeout.rs
+++ b/conjure-error/src/types/timeout.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "A generic `TIMEOUT` error."]
+///A generic `TIMEOUT` error.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct Timeout {}
 impl Timeout {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> Timeout {
         Timeout {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `Timeout` type."]
+///A builder for the `Timeout` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> Timeout {
         Timeout {}

--- a/example-api/src/another/different_package.rs
+++ b/example-api/src/another/different_package.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Different package."]
+///Different package.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct DifferentPackage {}
 impl DifferentPackage {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> DifferentPackage {
         DifferentPackage {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `DifferentPackage` type."]
+///A builder for the `DifferentPackage` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> DifferentPackage {
         DifferentPackage {}

--- a/example-api/src/another/mod.rs
+++ b/example-api/src/another/mod.rs
@@ -2,7 +2,8 @@
 pub use self::different_package::DifferentPackage;
 #[doc(inline)]
 pub use self::test_service::{
-    AsyncTestService, TestService, TestServiceAsyncClient, TestServiceClient, TestServiceEndpoints,
+    TestServiceClient, TestServiceAsyncClient, TestService, AsyncTestService,
+    TestServiceEndpoints,
 };
 pub mod different_package;
 pub mod test_service;

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -18,12 +18,12 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        > {
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -83,9 +83,9 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        > {
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -618,12 +618,12 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        > {
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -680,9 +680,9 @@ where
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        > {
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -1194,12 +1194,12 @@ pub trait TestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        >;
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    >;
     fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1211,9 +1211,9 @@ pub trait TestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        >;
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    >;
     fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1324,12 +1324,12 @@ pub trait AsyncTestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
-        >;
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
+        >,
+        conjure_http::private::Error,
+    >;
     async fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1341,9 +1341,9 @@ pub trait AsyncTestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        >;
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    >;
     async fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1555,9 +1555,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -1578,9 +1578,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1631,9 +1631,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let request = conjure_http::private::decode_serializable_request(
             &parts_,
@@ -1662,9 +1662,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1728,9 +1728,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -1755,9 +1755,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1819,9 +1819,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -1846,9 +1846,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -1910,9 +1910,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -1937,9 +1937,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2001,9 +2001,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2028,9 +2028,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2092,9 +2092,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2119,9 +2119,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2179,9 +2179,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2202,9 +2202,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2258,9 +2258,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2282,9 +2282,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2342,9 +2342,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2369,9 +2369,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2433,9 +2433,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2461,9 +2461,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2532,9 +2532,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2560,9 +2560,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2625,9 +2625,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let dataset_rid = conjure_http::private::parse_path_param(
@@ -2652,9 +2652,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2709,9 +2709,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
@@ -2774,9 +2774,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -2876,9 +2876,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
@@ -2941,9 +2941,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3040,9 +3040,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -3063,9 +3063,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3116,9 +3116,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -3139,9 +3139,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3192,9 +3192,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -3215,9 +3215,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3268,9 +3268,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let maybe_string = conjure_http::private::decode_optional_serializable_request(
             &parts_,
@@ -3294,9 +3294,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {
@@ -3353,9 +3353,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-            conjure_http::private::Error,
-        > {
+        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+        conjure_http::private::Error,
+    > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         conjure_http::private::decode_empty_request(&parts_, body_)?;
@@ -3392,9 +3392,9 @@ where
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-            conjure_http::private::Error,
-        >
+        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+        conjure_http::private::Error,
+    >
     where
         I: 'async_trait,
     {

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -1,4 +1,4 @@
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 #[derive(Clone, Debug)]
 pub struct TestServiceAsyncClient<T>(T);
 impl<T> conjure_http::client::AsyncService<T> for TestServiceAsyncClient<T>
@@ -13,14 +13,17 @@ impl<T> TestServiceAsyncClient<T>
 where
     T: conjure_http::client::AsyncClient,
 {
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     pub async fn get_file_systems(
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    > {
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -30,14 +33,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getFileSystems",
-                "/catalog/fileSystems",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getFileSystems",
+                    "/catalog/fileSystems",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn create_dataset(
         &self,
@@ -45,22 +51,30 @@ where
         request: &super::super::product::CreateDatasetRequest,
         test_header_arg: &str,
     ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&request);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &request,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets");
         *request_.uri_mut() = path_.build();
         conjure_http::private::encode_header_auth(&mut request_, auth_);
-        conjure_http::private::encode_header(&mut request_, "test-header", &test_header_arg)?;
+        conjure_http::private::encode_header(
+            &mut request_,
+            "test-header",
+            &test_header_arg,
+        )?;
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "createDataset",
-                "/catalog/datasets",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "createDataset",
+                    "/catalog/datasets",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -68,8 +82,10 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
-    {
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::async_encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -80,14 +96,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getDataset",
-                "/catalog/datasets/{datasetRid}",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getDataset",
+                    "/catalog/datasets/{datasetRid}",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn get_raw_data(
         &self,
@@ -105,12 +124,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getRawData",
-                "/catalog/datasets/{datasetRid}/raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getRawData",
+                    "/catalog/datasets/{datasetRid}/raw",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -130,12 +151,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getAliasedRawData",
-                "/catalog/datasets/{datasetRid}/raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getAliasedRawData",
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -155,12 +178,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "maybeGetRawData",
-                "/catalog/datasets/{datasetRid}/raw-maybe",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "maybeGetRawData",
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::decode_optional_binary_response(response_)
     }
@@ -180,12 +205,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getAliasedString",
-                "/catalog/datasets/{datasetRid}/string-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getAliasedString",
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -198,7 +225,9 @@ where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
         conjure_http::private::pin_mut!(input);
-        let mut request_ = conjure_http::private::async_encode_binary_request(input as _);
+        let mut request_ = conjure_http::private::async_encode_binary_request(
+            input as _,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw");
@@ -207,12 +236,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "uploadRawData",
-                "/catalog/datasets/upload-raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "uploadRawData",
+                    "/catalog/datasets/upload-raw",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
@@ -225,7 +256,9 @@ where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
         conjure_http::private::pin_mut!(input);
-        let mut request_ = conjure_http::private::async_encode_binary_request(input as _);
+        let mut request_ = conjure_http::private::async_encode_binary_request(
+            input as _,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw-aliased");
@@ -234,12 +267,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "uploadAliasedRawData",
-                "/catalog/datasets/upload-raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "uploadAliasedRawData",
+                    "/catalog/datasets/upload-raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
@@ -259,16 +294,19 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getBranches",
-                "/catalog/datasets/{datasetRid}/branches",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getBranches",
+                    "/catalog/datasets/{datasetRid}/branches",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     #[deprecated(note = "use getBranches instead")]
     pub async fn get_branches_deprecated(
         &self,
@@ -286,14 +324,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getBranchesDeprecated",
-                "/catalog/datasets/{datasetRid}/branchesDeprecated",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getBranchesDeprecated",
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn resolve_branch(
         &self,
@@ -314,14 +355,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "resolveBranch",
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "resolveBranch",
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn test_param(
         &self,
@@ -339,14 +383,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testParam",
-                "/catalog/datasets/{datasetRid}/testParam",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testParam",
+                    "/catalog/datasets/{datasetRid}/testParam",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn test_query_params(
         &self,
@@ -358,7 +405,9 @@ where
         set_end: &std::collections::BTreeSet<String>,
         optional_end: Option<&conjure_object::ResourceIdentifier>,
     ) -> Result<i32, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&query);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &query,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/test-query-params");
@@ -372,12 +421,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testQueryParams",
-                "/catalog/test-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testQueryParams",
+                    "/catalog/test-query-params",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -391,7 +442,9 @@ where
         set_end: &std::collections::BTreeSet<String>,
         optional_end: Option<&conjure_object::ResourceIdentifier>,
     ) -> Result<(), conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&query);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &query,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/test-no-response-query-params");
@@ -405,12 +458,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testNoResponseQueryParams",
-                "/catalog/test-no-response-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testNoResponseQueryParams",
+                    "/catalog/test-no-response-query-params",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
@@ -427,12 +482,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testBoolean",
-                "/catalog/boolean",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testBoolean",
+                    "/catalog/boolean",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -449,12 +506,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testDouble",
-                "/catalog/double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testDouble",
+                    "/catalog/double",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -471,12 +530,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testInteger",
-                "/catalog/integer",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testInteger",
+                    "/catalog/integer",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_serializable_response(response_).await
     }
@@ -485,7 +546,9 @@ where
         auth_: &conjure_object::BearerToken,
         maybe_string: Option<&str>,
     ) -> Result<Option<String>, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::async_encode_serializable_request(&maybe_string);
+        let mut request_ = conjure_http::private::async_encode_serializable_request(
+            &maybe_string,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/optional");
@@ -494,14 +557,17 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testPostOptional",
-                "/catalog/optional",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testPostOptional",
+                    "/catalog/optional",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
-        conjure_http::private::async_decode_default_serializable_response(response_).await
+        conjure_http::private::async_decode_default_serializable_response(response_)
+            .await
     }
     pub async fn test_optional_integer_and_double(
         &self,
@@ -520,17 +586,19 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testOptionalIntegerAndDouble",
-                "/catalog/optional-integer-double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testOptionalIntegerAndDouble",
+                    "/catalog/optional-integer-double",
+                ),
+            );
         let response_ = self.0.send(request_).await?;
         conjure_http::private::async_decode_empty_response(response_).await
     }
 }
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 #[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
 impl<T> conjure_http::client::Service<T> for TestServiceClient<T>
@@ -545,14 +613,17 @@ impl<T> TestServiceClient<T>
 where
     T: conjure_http::client::Client,
 {
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     pub fn get_file_systems(
         &self,
         auth_: &conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    > {
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -562,12 +633,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getFileSystems",
-                "/catalog/fileSystems",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getFileSystems",
+                    "/catalog/fileSystems",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -583,16 +656,22 @@ where
         path_.push_literal("/catalog/datasets");
         *request_.uri_mut() = path_.build();
         conjure_http::private::encode_header_auth(&mut request_, auth_);
-        conjure_http::private::encode_header(&mut request_, "test-header", &test_header_arg)?;
+        conjure_http::private::encode_header(
+            &mut request_,
+            "test-header",
+            &test_header_arg,
+        )?;
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "createDataset",
-                "/catalog/datasets",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "createDataset",
+                    "/catalog/datasets",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -600,8 +679,10 @@ where
         &self,
         auth_: &conjure_object::BearerToken,
         dataset_rid: &conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>
-    {
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        > {
         let mut request_ = conjure_http::private::encode_empty_request();
         *request_.method_mut() = conjure_http::private::http::Method::GET;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -612,12 +693,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getDataset",
-                "/catalog/datasets/{datasetRid}",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getDataset",
+                    "/catalog/datasets/{datasetRid}",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -637,12 +720,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getRawData",
-                "/catalog/datasets/{datasetRid}/raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getRawData",
+                    "/catalog/datasets/{datasetRid}/raw",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -662,12 +747,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getAliasedRawData",
-                "/catalog/datasets/{datasetRid}/raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getAliasedRawData",
+                    "/catalog/datasets/{datasetRid}/raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_binary_response(response_)
     }
@@ -687,12 +774,14 @@ where
         conjure_http::private::encode_binary_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "maybeGetRawData",
-                "/catalog/datasets/{datasetRid}/raw-maybe",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "maybeGetRawData",
+                    "/catalog/datasets/{datasetRid}/raw-maybe",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_optional_binary_response(response_)
     }
@@ -712,12 +801,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getAliasedString",
-                "/catalog/datasets/{datasetRid}/string-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getAliasedString",
+                    "/catalog/datasets/{datasetRid}/string-aliased",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -739,12 +830,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "uploadRawData",
-                "/catalog/datasets/upload-raw",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "uploadRawData",
+                    "/catalog/datasets/upload-raw",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
@@ -766,12 +859,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "uploadAliasedRawData",
-                "/catalog/datasets/upload-raw-aliased",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "uploadAliasedRawData",
+                    "/catalog/datasets/upload-raw-aliased",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
@@ -791,16 +886,18 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getBranches",
-                "/catalog/datasets/{datasetRid}/branches",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getBranches",
+                    "/catalog/datasets/{datasetRid}/branches",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     #[deprecated(note = "use getBranches instead")]
     pub fn get_branches_deprecated(
         &self,
@@ -818,12 +915,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "getBranchesDeprecated",
-                "/catalog/datasets/{datasetRid}/branchesDeprecated",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "getBranchesDeprecated",
+                    "/catalog/datasets/{datasetRid}/branchesDeprecated",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -846,12 +945,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "resolveBranch",
-                "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "resolveBranch",
+                    "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -871,12 +972,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testParam",
-                "/catalog/datasets/{datasetRid}/testParam",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testParam",
+                    "/catalog/datasets/{datasetRid}/testParam",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -904,12 +1007,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testQueryParams",
-                "/catalog/test-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testQueryParams",
+                    "/catalog/test-query-params",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -937,12 +1042,14 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testNoResponseQueryParams",
-                "/catalog/test-no-response-query-params",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testNoResponseQueryParams",
+                    "/catalog/test-no-response-query-params",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
@@ -959,12 +1066,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testBoolean",
-                "/catalog/boolean",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testBoolean",
+                    "/catalog/boolean",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -981,12 +1090,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testDouble",
-                "/catalog/double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testDouble",
+                    "/catalog/double",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -1003,12 +1114,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testInteger",
-                "/catalog/integer",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testInteger",
+                    "/catalog/integer",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_serializable_response(response_)
     }
@@ -1017,7 +1130,9 @@ where
         auth_: &conjure_object::BearerToken,
         maybe_string: Option<&str>,
     ) -> Result<Option<String>, conjure_http::private::Error> {
-        let mut request_ = conjure_http::private::encode_serializable_request(&maybe_string);
+        let mut request_ = conjure_http::private::encode_serializable_request(
+            &maybe_string,
+        );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/optional");
@@ -1026,12 +1141,14 @@ where
         conjure_http::private::encode_serializable_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testPostOptional",
-                "/catalog/optional",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testPostOptional",
+                    "/catalog/optional",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
@@ -1052,32 +1169,37 @@ where
         conjure_http::private::encode_empty_response_headers(&mut request_);
         request_
             .extensions_mut()
-            .insert(conjure_http::client::Endpoint::new(
-                "TestService",
-                conjure_http::private::Option::Some("0.1.0"),
-                "testOptionalIntegerAndDouble",
-                "/catalog/optional-integer-double",
-            ));
+            .insert(
+                conjure_http::client::Endpoint::new(
+                    "TestService",
+                    conjure_http::private::Option::Some("0.1.0"),
+                    "testOptionalIntegerAndDouble",
+                    "/catalog/optional-integer-double",
+                ),
+            );
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_empty_response(response_)
     }
 }
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 pub trait TestService<I, O> {
-    #[doc = "The body type returned by the `get_raw_data` method."]
+    ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
-    #[doc = "The body type returned by the `get_aliased_raw_data` method."]
+    ///The body type returned by the `get_aliased_raw_data` method.
     type GetAliasedRawDataBody: conjure_http::server::WriteBody<O> + 'static;
-    #[doc = "The body type returned by the `maybe_get_raw_data` method."]
+    ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     fn get_file_systems(
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    >;
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        >;
     fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1088,7 +1210,10 @@ pub trait TestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>;
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        >;
     fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1124,7 +1249,7 @@ pub trait TestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     fn get_branches_deprecated(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1185,23 +1310,26 @@ pub trait TestService<I, O> {
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error>;
 }
-#[doc = "A Markdown description of the service."]
+///A Markdown description of the service.
 #[conjure_http::private::async_trait]
 pub trait AsyncTestService<I, O> {
-    #[doc = "The body type returned by the `get_raw_data` method."]
+    ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
-    #[doc = "The body type returned by the `get_aliased_raw_data` method."]
+    ///The body type returned by the `get_aliased_raw_data` method.
     type GetAliasedRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
-    #[doc = "The body type returned by the `maybe_get_raw_data` method."]
+    ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
-    #[doc = "Returns a mapping from file system id to backing file system configuration."]
+    ///Returns a mapping from file system id to backing file system configuration.
     async fn get_file_systems(
         &self,
         auth_: conjure_object::BearerToken,
     ) -> Result<
-        std::collections::BTreeMap<String, super::super::product::datasets::BackingFileSystem>,
-        conjure_http::private::Error,
-    >;
+            std::collections::BTreeMap<
+                String,
+                super::super::product::datasets::BackingFileSystem,
+            >,
+            conjure_http::private::Error,
+        >;
     async fn create_dataset(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1212,7 +1340,10 @@ pub trait AsyncTestService<I, O> {
         &self,
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> Result<Option<super::super::product::datasets::Dataset>, conjure_http::private::Error>;
+    ) -> Result<
+            Option<super::super::product::datasets::Dataset>,
+            conjure_http::private::Error,
+        >;
     async fn get_raw_data(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1248,7 +1379,7 @@ pub trait AsyncTestService<I, O> {
         auth_: conjure_object::BearerToken,
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
-    #[doc = "Gets all branches of this dataset."]
+    ///Gets all branches of this dataset.
     async fn get_branches_deprecated(
         &self,
         auth_: conjure_object::BearerToken,
@@ -1311,7 +1442,7 @@ pub trait AsyncTestService<I, O> {
 }
 pub struct TestServiceEndpoints<T>(conjure_http::private::Arc<T>);
 impl<T> TestServiceEndpoints<T> {
-    #[doc = r" Creates a new resource."]
+    /// Creates a new resource.
     pub fn new(handler: T) -> TestServiceEndpoints<T> {
         TestServiceEndpoints(conjure_http::private::Arc::new(handler))
     }
@@ -1319,9 +1450,13 @@ impl<T> TestServiceEndpoints<T> {
 impl<T, I, O> conjure_http::server::Service<I, O> for TestServiceEndpoints<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
-    fn endpoints(&self) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
+    fn endpoints(
+        &self,
+    ) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),
             Box::new(CreateDatasetEndpoint_(self.0.clone())),
@@ -1351,10 +1486,11 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
-    fn endpoints(&self) -> Vec<Box<dyn conjure_http::server::AsyncEndpoint<I, O> + Sync + Send>> {
+    fn endpoints(
+        &self,
+    ) -> Vec<Box<dyn conjure_http::server::AsyncEndpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),
             Box::new(CreateDatasetEndpoint_(self.0.clone())),
@@ -1386,12 +1522,12 @@ impl<T> conjure_http::server::EndpointMetadata for GetFileSystemsEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "fileSystems",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("fileSystems"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1410,23 +1546,23 @@ impl<T> conjure_http::server::EndpointMetadata for GetFileSystemsEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetFileSystemsEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_file_systems(auth_)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1435,17 +1571,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -1463,12 +1598,12 @@ impl<T> conjure_http::server::EndpointMetadata for CreateDatasetEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1487,25 +1622,31 @@ impl<T> conjure_http::server::EndpointMetadata for CreateDatasetEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for CreateDatasetEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
-        let request = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let test_header_arg =
-            conjure_http::private::parse_required_header(&parts_, "testHeaderArg", "Test-Header")?;
+        let request = conjure_http::private::decode_serializable_request(
+            &parts_,
+            body_,
+        )?;
+        let test_header_arg = conjure_http::private::parse_required_header(
+            &parts_,
+            "testHeaderArg",
+            "Test-Header",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.create_dataset(auth_, request, test_header_arg)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1514,33 +1655,33 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
-        let request =
-            conjure_http::private::async_decode_serializable_request(&parts_, body_).await?;
-        let test_header_arg =
-            conjure_http::private::parse_required_header(&parts_, "testHeaderArg", "Test-Header")?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self
-            .0
-            .create_dataset(auth_, request, test_header_arg)
+        let request = conjure_http::private::async_decode_serializable_request(
+                &parts_,
+                body_,
+            )
             .await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        let test_header_arg = conjure_http::private::parse_required_header(
+            &parts_,
+            "testHeaderArg",
+            "Test-Header",
+        )?;
+        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
+        let response_ = self.0.create_dataset(auth_, request, test_header_arg).await?;
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct GetDatasetEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1550,12 +1691,12 @@ impl<T> conjure_http::server::EndpointMetadata for GetDatasetEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
@@ -1578,24 +1719,27 @@ impl<T> conjure_http::server::EndpointMetadata for GetDatasetEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetDatasetEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_dataset(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1604,23 +1748,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_dataset(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -1633,17 +1779,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetRawDataEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed("raw")),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("raw"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1662,19 +1810,24 @@ impl<T> conjure_http::server::EndpointMetadata for GetRawDataEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_raw_data(auth_, dataset_rid)?;
         Ok(conjure_http::private::encode_binary_response(response_))
@@ -1686,28 +1839,28 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(
-            response_,
-        ))
+        Ok(conjure_http::private::async_encode_binary_response(response_))
     }
 }
 struct GetAliasedRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1717,19 +1870,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedRawDataEndpoint_<T>
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "raw-aliased",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("raw-aliased"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1748,19 +1901,24 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedRawDataEndpoint_<T>
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid)?;
         Ok(conjure_http::private::encode_binary_response(response_))
@@ -1772,28 +1930,28 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(
-            response_,
-        ))
+        Ok(conjure_http::private::async_encode_binary_response(response_))
     }
 }
 struct MaybeGetRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1803,19 +1961,19 @@ impl<T> conjure_http::server::EndpointMetadata for MaybeGetRawDataEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "raw-maybe",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("raw-maybe"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1834,24 +1992,27 @@ impl<T> conjure_http::server::EndpointMetadata for MaybeGetRawDataEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for MaybeGetRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_optional_binary_response(
-            response_,
-        ))
+        Ok(conjure_http::private::encode_optional_binary_response(response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1860,23 +2021,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_optional_binary_response(response_))
@@ -1889,19 +2052,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedStringEndpoint_<T> 
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "string-aliased",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("string-aliased"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -1920,24 +2083,27 @@ impl<T> conjure_http::server::EndpointMetadata for GetAliasedStringEndpoint_<T> 
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedStringEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_string(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -1946,28 +2112,28 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_aliased_string(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct UploadRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -1977,15 +2143,15 @@ impl<T> conjure_http::server::EndpointMetadata for UploadRawDataEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "upload-raw",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("upload-raw"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2004,16 +2170,18 @@ impl<T> conjure_http::server::EndpointMetadata for UploadRawDataEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2027,17 +2195,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2055,15 +2222,15 @@ impl<T> conjure_http::server::EndpointMetadata for UploadAliasedRawDataEndpoint_
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "upload-raw-aliased",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("upload-raw-aliased"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2082,16 +2249,18 @@ impl<T> conjure_http::server::EndpointMetadata for UploadAliasedRawDataEndpoint_
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadAliasedRawDataEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
@@ -2100,22 +2269,22 @@ where
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for UploadAliasedRawDataEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for UploadAliasedRawDataEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2133,19 +2302,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "branches",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("branches"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2164,24 +2333,27 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2190,23 +2362,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -2219,19 +2393,19 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesDeprecatedEndpoint
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "branchesDeprecated",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("branchesDeprecated"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2250,49 +2424,55 @@ impl<T> conjure_http::server::EndpointMetadata for GetBranchesDeprecatedEndpoint
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesDeprecatedEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches_deprecated(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetBranchesDeprecatedEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for GetBranchesDeprecatedEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.get_branches_deprecated(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -2305,26 +2485,26 @@ impl<T> conjure_http::server::EndpointMetadata for ResolveBranchEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "branches",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("branches"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("branch"),
                 regex: Some(conjure_http::private::Cow::Borrowed(".+")),
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "resolve",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("resolve"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2343,25 +2523,28 @@ impl<T> conjure_http::server::EndpointMetadata for ResolveBranchEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for ResolveBranchEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.resolve_branch(auth_, dataset_rid, branch)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2370,23 +2553,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.resolve_branch(auth_, dataset_rid, branch).await?;
@@ -2400,19 +2585,19 @@ impl<T> conjure_http::server::EndpointMetadata for TestParamEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "datasets",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("datasets"),
+            ),
             conjure_http::server::PathSegment::Parameter {
                 name: conjure_http::private::Cow::Borrowed("datasetRid"),
                 regex: None,
             },
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "testParam",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("testParam"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2431,24 +2616,27 @@ impl<T> conjure_http::server::EndpointMetadata for TestParamEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestParamEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_param(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2457,23 +2645,25 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let dataset_rid = conjure_http::private::parse_path_param(&parts_, "datasetRid")?;
+        let dataset_rid = conjure_http::private::parse_path_param(
+            &parts_,
+            "datasetRid",
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_param(auth_, dataset_rid).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
@@ -2486,12 +2676,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestQueryParamsEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "test-query-params",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("test-query-params"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2510,21 +2700,26 @@ impl<T> conjure_http::server::EndpointMetadata for TestQueryParamsEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestQueryParamsEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2532,8 +2727,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2549,18 +2747,18 @@ where
             &mut optional_end,
         )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.test_query_params(
-            auth_,
-            query,
-            something,
-            optional_middle,
-            implicit,
-            set_end,
-            optional_end,
-        )?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        let response_ = self
+            .0
+            .test_query_params(
+                auth_,
+                query,
+                something,
+                optional_middle,
+                implicit,
+                set_end,
+                optional_end,
+            )?;
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2569,26 +2767,31 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query =
-            conjure_http::private::async_decode_serializable_request(&parts_, body_).await?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let query = conjure_http::private::async_decode_serializable_request(
+                &parts_,
+                body_,
+            )
+            .await?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2596,8 +2799,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2625,24 +2831,23 @@ where
                 optional_end,
             )
             .await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestNoResponseQueryParamsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestNoResponseQueryParamsEndpoint_<T> {
+impl<T> conjure_http::server::EndpointMetadata
+for TestNoResponseQueryParamsEndpoint_<T> {
     fn method(&self) -> conjure_http::private::Method {
         conjure_http::private::Method::POST
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "test-no-response-query-params",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("test-no-response-query-params"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2658,24 +2863,30 @@ impl<T> conjure_http::server::EndpointMetadata for TestNoResponseQueryParamsEndp
         None
     }
 }
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestNoResponseQueryParamsEndpoint_<T>
+impl<T, I, O> conjure_http::server::Endpoint<I, O>
+for TestNoResponseQueryParamsEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2683,8 +2894,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2700,44 +2914,51 @@ where
             &mut optional_end,
         )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.test_no_response_query_params(
-            auth_,
-            query,
-            something,
-            optional_middle,
-            implicit,
-            set_end,
-            optional_end,
-        )?;
+        self.0
+            .test_no_response_query_params(
+                auth_,
+                query,
+                something,
+                optional_middle,
+                implicit,
+                set_end,
+                optional_end,
+            )?;
         Ok(conjure_http::private::encode_empty_response())
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestNoResponseQueryParamsEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for TestNoResponseQueryParamsEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query =
-            conjure_http::private::async_decode_serializable_request(&parts_, body_).await?;
-        let something =
-            conjure_http::private::parse_query_param(&query_params_, "something", "different")?;
+        let query = conjure_http::private::async_decode_serializable_request(
+                &parts_,
+                body_,
+            )
+            .await?;
+        let something = conjure_http::private::parse_query_param(
+            &query_params_,
+            "something",
+            "different",
+        )?;
         let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
         conjure_http::private::parse_optional_query_param(
             &query_params_,
@@ -2745,8 +2966,11 @@ where
             "optionalMiddle",
             &mut optional_middle,
         )?;
-        let implicit =
-            conjure_http::private::parse_query_param(&query_params_, "implicit", "implicit")?;
+        let implicit = conjure_http::private::parse_query_param(
+            &query_params_,
+            "implicit",
+            "implicit",
+        )?;
         let mut set_end: std::collections::BTreeSet<String> = Default::default();
         conjure_http::private::parse_set_query_param(
             &query_params_,
@@ -2783,12 +3007,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestBooleanEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "boolean",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("boolean"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2807,23 +3031,23 @@ impl<T> conjure_http::server::EndpointMetadata for TestBooleanEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestBooleanEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_boolean(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2832,17 +3056,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2850,9 +3073,7 @@ where
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_boolean(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -2862,12 +3083,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestDoubleEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "double",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("double"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2886,23 +3107,23 @@ impl<T> conjure_http::server::EndpointMetadata for TestDoubleEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestDoubleEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_double(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2911,17 +3132,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -2929,9 +3149,7 @@ where
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_double(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestIntegerEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -2941,12 +3159,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestIntegerEndpoint_<T> {
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "integer",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("integer"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -2965,23 +3183,23 @@ impl<T> conjure_http::server::EndpointMetadata for TestIntegerEndpoint_<T> {
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestIntegerEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_integer(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -2990,17 +3208,16 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
@@ -3008,9 +3225,7 @@ where
         conjure_http::private::decode_empty_request(&parts_, body_)?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_integer(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::async_encode_serializable_response(&response_))
     }
 }
 struct TestPostOptionalEndpoint_<T>(conjure_http::private::Arc<T>);
@@ -3020,12 +3235,12 @@ impl<T> conjure_http::server::EndpointMetadata for TestPostOptionalEndpoint_<T> 
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "optional",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("optional"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -3044,24 +3259,26 @@ impl<T> conjure_http::server::EndpointMetadata for TestPostOptionalEndpoint_<T> 
 impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestPostOptionalEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
-        let maybe_string =
-            conjure_http::private::decode_optional_serializable_request(&parts_, body_)?;
+        let maybe_string = conjure_http::private::decode_optional_serializable_request(
+            &parts_,
+            body_,
+        )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_post_optional(auth_, maybe_string)?;
-        Ok(conjure_http::private::encode_default_serializable_response(
-            &response_,
-        ))
+        Ok(conjure_http::private::encode_default_serializable_response(&response_))
     }
 }
 #[conjure_http::private::async_trait]
@@ -3070,42 +3287,44 @@ where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {
         let (parts_, body_) = request.into_parts();
-        let maybe_string =
-            conjure_http::private::async_decode_optional_serializable_request(&parts_, body_)
-                .await?;
+        let maybe_string = conjure_http::private::async_decode_optional_serializable_request(
+                &parts_,
+                body_,
+            )
+            .await?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
         let response_ = self.0.test_post_optional(auth_, maybe_string).await?;
         Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
     }
 }
 struct TestOptionalIntegerAndDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestOptionalIntegerAndDoubleEndpoint_<T> {
+impl<T> conjure_http::server::EndpointMetadata
+for TestOptionalIntegerAndDoubleEndpoint_<T> {
     fn method(&self) -> conjure_http::private::Method {
         conjure_http::private::Method::GET
     }
     fn path(&self) -> &[conjure_http::server::PathSegment] {
         &[
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "catalog",
-            )),
-            conjure_http::server::PathSegment::Literal(conjure_http::private::Cow::Borrowed(
-                "optional-integer-double",
-            )),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("catalog"),
+            ),
+            conjure_http::server::PathSegment::Literal(
+                conjure_http::private::Cow::Borrowed("optional-integer-double"),
+            ),
         ]
     }
     fn template(&self) -> &str {
@@ -3121,19 +3340,22 @@ impl<T> conjure_http::server::EndpointMetadata for TestOptionalIntegerAndDoubleE
         None
     }
 }
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestOptionalIntegerAndDoubleEndpoint_<T>
+impl<T, I, O> conjure_http::server::Endpoint<I, O>
+for TestOptionalIntegerAndDoubleEndpoint_<T>
 where
     T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>>,
+    I: Iterator<
+        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
+    >,
 {
     fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
+            conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
+            conjure_http::private::Error,
+        > {
         let (parts_, body_) = request.into_parts();
         let query_params_ = conjure_http::private::parse_query_params(&parts_);
         conjure_http::private::decode_empty_request(&parts_, body_)?;
@@ -3152,28 +3374,27 @@ where
             &mut maybe_double,
         )?;
         let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0
-            .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
+        self.0.test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
         Ok(conjure_http::private::encode_empty_response())
     }
 }
 #[conjure_http::private::async_trait]
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestOptionalIntegerAndDoubleEndpoint_<T>
+impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
+for TestOptionalIntegerAndDoubleEndpoint_<T>
 where
     T: AsyncTestService<I, O> + 'static + Sync + Send,
     I: conjure_http::private::Stream<
             Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync
-        + Send,
+        > + Sync + Send,
 {
     async fn handle(
         &self,
         _safe_params: &mut conjure_http::SafeParams,
         request: conjure_http::private::Request<I>,
     ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    >
+            conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
+            conjure_http::private::Error,
+        >
     where
         I: 'async_trait,
     {

--- a/example-api/src/product/alias_as_map_key_example.rs
+++ b/example-api/src/product/alias_as_map_key_example.rs
@@ -1,19 +1,33 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct AliasAsMapKeyExample {
-    strings: std::collections::BTreeMap<super::StringAliasExample, super::ManyFieldExample>,
+    strings: std::collections::BTreeMap<
+        super::StringAliasExample,
+        super::ManyFieldExample,
+    >,
     rids: std::collections::BTreeMap<super::RidAliasExample, super::ManyFieldExample>,
-    bearertokens:
-        std::collections::BTreeMap<super::BearerTokenAliasExample, super::ManyFieldExample>,
-    integers: std::collections::BTreeMap<super::IntegerAliasExample, super::ManyFieldExample>,
-    safelongs: std::collections::BTreeMap<super::SafeLongAliasExample, super::ManyFieldExample>,
-    datetimes: std::collections::BTreeMap<super::DateTimeAliasExample, super::ManyFieldExample>,
+    bearertokens: std::collections::BTreeMap<
+        super::BearerTokenAliasExample,
+        super::ManyFieldExample,
+    >,
+    integers: std::collections::BTreeMap<
+        super::IntegerAliasExample,
+        super::ManyFieldExample,
+    >,
+    safelongs: std::collections::BTreeMap<
+        super::SafeLongAliasExample,
+        super::ManyFieldExample,
+    >,
+    datetimes: std::collections::BTreeMap<
+        super::DateTimeAliasExample,
+        super::ManyFieldExample,
+    >,
     uuids: std::collections::BTreeMap<super::UuidAliasExample, super::ManyFieldExample>,
 }
 impl AliasAsMapKeyExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,7 +35,10 @@ impl AliasAsMapKeyExample {
     #[inline]
     pub fn strings(
         &self,
-    ) -> &std::collections::BTreeMap<super::StringAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::StringAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.strings
     }
     #[inline]
@@ -33,25 +50,37 @@ impl AliasAsMapKeyExample {
     #[inline]
     pub fn bearertokens(
         &self,
-    ) -> &std::collections::BTreeMap<super::BearerTokenAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::BearerTokenAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.bearertokens
     }
     #[inline]
     pub fn integers(
         &self,
-    ) -> &std::collections::BTreeMap<super::IntegerAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::IntegerAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.integers
     }
     #[inline]
     pub fn safelongs(
         &self,
-    ) -> &std::collections::BTreeMap<super::SafeLongAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::SafeLongAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.safelongs
     }
     #[inline]
     pub fn datetimes(
         &self,
-    ) -> &std::collections::BTreeMap<super::DateTimeAliasExample, super::ManyFieldExample> {
+    ) -> &std::collections::BTreeMap<
+            super::DateTimeAliasExample,
+            super::ManyFieldExample,
+        > {
         &self.datetimes
     }
     #[inline]
@@ -61,16 +90,30 @@ impl AliasAsMapKeyExample {
         &self.uuids
     }
 }
-#[doc = "A builder for the `AliasAsMapKeyExample` type."]
+///A builder for the `AliasAsMapKeyExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
-    strings: std::collections::BTreeMap<super::StringAliasExample, super::ManyFieldExample>,
+    strings: std::collections::BTreeMap<
+        super::StringAliasExample,
+        super::ManyFieldExample,
+    >,
     rids: std::collections::BTreeMap<super::RidAliasExample, super::ManyFieldExample>,
-    bearertokens:
-        std::collections::BTreeMap<super::BearerTokenAliasExample, super::ManyFieldExample>,
-    integers: std::collections::BTreeMap<super::IntegerAliasExample, super::ManyFieldExample>,
-    safelongs: std::collections::BTreeMap<super::SafeLongAliasExample, super::ManyFieldExample>,
-    datetimes: std::collections::BTreeMap<super::DateTimeAliasExample, super::ManyFieldExample>,
+    bearertokens: std::collections::BTreeMap<
+        super::BearerTokenAliasExample,
+        super::ManyFieldExample,
+    >,
+    integers: std::collections::BTreeMap<
+        super::IntegerAliasExample,
+        super::ManyFieldExample,
+    >,
+    safelongs: std::collections::BTreeMap<
+        super::SafeLongAliasExample,
+        super::ManyFieldExample,
+    >,
+    datetimes: std::collections::BTreeMap<
+        super::DateTimeAliasExample,
+        super::ManyFieldExample,
+    >,
     uuids: std::collections::BTreeMap<super::UuidAliasExample, super::ManyFieldExample>,
 }
 impl Builder {
@@ -127,7 +170,9 @@ impl Builder {
     #[inline]
     pub fn bearertokens<T>(&mut self, bearertokens: T) -> &mut Self
     where
-        T: IntoIterator<Item = (super::BearerTokenAliasExample, super::ManyFieldExample)>,
+        T: IntoIterator<
+            Item = (super::BearerTokenAliasExample, super::ManyFieldExample),
+        >,
     {
         self.bearertokens = bearertokens.into_iter().collect();
         self
@@ -135,7 +180,9 @@ impl Builder {
     #[inline]
     pub fn extend_bearertokens<T>(&mut self, bearertokens: T) -> &mut Self
     where
-        T: IntoIterator<Item = (super::BearerTokenAliasExample, super::ManyFieldExample)>,
+        T: IntoIterator<
+            Item = (super::BearerTokenAliasExample, super::ManyFieldExample),
+        >,
     {
         self.bearertokens.extend(bearertokens);
         self
@@ -249,11 +296,11 @@ impl Builder {
         self.uuids.insert(key, value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> AliasAsMapKeyExample {
         AliasAsMapKeyExample {

--- a/example-api/src/product/alias_as_map_key_example.rs
+++ b/example-api/src/product/alias_as_map_key_example.rs
@@ -36,9 +36,9 @@ impl AliasAsMapKeyExample {
     pub fn strings(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::StringAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::StringAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.strings
     }
     #[inline]
@@ -51,36 +51,36 @@ impl AliasAsMapKeyExample {
     pub fn bearertokens(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::BearerTokenAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::BearerTokenAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.bearertokens
     }
     #[inline]
     pub fn integers(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::IntegerAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::IntegerAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.integers
     }
     #[inline]
     pub fn safelongs(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::SafeLongAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::SafeLongAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.safelongs
     }
     #[inline]
     pub fn datetimes(
         &self,
     ) -> &std::collections::BTreeMap<
-            super::DateTimeAliasExample,
-            super::ManyFieldExample,
-        > {
+        super::DateTimeAliasExample,
+        super::ManyFieldExample,
+    > {
         &self.datetimes
     }
     #[inline]

--- a/example-api/src/product/aliased_binary.rs
+++ b/example-api/src/product/aliased_binary.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct AliasedBinary(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for AliasedBinary {

--- a/example-api/src/product/aliased_string.rs
+++ b/example-api/src/product/aliased_string.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct AliasedString(pub String);
 impl std::fmt::Display for AliasedString {

--- a/example-api/src/product/any_example.rs
+++ b/example-api/src/product/any_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct AnyExample {
     any: conjure_object::Any,
 }
 impl AnyExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(any: T) -> AnyExample
     where
@@ -16,7 +16,7 @@ impl AnyExample {
             any: conjure_object::Any::new(any).expect("value failed to serialize"),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,27 +26,30 @@ impl AnyExample {
         &self.any
     }
 }
-#[doc = "A builder for the `AnyExample` type."]
+///A builder for the `AnyExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     any: Option<conjure_object::Any>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn any<T>(&mut self, any: T) -> &mut Self
     where
         T: conjure_object::serde::Serialize,
     {
-        self.any = Some(conjure_object::Any::new(any).expect("value failed to serialize"));
+        self
+            .any = Some(
+            conjure_object::Any::new(any).expect("value failed to serialize"),
+        );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> AnyExample {
         AnyExample {

--- a/example-api/src/product/any_map_example.rs
+++ b/example-api/src/product/any_map_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct AnyMapExample {
     items: std::collections::BTreeMap<String, conjure_object::Any>,
 }
 impl AnyMapExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(items: T) -> AnyMapExample
     where
@@ -16,7 +16,7 @@ impl AnyMapExample {
             items: items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl AnyMapExample {
         &self.items
     }
 }
-#[doc = "A builder for the `AnyMapExample` type."]
+///A builder for the `AnyMapExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: std::collections::BTreeMap<String, conjure_object::Any>,
@@ -54,17 +54,18 @@ impl Builder {
         K: Into<String>,
         V: conjure_object::serde::Serialize,
     {
-        self.items.insert(
-            key.into(),
-            conjure_object::Any::new(value).expect("value failed to serialize"),
-        );
+        self.items
+            .insert(
+                key.into(),
+                conjure_object::Any::new(value).expect("value failed to serialize"),
+            );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> AnyMapExample {
         AnyMapExample {

--- a/example-api/src/product/bearer_token_alias_example.rs
+++ b/example-api/src/product/bearer_token_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BearerTokenAliasExample(pub conjure_object::BearerToken);
 impl conjure_object::Plain for BearerTokenAliasExample {

--- a/example-api/src/product/bearer_token_example.rs
+++ b/example-api/src/product/bearer_token_example.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BearerTokenExample {
     bearer_token_value: conjure_object::BearerToken,
 }
 impl BearerTokenExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(bearer_token_value: conjure_object::BearerToken) -> BearerTokenExample {
         BearerTokenExample {
             bearer_token_value: bearer_token_value,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,14 +23,14 @@ impl BearerTokenExample {
         &self.bearer_token_value
     }
 }
-#[doc = "A builder for the `BearerTokenExample` type."]
+///A builder for the `BearerTokenExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     bearer_token_value: Option<conjure_object::BearerToken>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn bearer_token_value(
         &mut self,
@@ -39,11 +39,11 @@ impl Builder {
         self.bearer_token_value = Some(bearer_token_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BearerTokenExample {
         BearerTokenExample {
@@ -104,7 +104,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             Some(v) => v,
             None => return Err(de::Error::missing_field("bearerTokenValue")),
         };
-        Ok(BearerTokenExample { bearer_token_value })
+        Ok(BearerTokenExample {
+            bearer_token_value,
+        })
     }
 }
 enum Field_ {

--- a/example-api/src/product/binary_alias_example.rs
+++ b/example-api/src/product/binary_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct BinaryAliasExample(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for BinaryAliasExample {

--- a/example-api/src/product/binary_example.rs
+++ b/example-api/src/product/binary_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BinaryExample {
     binary: conjure_object::ByteBuf,
 }
 impl BinaryExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(binary: T) -> BinaryExample
     where
@@ -16,7 +16,7 @@ impl BinaryExample {
             binary: conjure_object::ByteBuf::from(binary),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,14 +26,14 @@ impl BinaryExample {
         &**self.binary
     }
 }
-#[doc = "A builder for the `BinaryExample` type."]
+///A builder for the `BinaryExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     binary: Option<conjure_object::ByteBuf>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn binary<T>(&mut self, binary: T) -> &mut Self
     where
@@ -42,11 +42,11 @@ impl Builder {
         self.binary = Some(conjure_object::ByteBuf::from(binary));
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BinaryExample {
         BinaryExample {
@@ -57,9 +57,7 @@ impl Builder {
 impl From<BinaryExample> for Builder {
     #[inline]
     fn from(_v: BinaryExample) -> Builder {
-        Builder {
-            binary: Some(_v.binary),
-        }
+        Builder { binary: Some(_v.binary) }
     }
 }
 impl ser::Serialize for BinaryExample {

--- a/example-api/src/product/boolean_alias_example.rs
+++ b/example-api/src/product/boolean_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
 pub struct BooleanAliasExample(pub bool);
 impl std::fmt::Display for BooleanAliasExample {

--- a/example-api/src/product/boolean_example.rs
+++ b/example-api/src/product/boolean_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct BooleanExample {
     coin: bool,
 }
 impl BooleanExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(coin: bool) -> BooleanExample {
         BooleanExample { coin: coin }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl BooleanExample {
         self.coin
     }
 }
-#[doc = "A builder for the `BooleanExample` type."]
+///A builder for the `BooleanExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     coin: Option<bool>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn coin(&mut self, coin: bool) -> &mut Self {
         self.coin = Some(coin);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BooleanExample {
         BooleanExample {
@@ -49,9 +49,7 @@ impl Builder {
 impl From<BooleanExample> for Builder {
     #[inline]
     fn from(_v: BooleanExample) -> Builder {
-        Builder {
-            coin: Some(_v.coin),
-        }
+        Builder { coin: Some(_v.coin) }
     }
 }
 impl ser::Serialize for BooleanExample {

--- a/example-api/src/product/covariant_list_example.rs
+++ b/example-api/src/product/covariant_list_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct CovariantListExample {
@@ -7,7 +7,7 @@ pub struct CovariantListExample {
     external_items: Vec<String>,
 }
 impl CovariantListExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(items: T, external_items: U) -> CovariantListExample
     where
@@ -19,7 +19,7 @@ impl CovariantListExample {
             external_items: external_items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -33,7 +33,7 @@ impl CovariantListExample {
         &*self.external_items
     }
 }
-#[doc = "A builder for the `CovariantListExample` type."]
+///A builder for the `CovariantListExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: Vec<conjure_object::Any>,
@@ -89,11 +89,11 @@ impl Builder {
         self.external_items.push(value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> CovariantListExample {
         CovariantListExample {

--- a/example-api/src/product/covariant_optional_example.rs
+++ b/example-api/src/product/covariant_optional_example.rs
@@ -1,22 +1,24 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct CovariantOptionalExample {
     item: Option<conjure_object::Any>,
 }
 impl CovariantOptionalExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(item: T) -> CovariantOptionalExample
     where
         T: conjure_object::serde::Serialize,
     {
         CovariantOptionalExample {
-            item: Some(conjure_object::Any::new(item).expect("value failed to serialize")),
+            item: Some(
+                conjure_object::Any::new(item).expect("value failed to serialize"),
+            ),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +28,7 @@ impl CovariantOptionalExample {
         self.item.as_ref().map(|o| &*o)
     }
 }
-#[doc = "A builder for the `CovariantOptionalExample` type."]
+///A builder for the `CovariantOptionalExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     item: Option<conjure_object::Any>,
@@ -40,11 +42,11 @@ impl Builder {
         self.item = item.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> CovariantOptionalExample {
         CovariantOptionalExample {

--- a/example-api/src/product/create_dataset_request.rs
+++ b/example-api/src/product/create_dataset_request.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct CreateDatasetRequest {
@@ -7,7 +7,7 @@ pub struct CreateDatasetRequest {
     path: String,
 }
 impl CreateDatasetRequest {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(file_system_id: T, path: U) -> CreateDatasetRequest
     where
@@ -19,7 +19,7 @@ impl CreateDatasetRequest {
             path: path.into(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -33,15 +33,15 @@ impl CreateDatasetRequest {
         &*self.path
     }
 }
-#[doc = "A builder for the `CreateDatasetRequest` type."]
+///A builder for the `CreateDatasetRequest` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     file_system_id: Option<String>,
     path: Option<String>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
     where
@@ -50,8 +50,8 @@ impl Builder {
         self.file_system_id = Some(file_system_id.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn path<T>(&mut self, path: T) -> &mut Self
     where
@@ -60,11 +60,11 @@ impl Builder {
         self.path = Some(path.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> CreateDatasetRequest {
         CreateDatasetRequest {

--- a/example-api/src/product/datasets/backing_file_system.rs
+++ b/example-api/src/product/datasets/backing_file_system.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct BackingFileSystem {
@@ -8,9 +8,13 @@ pub struct BackingFileSystem {
     configuration: std::collections::BTreeMap<String, String>,
 }
 impl BackingFileSystem {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
-    pub fn new<T, U, V>(file_system_id: T, base_uri: U, configuration: V) -> BackingFileSystem
+    pub fn new<T, U, V>(
+        file_system_id: T,
+        base_uri: U,
+        configuration: V,
+    ) -> BackingFileSystem
     where
         T: Into<String>,
         U: Into<String>,
@@ -22,12 +26,12 @@ impl BackingFileSystem {
             configuration: configuration.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "The name by which this file system is identified."]
+    ///The name by which this file system is identified.
     #[inline]
     pub fn file_system_id(&self) -> &str {
         &*self.file_system_id
@@ -41,7 +45,7 @@ impl BackingFileSystem {
         &self.configuration
     }
 }
-#[doc = "A builder for the `BackingFileSystem` type."]
+///A builder for the `BackingFileSystem` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     file_system_id: Option<String>,
@@ -49,9 +53,9 @@ pub struct Builder {
     configuration: std::collections::BTreeMap<String, String>,
 }
 impl Builder {
-    #[doc = "The name by which this file system is identified."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///The name by which this file system is identified.
+    ///
+    /// Required.
     #[inline]
     pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
     where
@@ -60,8 +64,8 @@ impl Builder {
         self.file_system_id = Some(file_system_id.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn base_uri<T>(&mut self, base_uri: T) -> &mut Self
     where
@@ -95,11 +99,11 @@ impl Builder {
         self.configuration.insert(key.into(), value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> BackingFileSystem {
         BackingFileSystem {

--- a/example-api/src/product/datasets/dataset.rs
+++ b/example-api/src/product/datasets/dataset.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Dataset {
@@ -7,7 +7,7 @@ pub struct Dataset {
     rid: conjure_object::ResourceIdentifier,
 }
 impl Dataset {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(file_system_id: T, rid: conjure_object::ResourceIdentifier) -> Dataset
     where
@@ -18,7 +18,7 @@ impl Dataset {
             rid: rid,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -27,21 +27,21 @@ impl Dataset {
     pub fn file_system_id(&self) -> &str {
         &*self.file_system_id
     }
-    #[doc = "Uniquely identifies this dataset."]
+    ///Uniquely identifies this dataset.
     #[inline]
     pub fn rid(&self) -> &conjure_object::ResourceIdentifier {
         &self.rid
     }
 }
-#[doc = "A builder for the `Dataset` type."]
+///A builder for the `Dataset` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     file_system_id: Option<String>,
     rid: Option<conjure_object::ResourceIdentifier>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn file_system_id<T>(&mut self, file_system_id: T) -> &mut Self
     where
@@ -50,19 +50,19 @@ impl Builder {
         self.file_system_id = Some(file_system_id.into());
         self
     }
-    #[doc = "Uniquely identifies this dataset."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///Uniquely identifies this dataset.
+    ///
+    /// Required.
     #[inline]
     pub fn rid(&mut self, rid: conjure_object::ResourceIdentifier) -> &mut Self {
         self.rid = Some(rid);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> Dataset {
         Dataset {
@@ -132,10 +132,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             Some(v) => v,
             None => return Err(de::Error::missing_field("rid")),
         };
-        Ok(Dataset {
-            file_system_id,
-            rid,
-        })
+        Ok(Dataset { file_system_id, rid })
     }
 }
 enum Field_ {

--- a/example-api/src/product/datasets/mod.rs
+++ b/example-api/src/product/datasets/mod.rs
@@ -1,6 +1,6 @@
 #[doc(inline)]
-pub use self::backing_file_system::BackingFileSystem;
-#[doc(inline)]
 pub use self::dataset::Dataset;
-pub mod backing_file_system;
+#[doc(inline)]
+pub use self::backing_file_system::BackingFileSystem;
 pub mod dataset;
+pub mod backing_file_system;

--- a/example-api/src/product/date_time_alias_example.rs
+++ b/example-api/src/product/date_time_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
 pub struct DateTimeAliasExample(pub conjure_object::DateTime<conjure_object::Utc>);
 impl std::fmt::Display for DateTimeAliasExample {
@@ -12,7 +12,9 @@ impl conjure_object::Plain for DateTimeAliasExample {
     }
 }
 impl conjure_object::FromPlain for DateTimeAliasExample {
-    type Err = <conjure_object::DateTime<conjure_object::Utc> as conjure_object::FromPlain>::Err;
+    type Err = <conjure_object::DateTime<
+        conjure_object::Utc,
+    > as conjure_object::FromPlain>::Err;
     #[inline]
     fn from_plain(s: &str) -> Result<DateTimeAliasExample, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(DateTimeAliasExample)

--- a/example-api/src/product/date_time_example.rs
+++ b/example-api/src/product/date_time_example.rs
@@ -1,17 +1,21 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct DateTimeExample {
     datetime: conjure_object::DateTime<conjure_object::Utc>,
 }
 impl DateTimeExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
-    pub fn new(datetime: conjure_object::DateTime<conjure_object::Utc>) -> DateTimeExample {
-        DateTimeExample { datetime: datetime }
+    pub fn new(
+        datetime: conjure_object::DateTime<conjure_object::Utc>,
+    ) -> DateTimeExample {
+        DateTimeExample {
+            datetime: datetime,
+        }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,14 +25,14 @@ impl DateTimeExample {
         self.datetime
     }
 }
-#[doc = "A builder for the `DateTimeExample` type."]
+///A builder for the `DateTimeExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     datetime: Option<conjure_object::DateTime<conjure_object::Utc>>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn datetime(
         &mut self,
@@ -37,11 +41,11 @@ impl Builder {
         self.datetime = Some(datetime);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> DateTimeExample {
         DateTimeExample {

--- a/example-api/src/product/double_alias_example.rs
+++ b/example-api/src/product/double_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Default)]
 pub struct DoubleAliasExample(pub f64);
 impl std::fmt::Display for DoubleAliasExample {

--- a/example-api/src/product/double_example.rs
+++ b/example-api/src/product/double_example.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy)]
 pub struct DoubleExample {
     double_value: f64,
 }
 impl DoubleExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(double_value: f64) -> DoubleExample {
         DoubleExample {
             double_value: double_value,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +23,24 @@ impl DoubleExample {
         self.double_value
     }
 }
-#[doc = "A builder for the `DoubleExample` type."]
+///A builder for the `DoubleExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     double_value: Option<f64>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn double_value(&mut self, double_value: f64) -> &mut Self {
         self.double_value = Some(double_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> DoubleExample {
         DoubleExample {

--- a/example-api/src/product/empty_object_example.rs
+++ b/example-api/src/product/empty_object_example.rs
@@ -1,29 +1,29 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct EmptyObjectExample {}
 impl EmptyObjectExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> EmptyObjectExample {
         EmptyObjectExample {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `EmptyObjectExample` type."]
+///A builder for the `EmptyObjectExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> EmptyObjectExample {
         EmptyObjectExample {}

--- a/example-api/src/product/enum_example.rs
+++ b/example-api/src/product/enum_example.rs
@@ -1,16 +1,16 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 use std::fmt;
 use std::str;
-#[doc = "This enumerates the numbers 1:2."]
+///This enumerates the numbers 1:2.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum EnumExample {
     One,
     Two,
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl EnumExample {
-    #[doc = r" Returns the string representation of the enum."]
+    /// Returns the string representation of the enum.
     #[inline]
     pub fn as_str(&self) -> &str {
         match self {
@@ -39,9 +39,7 @@ impl str::FromStr for EnumExample {
             "TWO" => Ok(EnumExample::Two),
             v => {
                 if conjure_object::private::valid_enum_variant(v) {
-                    Ok(EnumExample::Unknown(Unknown(
-                        v.to_string().into_boxed_str(),
-                    )))
+                    Ok(EnumExample::Unknown(Unknown(v.to_string().into_boxed_str())))
                 } else {
                     Err(conjure_object::plain::ParseEnumError::new())
                 }
@@ -52,7 +50,9 @@ impl str::FromStr for EnumExample {
 impl conjure_object::FromPlain for EnumExample {
     type Err = conjure_object::plain::ParseEnumError;
     #[inline]
-    fn from_plain(v: &str) -> Result<EnumExample, conjure_object::plain::ParseEnumError> {
+    fn from_plain(
+        v: &str,
+    ) -> Result<EnumExample, conjure_object::plain::ParseEnumError> {
         v.parse()
     }
 }
@@ -88,7 +88,7 @@ impl<'de> de::Visitor<'de> for Visitor_ {
         }
     }
 }
-#[doc = "An unknown variant of the EnumExample enum."]
+///An unknown variant of the EnumExample enum.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown(Box<str>);
 impl std::ops::Deref for Unknown {

--- a/example-api/src/product/enum_field_example.rs
+++ b/example-api/src/product/enum_field_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct EnumFieldExample {
     enum_: super::EnumExample,
 }
 impl EnumFieldExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(enum_: super::EnumExample) -> EnumFieldExample {
         EnumFieldExample { enum_: enum_ }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl EnumFieldExample {
         &self.enum_
     }
 }
-#[doc = "A builder for the `EnumFieldExample` type."]
+///A builder for the `EnumFieldExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     enum_: Option<super::EnumExample>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn enum_(&mut self, enum_: super::EnumExample) -> &mut Self {
         self.enum_ = Some(enum_);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> EnumFieldExample {
         EnumFieldExample {
@@ -49,9 +49,7 @@ impl Builder {
 impl From<EnumFieldExample> for Builder {
     #[inline]
     fn from(_v: EnumFieldExample) -> Builder {
-        Builder {
-            enum_: Some(_v.enum_),
-        }
+        Builder { enum_: Some(_v.enum_) }
     }
 }
 impl ser::Serialize for EnumFieldExample {

--- a/example-api/src/product/integer_alias_example.rs
+++ b/example-api/src/product/integer_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
 pub struct IntegerAliasExample(pub i32);
 impl std::fmt::Display for IntegerAliasExample {

--- a/example-api/src/product/integer_example.rs
+++ b/example-api/src/product/integer_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct IntegerExample {
     integer: i32,
 }
 impl IntegerExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(integer: i32) -> IntegerExample {
         IntegerExample { integer: integer }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl IntegerExample {
         self.integer
     }
 }
-#[doc = "A builder for the `IntegerExample` type."]
+///A builder for the `IntegerExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     integer: Option<i32>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn integer(&mut self, integer: i32) -> &mut Self {
         self.integer = Some(integer);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> IntegerExample {
         IntegerExample {

--- a/example-api/src/product/invalid_service_definition.rs
+++ b/example-api/src/product/invalid_service_definition.rs
@@ -1,14 +1,14 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Invalid Conjure service definition."]
+///Invalid Conjure service definition.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct InvalidServiceDefinition {
     service_name: String,
     service_def: conjure_object::Any,
 }
 impl InvalidServiceDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(service_name: T, service_def: U) -> InvalidServiceDefinition
     where
@@ -17,35 +17,36 @@ impl InvalidServiceDefinition {
     {
         InvalidServiceDefinition {
             service_name: service_name.into(),
-            service_def: conjure_object::Any::new(service_def).expect("value failed to serialize"),
+            service_def: conjure_object::Any::new(service_def)
+                .expect("value failed to serialize"),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "Name of the invalid service definition."]
+    ///Name of the invalid service definition.
     #[inline]
     pub fn service_name(&self) -> &str {
         &*self.service_name
     }
-    #[doc = "Details of the invalid service definition."]
+    ///Details of the invalid service definition.
     #[inline]
     pub fn service_def(&self) -> &conjure_object::Any {
         &self.service_def
     }
 }
-#[doc = "A builder for the `InvalidServiceDefinition` type."]
+///A builder for the `InvalidServiceDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     service_name: Option<String>,
     service_def: Option<conjure_object::Any>,
 }
 impl Builder {
-    #[doc = "Name of the invalid service definition."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///Name of the invalid service definition.
+    ///
+    /// Required.
     #[inline]
     pub fn service_name<T>(&mut self, service_name: T) -> &mut Self
     where
@@ -54,23 +55,25 @@ impl Builder {
         self.service_name = Some(service_name.into());
         self
     }
-    #[doc = "Details of the invalid service definition."]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///Details of the invalid service definition.
+    ///
+    /// Required.
     #[inline]
     pub fn service_def<T>(&mut self, service_def: T) -> &mut Self
     where
         T: conjure_object::serde::Serialize,
     {
-        self.service_def =
-            Some(conjure_object::Any::new(service_def).expect("value failed to serialize"));
+        self
+            .service_def = Some(
+            conjure_object::Any::new(service_def).expect("value failed to serialize"),
+        );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> InvalidServiceDefinition {
         InvalidServiceDefinition {
@@ -78,10 +81,7 @@ impl Builder {
                 .service_name
                 .clone()
                 .expect("field service_name was not set"),
-            service_def: self
-                .service_def
-                .clone()
-                .expect("field service_def was not set"),
+            service_def: self.service_def.clone().expect("field service_def was not set"),
         }
     }
 }

--- a/example-api/src/product/invalid_type_definition.rs
+++ b/example-api/src/product/invalid_type_definition.rs
@@ -1,14 +1,14 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Invalid Conjure type definition."]
+///Invalid Conjure type definition.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct InvalidTypeDefinition {
     type_name: String,
     type_def: conjure_object::Any,
 }
 impl InvalidTypeDefinition {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U>(type_name: T, type_def: U) -> InvalidTypeDefinition
     where
@@ -17,10 +17,11 @@ impl InvalidTypeDefinition {
     {
         InvalidTypeDefinition {
             type_name: type_name.into(),
-            type_def: conjure_object::Any::new(type_def).expect("value failed to serialize"),
+            type_def: conjure_object::Any::new(type_def)
+                .expect("value failed to serialize"),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -34,15 +35,15 @@ impl InvalidTypeDefinition {
         &self.type_def
     }
 }
-#[doc = "A builder for the `InvalidTypeDefinition` type."]
+///A builder for the `InvalidTypeDefinition` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     type_name: Option<String>,
     type_def: Option<conjure_object::Any>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_name<T>(&mut self, type_name: T) -> &mut Self
     where
@@ -51,22 +52,24 @@ impl Builder {
         self.type_name = Some(type_name.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn type_def<T>(&mut self, type_def: T) -> &mut Self
     where
         T: conjure_object::serde::Serialize,
     {
-        self.type_def =
-            Some(conjure_object::Any::new(type_def).expect("value failed to serialize"));
+        self
+            .type_def = Some(
+            conjure_object::Any::new(type_def).expect("value failed to serialize"),
+        );
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> InvalidTypeDefinition {
         InvalidTypeDefinition {

--- a/example-api/src/product/java_compilation_failed.rs
+++ b/example-api/src/product/java_compilation_failed.rs
@@ -1,30 +1,30 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
-#[doc = "Failed to compile Conjure definition to Java code."]
+///Failed to compile Conjure definition to Java code.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct JavaCompilationFailed {}
 impl JavaCompilationFailed {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new() -> JavaCompilationFailed {
         JavaCompilationFailed {}
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
 }
-#[doc = "A builder for the `JavaCompilationFailed` type."]
+///A builder for the `JavaCompilationFailed` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {}
 impl Builder {
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> JavaCompilationFailed {
         JavaCompilationFailed {}

--- a/example-api/src/product/list_example.rs
+++ b/example-api/src/product/list_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct ListExample {
@@ -8,7 +8,7 @@ pub struct ListExample {
     double_items: Vec<f64>,
 }
 impl ListExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T, U, V>(items: T, primitive_items: U, double_items: V) -> ListExample
     where
@@ -22,7 +22,7 @@ impl ListExample {
             double_items: double_items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -40,7 +40,7 @@ impl ListExample {
         &*self.double_items
     }
 }
-#[doc = "A builder for the `ListExample` type."]
+///A builder for the `ListExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: Vec<String>,
@@ -114,11 +114,11 @@ impl Builder {
         self.double_items.push(value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ListExample {
         ListExample {

--- a/example-api/src/product/many_field_example.rs
+++ b/example-api/src/product/many_field_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct ManyFieldExample {
@@ -13,53 +13,53 @@ pub struct ManyFieldExample {
     alias: super::StringAliasExample,
 }
 impl ManyFieldExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
     }
-    #[doc = "docs for string field"]
+    ///docs for string field
     #[inline]
     pub fn string(&self) -> &str {
         &*self.string
     }
-    #[doc = "docs for integer field"]
+    ///docs for integer field
     #[inline]
     pub fn integer(&self) -> i32 {
         self.integer
     }
-    #[doc = "docs for doubleValue field"]
+    ///docs for doubleValue field
     #[inline]
     pub fn double_value(&self) -> f64 {
         self.double_value
     }
-    #[doc = "docs for optionalItem field"]
+    ///docs for optionalItem field
     #[inline]
     pub fn optional_item(&self) -> Option<&str> {
         self.optional_item.as_ref().map(|o| &**o)
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn items(&self) -> &[String] {
         &*self.items
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn set(&self) -> &std::collections::BTreeSet<String> {
         &self.set
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn map(&self) -> &std::collections::BTreeMap<String, String> {
         &self.map
     }
-    #[doc = "docs for alias field"]
+    ///docs for alias field
     #[inline]
     pub fn alias(&self) -> &super::StringAliasExample {
         &self.alias
     }
 }
-#[doc = "A builder for the `ManyFieldExample` type."]
+///A builder for the `ManyFieldExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     string: Option<String>,
@@ -72,9 +72,9 @@ pub struct Builder {
     alias: Option<super::StringAliasExample>,
 }
 impl Builder {
-    #[doc = "docs for string field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for string field
+    ///
+    /// Required.
     #[inline]
     pub fn string<T>(&mut self, string: T) -> &mut Self
     where
@@ -83,23 +83,23 @@ impl Builder {
         self.string = Some(string.into());
         self
     }
-    #[doc = "docs for integer field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for integer field
+    ///
+    /// Required.
     #[inline]
     pub fn integer(&mut self, integer: i32) -> &mut Self {
         self.integer = Some(integer);
         self
     }
-    #[doc = "docs for doubleValue field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for doubleValue field
+    ///
+    /// Required.
     #[inline]
     pub fn double_value(&mut self, double_value: f64) -> &mut Self {
         self.double_value = Some(double_value);
         self
     }
-    #[doc = "docs for optionalItem field"]
+    ///docs for optionalItem field
     #[inline]
     pub fn optional_item<T>(&mut self, optional_item: T) -> &mut Self
     where
@@ -108,7 +108,7 @@ impl Builder {
         self.optional_item = optional_item.into();
         self
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
@@ -117,7 +117,7 @@ impl Builder {
         self.items = items.into_iter().collect();
         self
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn extend_items<T>(&mut self, items: T) -> &mut Self
     where
@@ -126,7 +126,7 @@ impl Builder {
         self.items.extend(items);
         self
     }
-    #[doc = "docs for items field"]
+    ///docs for items field
     #[inline]
     pub fn push_items<T>(&mut self, value: T) -> &mut Self
     where
@@ -135,7 +135,7 @@ impl Builder {
         self.items.push(value.into());
         self
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn set<T>(&mut self, set: T) -> &mut Self
     where
@@ -144,7 +144,7 @@ impl Builder {
         self.set = set.into_iter().collect();
         self
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn extend_set<T>(&mut self, set: T) -> &mut Self
     where
@@ -153,7 +153,7 @@ impl Builder {
         self.set.extend(set);
         self
     }
-    #[doc = "docs for set field"]
+    ///docs for set field
     #[inline]
     pub fn insert_set<T>(&mut self, value: T) -> &mut Self
     where
@@ -162,7 +162,7 @@ impl Builder {
         self.set.insert(value.into());
         self
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn map<T>(&mut self, map: T) -> &mut Self
     where
@@ -171,7 +171,7 @@ impl Builder {
         self.map = map.into_iter().collect();
         self
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn extend_map<T>(&mut self, map: T) -> &mut Self
     where
@@ -180,7 +180,7 @@ impl Builder {
         self.map.extend(map);
         self
     }
-    #[doc = "docs for map field"]
+    ///docs for map field
     #[inline]
     pub fn insert_map<K, V>(&mut self, key: K, value: V) -> &mut Self
     where
@@ -190,19 +190,19 @@ impl Builder {
         self.map.insert(key.into(), value.into());
         self
     }
-    #[doc = "docs for alias field"]
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///docs for alias field
+    ///
+    /// Required.
     #[inline]
     pub fn alias(&mut self, alias: super::StringAliasExample) -> &mut Self {
         self.alias = Some(alias);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ManyFieldExample {
         ManyFieldExample {

--- a/example-api/src/product/map_alias_example.rs
+++ b/example-api/src/product/map_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct MapAliasExample(pub std::collections::BTreeMap<String, conjure_object::Any>);
 impl std::ops::Deref for MapAliasExample {
@@ -10,7 +10,9 @@ impl std::ops::Deref for MapAliasExample {
 }
 impl std::ops::DerefMut for MapAliasExample {
     #[inline]
-    fn deref_mut(&mut self) -> &mut std::collections::BTreeMap<String, conjure_object::Any> {
+    fn deref_mut(
+        &mut self,
+    ) -> &mut std::collections::BTreeMap<String, conjure_object::Any> {
         &mut self.0
     }
 }

--- a/example-api/src/product/map_example.rs
+++ b/example-api/src/product/map_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct MapExample {
     items: std::collections::BTreeMap<String, String>,
 }
 impl MapExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(items: T) -> MapExample
     where
@@ -16,7 +16,7 @@ impl MapExample {
             items: items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl MapExample {
         &self.items
     }
 }
-#[doc = "A builder for the `MapExample` type."]
+///A builder for the `MapExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: std::collections::BTreeMap<String, String>,
@@ -57,11 +57,11 @@ impl Builder {
         self.items.insert(key.into(), value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> MapExample {
         MapExample {

--- a/example-api/src/product/mod.rs
+++ b/example-api/src/product/mod.rs
@@ -1,145 +1,145 @@
 #[doc(inline)]
-pub use self::alias_as_map_key_example::AliasAsMapKeyExample;
-#[doc(inline)]
-pub use self::aliased_binary::AliasedBinary;
-#[doc(inline)]
 pub use self::aliased_string::AliasedString;
-#[doc(inline)]
-pub use self::any_example::AnyExample;
-#[doc(inline)]
-pub use self::any_map_example::AnyMapExample;
-#[doc(inline)]
-pub use self::bearer_token_alias_example::BearerTokenAliasExample;
-#[doc(inline)]
-pub use self::bearer_token_example::BearerTokenExample;
-#[doc(inline)]
-pub use self::binary_alias_example::BinaryAliasExample;
-#[doc(inline)]
-pub use self::binary_example::BinaryExample;
-#[doc(inline)]
-pub use self::boolean_alias_example::BooleanAliasExample;
-#[doc(inline)]
-pub use self::boolean_example::BooleanExample;
-#[doc(inline)]
-pub use self::covariant_list_example::CovariantListExample;
-#[doc(inline)]
-pub use self::covariant_optional_example::CovariantOptionalExample;
 #[doc(inline)]
 pub use self::create_dataset_request::CreateDatasetRequest;
 #[doc(inline)]
-pub use self::date_time_alias_example::DateTimeAliasExample;
-#[doc(inline)]
-pub use self::date_time_example::DateTimeExample;
-#[doc(inline)]
-pub use self::double_alias_example::DoubleAliasExample;
-#[doc(inline)]
-pub use self::double_example::DoubleExample;
-#[doc(inline)]
-pub use self::empty_object_example::EmptyObjectExample;
-#[doc(inline)]
-pub use self::enum_example::EnumExample;
-#[doc(inline)]
-pub use self::enum_field_example::EnumFieldExample;
-#[doc(inline)]
-pub use self::integer_alias_example::IntegerAliasExample;
-#[doc(inline)]
-pub use self::integer_example::IntegerExample;
-#[doc(inline)]
-pub use self::invalid_service_definition::InvalidServiceDefinition;
-#[doc(inline)]
-pub use self::invalid_type_definition::InvalidTypeDefinition;
-#[doc(inline)]
-pub use self::java_compilation_failed::JavaCompilationFailed;
-#[doc(inline)]
-pub use self::list_example::ListExample;
-#[doc(inline)]
-pub use self::many_field_example::ManyFieldExample;
-#[doc(inline)]
-pub use self::map_alias_example::MapAliasExample;
-#[doc(inline)]
-pub use self::map_example::MapExample;
+pub use self::aliased_binary::AliasedBinary;
 #[doc(inline)]
 pub use self::nested_aliased_binary::NestedAliasedBinary;
 #[doc(inline)]
-pub use self::nested_string_alias_example::NestedStringAliasExample;
+pub use self::integer_example::IntegerExample;
 #[doc(inline)]
-pub use self::optional_example::OptionalExample;
+pub use self::boolean_example::BooleanExample;
+#[doc(inline)]
+pub use self::any_example::AnyExample;
+#[doc(inline)]
+pub use self::map_alias_example::MapAliasExample;
 #[doc(inline)]
 pub use self::primitive_optionals_example::PrimitiveOptionalsExample;
 #[doc(inline)]
-pub use self::reference_alias_example::ReferenceAliasExample;
+pub use self::empty_object_example::EmptyObjectExample;
 #[doc(inline)]
-pub use self::reserved_key_example::ReservedKeyExample;
-#[doc(inline)]
-pub use self::rid_alias_example::RidAliasExample;
-#[doc(inline)]
-pub use self::rid_example::RidExample;
-#[doc(inline)]
-pub use self::safe_long_alias_example::SafeLongAliasExample;
+pub use self::boolean_alias_example::BooleanAliasExample;
 #[doc(inline)]
 pub use self::safe_long_example::SafeLongExample;
 #[doc(inline)]
-pub use self::set_example::SetExample;
-#[doc(inline)]
 pub use self::single_union::SingleUnion;
 #[doc(inline)]
-pub use self::string_alias_example::StringAliasExample;
+pub use self::date_time_example::DateTimeExample;
 #[doc(inline)]
-pub use self::string_example::StringExample;
+pub use self::bearer_token_alias_example::BearerTokenAliasExample;
 #[doc(inline)]
-pub use self::union_::Union;
+pub use self::set_example::SetExample;
+#[doc(inline)]
+pub use self::rid_example::RidExample;
+#[doc(inline)]
+pub use self::enum_field_example::EnumFieldExample;
+#[doc(inline)]
+pub use self::covariant_list_example::CovariantListExample;
+#[doc(inline)]
+pub use self::reserved_key_example::ReservedKeyExample;
+#[doc(inline)]
+pub use self::reference_alias_example::ReferenceAliasExample;
+#[doc(inline)]
+pub use self::binary_example::BinaryExample;
+#[doc(inline)]
+pub use self::date_time_alias_example::DateTimeAliasExample;
+#[doc(inline)]
+pub use self::any_map_example::AnyMapExample;
+#[doc(inline)]
+pub use self::binary_alias_example::BinaryAliasExample;
+#[doc(inline)]
+pub use self::nested_string_alias_example::NestedStringAliasExample;
+#[doc(inline)]
+pub use self::many_field_example::ManyFieldExample;
+#[doc(inline)]
+pub use self::alias_as_map_key_example::AliasAsMapKeyExample;
+#[doc(inline)]
+pub use self::bearer_token_example::BearerTokenExample;
 #[doc(inline)]
 pub use self::union_type_example::UnionTypeExample;
 #[doc(inline)]
+pub use self::list_example::ListExample;
+#[doc(inline)]
+pub use self::string_alias_example::StringAliasExample;
+#[doc(inline)]
+pub use self::rid_alias_example::RidAliasExample;
+#[doc(inline)]
+pub use self::double_alias_example::DoubleAliasExample;
+#[doc(inline)]
+pub use self::integer_alias_example::IntegerAliasExample;
+#[doc(inline)]
+pub use self::covariant_optional_example::CovariantOptionalExample;
+#[doc(inline)]
+pub use self::map_example::MapExample;
+#[doc(inline)]
+pub use self::double_example::DoubleExample;
+#[doc(inline)]
+pub use self::safe_long_alias_example::SafeLongAliasExample;
+#[doc(inline)]
+pub use self::optional_example::OptionalExample;
+#[doc(inline)]
+pub use self::enum_example::EnumExample;
+#[doc(inline)]
+pub use self::union_::Union;
+#[doc(inline)]
 pub use self::uuid_alias_example::UuidAliasExample;
 #[doc(inline)]
+pub use self::string_example::StringExample;
+#[doc(inline)]
 pub use self::uuid_example::UuidExample;
-pub mod alias_as_map_key_example;
-pub mod aliased_binary;
+#[doc(inline)]
+pub use self::invalid_type_definition::InvalidTypeDefinition;
+#[doc(inline)]
+pub use self::invalid_service_definition::InvalidServiceDefinition;
+#[doc(inline)]
+pub use self::java_compilation_failed::JavaCompilationFailed;
 pub mod aliased_string;
-pub mod any_example;
-pub mod any_map_example;
-pub mod bearer_token_alias_example;
-pub mod bearer_token_example;
-pub mod binary_alias_example;
-pub mod binary_example;
-pub mod boolean_alias_example;
-pub mod boolean_example;
-pub mod covariant_list_example;
-pub mod covariant_optional_example;
 pub mod create_dataset_request;
-pub mod datasets;
-pub mod date_time_alias_example;
-pub mod date_time_example;
-pub mod double_alias_example;
-pub mod double_example;
-pub mod empty_object_example;
-pub mod enum_example;
-pub mod enum_field_example;
-pub mod integer_alias_example;
-pub mod integer_example;
-pub mod invalid_service_definition;
-pub mod invalid_type_definition;
-pub mod java_compilation_failed;
-pub mod list_example;
-pub mod many_field_example;
-pub mod map_alias_example;
-pub mod map_example;
+pub mod aliased_binary;
 pub mod nested_aliased_binary;
-pub mod nested_string_alias_example;
-pub mod optional_example;
+pub mod integer_example;
+pub mod boolean_example;
+pub mod any_example;
+pub mod map_alias_example;
 pub mod primitive_optionals_example;
-pub mod reference_alias_example;
-pub mod reserved_key_example;
-pub mod rid_alias_example;
-pub mod rid_example;
-pub mod safe_long_alias_example;
+pub mod empty_object_example;
+pub mod boolean_alias_example;
 pub mod safe_long_example;
-pub mod set_example;
 pub mod single_union;
-pub mod string_alias_example;
-pub mod string_example;
-pub mod union_;
+pub mod date_time_example;
+pub mod bearer_token_alias_example;
+pub mod set_example;
+pub mod rid_example;
+pub mod enum_field_example;
+pub mod covariant_list_example;
+pub mod reserved_key_example;
+pub mod reference_alias_example;
+pub mod binary_example;
+pub mod date_time_alias_example;
+pub mod any_map_example;
+pub mod binary_alias_example;
+pub mod nested_string_alias_example;
+pub mod many_field_example;
+pub mod alias_as_map_key_example;
+pub mod bearer_token_example;
 pub mod union_type_example;
+pub mod list_example;
+pub mod string_alias_example;
+pub mod rid_alias_example;
+pub mod double_alias_example;
+pub mod integer_alias_example;
+pub mod covariant_optional_example;
+pub mod map_example;
+pub mod double_example;
+pub mod safe_long_alias_example;
+pub mod optional_example;
+pub mod enum_example;
+pub mod union_;
 pub mod uuid_alias_example;
+pub mod string_example;
 pub mod uuid_example;
+pub mod invalid_type_definition;
+pub mod invalid_service_definition;
+pub mod java_compilation_failed;
+pub mod datasets;

--- a/example-api/src/product/nested_aliased_binary.rs
+++ b/example-api/src/product/nested_aliased_binary.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct NestedAliasedBinary(pub super::AliasedBinary);
 impl conjure_object::Plain for NestedAliasedBinary {

--- a/example-api/src/product/nested_string_alias_example.rs
+++ b/example-api/src/product/nested_string_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct NestedStringAliasExample(pub super::StringAliasExample);
 impl std::fmt::Display for NestedStringAliasExample {

--- a/example-api/src/product/optional_example.rs
+++ b/example-api/src/product/optional_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct OptionalExample {
     item: Option<String>,
 }
 impl OptionalExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(item: T) -> OptionalExample
     where
@@ -16,7 +16,7 @@ impl OptionalExample {
             item: Some(item.into()),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl OptionalExample {
         self.item.as_ref().map(|o| &**o)
     }
 }
-#[doc = "A builder for the `OptionalExample` type."]
+///A builder for the `OptionalExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     item: Option<String>,
@@ -40,11 +40,11 @@ impl Builder {
         self.item = item.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> OptionalExample {
         OptionalExample {

--- a/example-api/src/product/primitive_optionals_example.rs
+++ b/example-api/src/product/primitive_optionals_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct PrimitiveOptionalsExample {
@@ -12,7 +12,7 @@ pub struct PrimitiveOptionalsExample {
     uuid: Option<conjure_object::Uuid>,
 }
 impl PrimitiveOptionalsExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -46,7 +46,7 @@ impl PrimitiveOptionalsExample {
         self.uuid.as_ref().map(|o| *o)
     }
 }
-#[doc = "A builder for the `PrimitiveOptionalsExample` type."]
+///A builder for the `PrimitiveOptionalsExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     num: Option<f64>,
@@ -114,11 +114,11 @@ impl Builder {
         self.uuid = uuid.into();
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> PrimitiveOptionalsExample {
         PrimitiveOptionalsExample {
@@ -226,15 +226,7 @@ impl<'de> de::Deserialize<'de> for PrimitiveOptionalsExample {
     {
         d.deserialize_struct(
             "PrimitiveOptionalsExample",
-            &[
-                "num",
-                "bool",
-                "integer",
-                "safelong",
-                "rid",
-                "bearertoken",
-                "uuid",
-            ],
+            &["num", "bool", "integer", "safelong", "rid", "bearertoken", "uuid"],
             Visitor_,
         )
     }

--- a/example-api/src/product/reference_alias_example.rs
+++ b/example-api/src/product/reference_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ReferenceAliasExample(pub super::AnyExample);
 impl std::ops::Deref for ReferenceAliasExample {

--- a/example-api/src/product/reserved_key_example.rs
+++ b/example-api/src/product/reserved_key_example.rs
@@ -1,5 +1,5 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct ReservedKeyExample {
@@ -10,7 +10,7 @@ pub struct ReservedKeyExample {
     memoized_hash_code: i32,
 }
 impl ReservedKeyExample {
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -36,7 +36,7 @@ impl ReservedKeyExample {
         self.memoized_hash_code
     }
 }
-#[doc = "A builder for the `ReservedKeyExample` type."]
+///A builder for the `ReservedKeyExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     package: Option<String>,
@@ -46,8 +46,8 @@ pub struct Builder {
     memoized_hash_code: Option<i32>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn package<T>(&mut self, package: T) -> &mut Self
     where
@@ -56,8 +56,8 @@ impl Builder {
         self.package = Some(package.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn interface<T>(&mut self, interface: T) -> &mut Self
     where
@@ -66,8 +66,8 @@ impl Builder {
         self.interface = Some(interface.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn field_name_with_dashes<T>(&mut self, field_name_with_dashes: T) -> &mut Self
     where
@@ -76,8 +76,8 @@ impl Builder {
         self.field_name_with_dashes = Some(field_name_with_dashes.into());
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn primitve_field_name_with_dashes(
         &mut self,
@@ -86,18 +86,18 @@ impl Builder {
         self.primitve_field_name_with_dashes = Some(primitve_field_name_with_dashes);
         self
     }
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn memoized_hash_code(&mut self, memoized_hash_code: i32) -> &mut Self {
         self.memoized_hash_code = Some(memoized_hash_code);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> ReservedKeyExample {
         ReservedKeyExample {
@@ -185,9 +185,11 @@ impl<'de> de::Visitor<'de> for Visitor_ {
             match field_ {
                 Field_::Package => package = Some(map_.next_value()?),
                 Field_::Interface => interface = Some(map_.next_value()?),
-                Field_::FieldNameWithDashes => field_name_with_dashes = Some(map_.next_value()?),
+                Field_::FieldNameWithDashes => {
+                    field_name_with_dashes = Some(map_.next_value()?);
+                }
                 Field_::PrimitveFieldNameWithDashes => {
-                    primitve_field_name_with_dashes = Some(map_.next_value()?)
+                    primitve_field_name_with_dashes = Some(map_.next_value()?);
                 }
                 Field_::MemoizedHashCode => memoized_hash_code = Some(map_.next_value()?),
                 Field_::Unknown_ => {
@@ -209,7 +211,9 @@ impl<'de> de::Visitor<'de> for Visitor_ {
         };
         let primitve_field_name_with_dashes = match primitve_field_name_with_dashes {
             Some(v) => v,
-            None => return Err(de::Error::missing_field("primitve-field-name-with-dashes")),
+            None => {
+                return Err(de::Error::missing_field("primitve-field-name-with-dashes"));
+            }
         };
         let memoized_hash_code = match memoized_hash_code {
             Some(v) => v,

--- a/example-api/src/product/rid_alias_example.rs
+++ b/example-api/src/product/rid_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct RidAliasExample(pub conjure_object::ResourceIdentifier);
 impl std::fmt::Display for RidAliasExample {

--- a/example-api/src/product/rid_example.rs
+++ b/example-api/src/product/rid_example.rs
@@ -1,19 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct RidExample {
     rid_value: conjure_object::ResourceIdentifier,
 }
 impl RidExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(rid_value: conjure_object::ResourceIdentifier) -> RidExample {
-        RidExample {
-            rid_value: rid_value,
-        }
+        RidExample { rid_value: rid_value }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +21,27 @@ impl RidExample {
         &self.rid_value
     }
 }
-#[doc = "A builder for the `RidExample` type."]
+///A builder for the `RidExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     rid_value: Option<conjure_object::ResourceIdentifier>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
-    pub fn rid_value(&mut self, rid_value: conjure_object::ResourceIdentifier) -> &mut Self {
+    pub fn rid_value(
+        &mut self,
+        rid_value: conjure_object::ResourceIdentifier,
+    ) -> &mut Self {
         self.rid_value = Some(rid_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> RidExample {
         RidExample {

--- a/example-api/src/product/safe_long_alias_example.rs
+++ b/example-api/src/product/safe_long_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
 pub struct SafeLongAliasExample(pub conjure_object::SafeLong);
 impl std::fmt::Display for SafeLongAliasExample {

--- a/example-api/src/product/safe_long_example.rs
+++ b/example-api/src/product/safe_long_example.rs
@@ -1,19 +1,19 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct SafeLongExample {
     safe_long_value: conjure_object::SafeLong,
 }
 impl SafeLongExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(safe_long_value: conjure_object::SafeLong) -> SafeLongExample {
         SafeLongExample {
             safe_long_value: safe_long_value,
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -23,24 +23,27 @@ impl SafeLongExample {
         self.safe_long_value
     }
 }
-#[doc = "A builder for the `SafeLongExample` type."]
+///A builder for the `SafeLongExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     safe_long_value: Option<conjure_object::SafeLong>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
-    pub fn safe_long_value(&mut self, safe_long_value: conjure_object::SafeLong) -> &mut Self {
+    pub fn safe_long_value(
+        &mut self,
+        safe_long_value: conjure_object::SafeLong,
+    ) -> &mut Self {
         self.safe_long_value = Some(safe_long_value);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> SafeLongExample {
         SafeLongExample {

--- a/example-api/src/product/set_example.rs
+++ b/example-api/src/product/set_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct SetExample {
     items: std::collections::BTreeSet<String>,
 }
 impl SetExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(items: T) -> SetExample
     where
@@ -16,7 +16,7 @@ impl SetExample {
             items: items.into_iter().collect(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,7 +26,7 @@ impl SetExample {
         &self.items
     }
 }
-#[doc = "A builder for the `SetExample` type."]
+///A builder for the `SetExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     items: std::collections::BTreeSet<String>,
@@ -56,11 +56,11 @@ impl Builder {
         self.items.insert(value.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> SetExample {
         SetExample {

--- a/example-api/src/product/single_union.rs
+++ b/example-api/src/product/single_union.rs
@@ -1,11 +1,11 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SingleUnion {
     Foo(String),
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl ser::Serialize for SingleUnion {
@@ -59,19 +59,22 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                             let value = map.next_value()?;
                             SingleUnion::Unknown(Unknown { type_, value })
                         } else {
-                            return Err(de::Error::invalid_value(
-                                de::Unexpected::Str(&type_),
-                                &&*b,
-                            ));
+                            return Err(
+                                de::Error::invalid_value(de::Unexpected::Str(&type_), &&*b),
+                            )
                         }
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -93,10 +96,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -146,14 +151,14 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
         Ok(v)
     }
 }
-#[doc = "An unknown variant of the SingleUnion union."]
+///An unknown variant of the SingleUnion union.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown {
     type_: Box<str>,
     value: conjure_object::Any,
 }
 impl Unknown {
-    #[doc = r" Returns the unknown variant's type name."]
+    /// Returns the unknown variant's type name.
     #[inline]
     pub fn type_(&self) -> &str {
         &self.type_

--- a/example-api/src/product/string_alias_example.rs
+++ b/example-api/src/product/string_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 pub struct StringAliasExample(pub String);
 impl std::fmt::Display for StringAliasExample {

--- a/example-api/src/product/string_example.rs
+++ b/example-api/src/product/string_example.rs
@@ -1,12 +1,12 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct StringExample {
     string: String,
 }
 impl StringExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(string: T) -> StringExample
     where
@@ -16,7 +16,7 @@ impl StringExample {
             string: string.into(),
         }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -26,14 +26,14 @@ impl StringExample {
         &*self.string
     }
 }
-#[doc = "A builder for the `StringExample` type."]
+///A builder for the `StringExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     string: Option<String>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn string<T>(&mut self, string: T) -> &mut Self
     where
@@ -42,11 +42,11 @@ impl Builder {
         self.string = Some(string.into());
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> StringExample {
         StringExample {
@@ -57,9 +57,7 @@ impl Builder {
 impl From<StringExample> for Builder {
     #[inline]
     fn from(_v: StringExample) -> Builder {
-        Builder {
-            string: Some(_v.string),
-        }
+        Builder { string: Some(_v.string) }
     }
 }
 impl ser::Serialize for StringExample {

--- a/example-api/src/product/union_.rs
+++ b/example-api/src/product/union_.rs
@@ -1,12 +1,12 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum Union {
     Foo(String),
     Bar(i32),
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl ser::Serialize for Union {
@@ -68,19 +68,22 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                             let value = map.next_value()?;
                             Union::Unknown(Unknown { type_, value })
                         } else {
-                            return Err(de::Error::invalid_value(
-                                de::Unexpected::Str(&type_),
-                                &&*b,
-                            ));
+                            return Err(
+                                de::Error::invalid_value(de::Unexpected::Str(&type_), &&*b),
+                            )
                         }
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -106,10 +109,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -162,14 +167,14 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
         Ok(v)
     }
 }
-#[doc = "An unknown variant of the Union union."]
+///An unknown variant of the Union union.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown {
     type_: Box<str>,
     value: conjure_object::Any,
 }
 impl Unknown {
-    #[doc = r" Returns the unknown variant's type name."]
+    /// Returns the unknown variant's type name.
     #[inline]
     pub fn type_(&self) -> &str {
         &self.type_

--- a/example-api/src/product/union_type_example.rs
+++ b/example-api/src/product/union_type_example.rs
@@ -1,10 +1,10 @@
-use conjure_object::private::{UnionField_, UnionTypeField_};
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
-use conjure_object::serde::{de, ser};
+use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum UnionTypeExample {
-    #[doc = "Docs for when UnionTypeExample is of type StringExample."]
+    ///Docs for when UnionTypeExample is of type StringExample.
     StringExample(super::StringExample),
     Set(std::collections::BTreeSet<String>),
     ThisFieldIsAnInteger(i32),
@@ -12,7 +12,7 @@ pub enum UnionTypeExample {
     If(i32),
     New(i32),
     Interface(i32),
-    #[doc = r" An unknown variant."]
+    /// An unknown variant.
     Unknown(Unknown),
 }
 impl ser::Serialize for UnionTypeExample {
@@ -89,7 +89,10 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                         let value = map.next_value()?;
                         UnionTypeExample::Set(value)
                     }
-                    (Variant_::ThisFieldIsAnInteger, Some(Variant_::ThisFieldIsAnInteger)) => {
+                    (
+                        Variant_::ThisFieldIsAnInteger,
+                        Some(Variant_::ThisFieldIsAnInteger),
+                    ) => {
                         let value = map.next_value()?;
                         UnionTypeExample::ThisFieldIsAnInteger(value)
                     }
@@ -114,19 +117,22 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                             let value = map.next_value()?;
                             UnionTypeExample::Unknown(Unknown { type_, value })
                         } else {
-                            return Err(de::Error::invalid_value(
-                                de::Unexpected::Str(&type_),
-                                &&*b,
-                            ));
+                            return Err(
+                                de::Error::invalid_value(de::Unexpected::Str(&type_), &&*b),
+                            )
                         }
                     }
                     (variant, Some(key)) => {
-                        return Err(de::Error::invalid_value(
-                            de::Unexpected::Str(key.as_str()),
-                            &variant.as_str(),
-                        ));
+                        return Err(
+                            de::Error::invalid_value(
+                                de::Unexpected::Str(key.as_str()),
+                                &variant.as_str(),
+                            ),
+                        );
                     }
-                    (variant, None) => return Err(de::Error::missing_field(variant.as_str())),
+                    (variant, None) => {
+                        return Err(de::Error::missing_field(variant.as_str()));
+                    }
                 }
             }
             Some(UnionField_::Value(variant)) => {
@@ -172,10 +178,12 @@ impl<'de> de::Visitor<'de> for Visitor_ {
                 }
                 let type_variant = map.next_value::<Variant_>()?;
                 if variant != type_variant {
-                    return Err(de::Error::invalid_value(
-                        de::Unexpected::Str(type_variant.as_str()),
-                        &variant.as_str(),
-                    ));
+                    return Err(
+                        de::Error::invalid_value(
+                            de::Unexpected::Str(type_variant.as_str()),
+                            &variant.as_str(),
+                        ),
+                    );
                 }
                 value
             }
@@ -243,14 +251,14 @@ impl<'de> de::Visitor<'de> for VariantVisitor_ {
         Ok(v)
     }
 }
-#[doc = "An unknown variant of the UnionTypeExample union."]
+///An unknown variant of the UnionTypeExample union.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Unknown {
     type_: Box<str>,
     value: conjure_object::Any,
 }
 impl Unknown {
-    #[doc = r" Returns the unknown variant's type name."]
+    /// Returns the unknown variant's type name.
     #[inline]
     pub fn type_(&self) -> &str {
         &self.type_

--- a/example-api/src/product/uuid_alias_example.rs
+++ b/example-api/src/product/uuid_alias_example.rs
@@ -1,4 +1,4 @@
-use conjure_object::serde::{de, ser};
+use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
 pub struct UuidAliasExample(pub conjure_object::Uuid);
 impl std::fmt::Display for UuidAliasExample {

--- a/example-api/src/product/uuid_example.rs
+++ b/example-api/src/product/uuid_example.rs
@@ -1,17 +1,17 @@
+use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
-use conjure_object::serde::{de, ser};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 pub struct UuidExample {
     uuid: conjure_object::Uuid,
 }
 impl UuidExample {
-    #[doc = r" Constructs a new instance of the type."]
+    /// Constructs a new instance of the type.
     #[inline]
     pub fn new(uuid: conjure_object::Uuid) -> UuidExample {
         UuidExample { uuid: uuid }
     }
-    #[doc = r" Returns a new builder."]
+    /// Returns a new builder.
     #[inline]
     pub fn builder() -> Builder {
         Default::default()
@@ -21,24 +21,24 @@ impl UuidExample {
         self.uuid
     }
 }
-#[doc = "A builder for the `UuidExample` type."]
+///A builder for the `UuidExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
     uuid: Option<conjure_object::Uuid>,
 }
 impl Builder {
-    #[doc = r""]
-    #[doc = r" Required."]
+    ///
+    /// Required.
     #[inline]
     pub fn uuid(&mut self, uuid: conjure_object::Uuid) -> &mut Self {
         self.uuid = Some(uuid);
         self
     }
-    #[doc = r" Constructs a new instance of the type."]
-    #[doc = r""]
-    #[doc = r" # Panics"]
-    #[doc = r""]
-    #[doc = r" Panics if a required field was not set."]
+    /// Constructs a new instance of the type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a required field was not set.
     #[inline]
     pub fn build(&self) -> UuidExample {
         UuidExample {
@@ -49,9 +49,7 @@ impl Builder {
 impl From<UuidExample> for Builder {
     #[inline]
     fn from(_v: UuidExample) -> Builder {
-        Builder {
-            uuid: Some(_v.uuid),
-        }
+        Builder { uuid: Some(_v.uuid) }
     }
 }
 impl ser::Serialize for UuidExample {


### PR DESCRIPTION
This avoids having a dependency on rustfmt being installed in the environment, and deals a bit better with autogenerated code in some contexts.

The vast majority of the change is just style changes to the generated code we check in!

Closes #197

