### PR TITLE
Expand Any support

### DIFF
--- a/changelog/@unreleased/pr-201.v2.yml
+++ b/changelog/@unreleased/pr-201.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`Any` now supports 128 bit integers.'
+  links:
+  - https://github.com/palantir/conjure-rust/pull/201

--- a/conjure-object/src/any/de.rs
+++ b/conjure-object/src/any/de.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::any::{Any, Error, Inner};
-use ordered_float::NotNan;
+use ordered_float::OrderedFloat;
 use serde::de::{
-    DeserializeSeed, EnumAccess, Error as _, IntoDeserializer, MapAccess, SeqAccess, Unexpected,
-    VariantAccess, Visitor,
+    DeserializeSeed, EnumAccess, Error as _, MapAccess, SeqAccess, Unexpected, VariantAccess,
+    Visitor,
 };
 use serde::{de, forward_to_deserialize_any, Deserialize, Deserializer};
 use std::collections::{btree_map, BTreeMap};
@@ -49,37 +49,95 @@ impl<'de> Visitor<'de> for AnyVisitor {
         Ok(Any(Inner::Bool(v)))
     }
 
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::I8(v)))
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::I16(v)))
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::I32(v)))
+    }
+
     fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        if v >= 0 {
-            Ok(Any(Inner::PositiveInt(v as u64)))
-        } else {
-            Ok(Any(Inner::NegativeInt(v)))
-        }
+        Ok(Any(Inner::I64(v)))
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::I128(v)))
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::U8(v)))
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::U16(v)))
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::U32(v)))
     }
 
     fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        Ok(Any(Inner::PositiveInt(v)))
+        Ok(Any(Inner::U64(v)))
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::U128(v)))
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::F32(OrderedFloat(v))))
     }
 
     fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        if v.is_nan() {
-            Ok(Any(Inner::String("NaN".to_string())))
-        } else if v == f64::INFINITY {
-            Ok(Any(Inner::String("Infinity".to_string())))
-        } else if v == f64::NEG_INFINITY {
-            Ok(Any(Inner::String("-Infinity".to_string())))
-        } else {
-            Ok(Any(Inner::Float(NotNan::new(v).unwrap())))
-        }
+        Ok(Any(Inner::F64(OrderedFloat(v))))
+    }
+
+    fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::Char(v)))
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -94,6 +152,20 @@ impl<'de> Visitor<'de> for AnyVisitor {
         E: de::Error,
     {
         Ok(Any(Inner::String(v)))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::Bytes(v.to_vec())))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Any(Inner::Bytes(v)))
     }
 
     fn visit_none<E>(self) -> Result<Self::Value, E>
@@ -127,7 +199,7 @@ impl<'de> Visitor<'de> for AnyVisitor {
             out.push(value);
         }
 
-        Ok(Any(Inner::Array(out)))
+        Ok(Any(Inner::Seq(out)))
     }
 
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -140,7 +212,7 @@ impl<'de> Visitor<'de> for AnyVisitor {
             out.insert(key, value);
         }
 
-        Ok(Any(Inner::Object(out)))
+        Ok(Any(Inner::Map(out)))
     }
 }
 
@@ -154,12 +226,23 @@ impl<'de> Deserializer<'de> for Any {
         match self.0 {
             Inner::Null => visitor.visit_unit(),
             Inner::Bool(v) => visitor.visit_bool(v),
-            Inner::Float(v) => visitor.visit_f64(*v),
-            Inner::PositiveInt(v) => visitor.visit_u64(v),
-            Inner::NegativeInt(v) => visitor.visit_i64(v),
+            Inner::I8(v) => visitor.visit_i8(v),
+            Inner::I16(v) => visitor.visit_i16(v),
+            Inner::I32(v) => visitor.visit_i32(v),
+            Inner::I64(v) => visitor.visit_i64(v),
+            Inner::I128(v) => visitor.visit_i128(v),
+            Inner::U8(v) => visitor.visit_u8(v),
+            Inner::U16(v) => visitor.visit_u16(v),
+            Inner::U32(v) => visitor.visit_u32(v),
+            Inner::U64(v) => visitor.visit_u64(v),
+            Inner::U128(v) => visitor.visit_u128(v),
+            Inner::F32(v) => visitor.visit_f32(v.0),
+            Inner::F64(v) => visitor.visit_f64(v.0),
+            Inner::Char(v) => visitor.visit_char(v),
             Inner::String(v) => visitor.visit_string(v),
-            Inner::Array(v) => visitor.visit_seq(SeqDeserializer(v.into_iter())),
-            Inner::Object(v) => visitor.visit_map(MapDeserializer {
+            Inner::Bytes(v) => visitor.visit_byte_buf(v),
+            Inner::Seq(v) => visitor.visit_seq(SeqDeserializer(v.into_iter())),
+            Inner::Map(v) => visitor.visit_map(MapDeserializer {
                 it: v.into_iter(),
                 value: None,
             }),
@@ -230,7 +313,7 @@ impl<'de> Deserializer<'de> for Any {
         V: Visitor<'de>,
     {
         let (variant, value) = match self.0 {
-            Inner::Object(value) => {
+            Inner::Map(value) => {
                 let mut iter = value.into_iter();
                 let (variant, value) = match iter.next() {
                     Some(v) => v,
@@ -249,7 +332,7 @@ impl<'de> Deserializer<'de> for Any {
                 }
                 (variant, Some(value))
             }
-            Inner::String(variant) => (variant, None),
+            Inner::String(variant) => (Any(Inner::String(variant)), None),
             _ => return self.deserialize_any(visitor),
         };
 
@@ -283,7 +366,7 @@ impl<'de> SeqAccess<'de> for SeqDeserializer {
 }
 
 struct MapDeserializer {
-    it: btree_map::IntoIter<String, Any>,
+    it: btree_map::IntoIter<Any, Any>,
     value: Option<Any>,
 }
 
@@ -318,97 +401,82 @@ impl<'de> MapAccess<'de> for MapDeserializer {
     }
 }
 
-macro_rules! deserialize_integer_key {
+macro_rules! deserialize_parse {
     ($method:ident => $visit:ident) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where
             V: Visitor<'de>,
         {
-            match self.0.parse() {
-                Ok(v) => visitor.$visit(v),
-                Err(_) => visitor.visit_string(self.0),
+            if let Inner::String(s) = &(self.0).0 {
+                if let Ok(v) = s.parse() {
+                    return visitor.$visit(v);
+                }
             }
+
+            self.0.$method(visitor)
         }
     };
 }
 
-struct KeyDeserializer(String);
+macro_rules! deserialize_delegate {
+    ($method:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.0.$method(visitor)
+        }
+    };
+}
+
+struct KeyDeserializer(Any);
 
 impl<'de> Deserializer<'de> for KeyDeserializer {
     type Error = Error;
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_string(self.0)
-    }
+    deserialize_delegate!(deserialize_any);
 
-    deserialize_integer_key!(deserialize_bool => visit_bool);
-    deserialize_integer_key!(deserialize_i8 => visit_i8);
-    deserialize_integer_key!(deserialize_i16 => visit_i16);
-    deserialize_integer_key!(deserialize_i32 => visit_i32);
-    deserialize_integer_key!(deserialize_i64 => visit_i64);
-    deserialize_integer_key!(deserialize_u8 => visit_u8);
-    deserialize_integer_key!(deserialize_u16 => visit_u16);
-    deserialize_integer_key!(deserialize_u32 => visit_u32);
-    deserialize_integer_key!(deserialize_u64 => visit_u64);
+    deserialize_parse!(deserialize_bool => visit_bool);
+    deserialize_parse!(deserialize_i8 => visit_i8);
+    deserialize_parse!(deserialize_i16 => visit_i16);
+    deserialize_parse!(deserialize_i32 => visit_i32);
+    deserialize_parse!(deserialize_i64 => visit_i64);
+    deserialize_parse!(deserialize_i128 => visit_i128);
+    deserialize_parse!(deserialize_u8 => visit_u8);
+    deserialize_parse!(deserialize_u16 => visit_u16);
+    deserialize_parse!(deserialize_u32 => visit_u32);
+    deserialize_parse!(deserialize_u64 => visit_u64);
+    deserialize_parse!(deserialize_u128 => visit_u128);
+    deserialize_parse!(deserialize_f32 => visit_f32);
+    deserialize_parse!(deserialize_f64 => visit_f64);
 
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match &*self.0 {
-            "NaN" => visitor.visit_f32(f32::NAN),
-            "Infinity" => visitor.visit_f32(f32::INFINITY),
-            "-Infinity" => visitor.visit_f32(f32::NEG_INFINITY),
-            _ => match self.0.parse() {
-                Ok(v) => visitor.visit_f32(v),
-                Err(_) => visitor.visit_string(self.0),
-            },
-        }
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match &*self.0 {
-            "NaN" => visitor.visit_f64(f64::NAN),
-            "Infinity" => visitor.visit_f64(f64::INFINITY),
-            "-Infinity" => visitor.visit_f64(f64::NEG_INFINITY),
-            _ => match self.0.parse() {
-                Ok(v) => visitor.visit_f64(v),
-                Err(_) => visitor.visit_string(self.0),
-            },
-        }
-    }
-
-    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match base64::decode(&self.0) {
-            Ok(buf) => visitor.visit_byte_buf(buf),
-            Err(_) => Err(Error::invalid_value(
-                Unexpected::Str(&self.0),
-                &"base64 bytes",
-            )),
-        }
-    }
-
-    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_bytes(visitor)
-    }
+    deserialize_delegate!(deserialize_char);
+    deserialize_delegate!(deserialize_str);
+    deserialize_delegate!(deserialize_string);
+    deserialize_delegate!(deserialize_bytes);
+    deserialize_delegate!(deserialize_byte_buf);
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
-        visitor.visit_some(self)
+        match &(self.0).0 {
+            Inner::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    deserialize_delegate!(deserialize_unit);
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.0.deserialize_unit_struct(name, visitor)
     }
 
     fn deserialize_newtype_struct<V>(
@@ -420,6 +488,41 @@ impl<'de> Deserializer<'de> for KeyDeserializer {
         V: Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
+    }
+
+    deserialize_delegate!(deserialize_seq);
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.0.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.0.deserialize_tuple_struct(name, len, visitor)
+    }
+
+    deserialize_delegate!(deserialize_map);
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.0.deserialize_struct(name, fields, visitor)
     }
 
     fn deserialize_enum<V>(
@@ -434,9 +537,8 @@ impl<'de> Deserializer<'de> for KeyDeserializer {
         visitor.visit_enum(self)
     }
 
-    forward_to_deserialize_any! {
-        char str string unit unit_struct seq tuple tuple_struct map struct identifier ignored_any
-    }
+    deserialize_delegate!(deserialize_identifier);
+    deserialize_delegate!(deserialize_ignored_any);
 }
 
 impl<'de> EnumAccess<'de> for KeyDeserializer {
@@ -496,7 +598,7 @@ impl<'de> VariantAccess<'de> for UnitVariantDeserializer {
 }
 
 struct EnumDeserializer {
-    variant: String,
+    variant: Any,
     value: Option<Any>,
 }
 
@@ -508,7 +610,7 @@ impl<'de> EnumAccess<'de> for EnumDeserializer {
     where
         V: DeserializeSeed<'de>,
     {
-        let variant = seed.deserialize(self.variant.into_deserializer())?;
+        let variant = seed.deserialize(self.variant)?;
         Ok((variant, VariantDeserializer(self.value)))
     }
 }
@@ -550,7 +652,7 @@ impl<'de> VariantAccess<'de> for VariantDeserializer {
         V: Visitor<'de>,
     {
         match self.0 {
-            Some(Any(Inner::Array(value))) => visitor.visit_seq(SeqDeserializer(value.into_iter())),
+            Some(Any(Inner::Seq(value))) => visitor.visit_seq(SeqDeserializer(value.into_iter())),
             Some(v) => Err(Error::invalid_value(v.unexpected(), &"tuple variant")),
             None => Err(Error::invalid_value(
                 Unexpected::UnitVariant,
@@ -568,7 +670,7 @@ impl<'de> VariantAccess<'de> for VariantDeserializer {
         V: Visitor<'de>,
     {
         match self.0 {
-            Some(Any(Inner::Object(value))) => visitor.visit_map(MapDeserializer {
+            Some(Any(Inner::Map(value))) => visitor.visit_map(MapDeserializer {
                 it: value.into_iter(),
                 value: None,
             }),

--- a/conjure-object/src/any/mod.rs
+++ b/conjure-object/src/any/mod.rs
@@ -14,7 +14,7 @@
 //! The Conjure `any` type.
 
 use crate::any::ser::AnySerializer;
-use ordered_float::NotNan;
+use ordered_float::OrderedFloat;
 use serde::de::{DeserializeOwned, Unexpected};
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -59,13 +59,23 @@ impl serde::ser::Error for Error {
 enum Inner {
     Null,
     Bool(bool),
-    // this f64 is always finite, not just not-nan
-    Float(NotNan<f64>),
-    PositiveInt(u64),
-    NegativeInt(i64),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    F32(OrderedFloat<f32>),
+    F64(OrderedFloat<f64>),
+    Char(char),
     String(String),
-    Array(Vec<Any>),
-    Object(BTreeMap<String, Any>),
+    Bytes(Vec<u8>),
+    Seq(Vec<Any>),
+    Map(BTreeMap<Any, Any>),
 }
 
 /// A representation of an arbitrary serializable value, corresponding to the Conjure `any` type.
@@ -109,12 +119,23 @@ impl Any {
         match &self.0 {
             Inner::Null => Unexpected::Unit,
             Inner::Bool(v) => Unexpected::Bool(*v),
-            Inner::Float(v) => Unexpected::Float(**v),
-            Inner::PositiveInt(v) => Unexpected::Unsigned(*v),
-            Inner::NegativeInt(v) => Unexpected::Signed(*v),
+            Inner::I8(v) => Unexpected::Signed(i64::from(*v)),
+            Inner::I16(v) => Unexpected::Signed(i64::from(*v)),
+            Inner::I32(v) => Unexpected::Signed(i64::from(*v)),
+            Inner::I64(v) => Unexpected::Signed(*v),
+            Inner::I128(v) => Unexpected::Signed(*v as i64),
+            Inner::U8(v) => Unexpected::Unsigned(u64::from(*v)),
+            Inner::U16(v) => Unexpected::Unsigned(u64::from(*v)),
+            Inner::U32(v) => Unexpected::Unsigned(u64::from(*v)),
+            Inner::U64(v) => Unexpected::Unsigned(*v),
+            Inner::U128(v) => Unexpected::Unsigned(*v as u64),
+            Inner::F32(v) => Unexpected::Float(v.0 as f64),
+            Inner::F64(v) => Unexpected::Float(v.0),
+            Inner::Char(v) => Unexpected::Char(*v),
             Inner::String(v) => Unexpected::Str(v),
-            Inner::Array(_) => Unexpected::Seq,
-            Inner::Object(_) => Unexpected::Map,
+            Inner::Bytes(v) => Unexpected::Bytes(v),
+            Inner::Seq(_) => Unexpected::Seq,
+            Inner::Map(_) => Unexpected::Map,
         }
     }
 }

--- a/conjure-test/src/test/objects.rs
+++ b/conjure-test/src/test/objects.rs
@@ -54,8 +54,10 @@ where
     assert_eq!(expected_value, actual_value);
 
     let actual_any = Any::new(ty).unwrap();
-    let expected_any = deserialize::<Any>(expected_json);
-    assert_eq!(expected_any, actual_any);
+    let any_json = serialize(&actual_any);
+    let expected_value = serde_json::from_str::<serde_json::Value>(expected_json).unwrap();
+    let actual_value = serde_json::from_str::<serde_json::Value>(&any_json).unwrap();
+    assert_eq!(expected_value, actual_value);
 }
 
 fn test_de<T>(ty: &T, json: &str)


### PR DESCRIPTION
## Before this PR
`Any` only supported a subset of data - in particular it would fail to work with 128 bit integers. It also immediately converted data to the Conjure JSON format (e.g. base64 encoding binary data).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`Any` now supports 128 bit integers.
==COMMIT_MSG==

Closes #191 
