### PR TITLE
Make all types implement Ord, Eq, and Hash

### DIFF
--- a/changelog/@unreleased/pr-203.v2.yml
+++ b/changelog/@unreleased/pr-203.v2.yml
@@ -1,0 +1,6 @@
+type: break
+break:
+  description: All generated types implement `Ord`, `Eq`, and `Hash`. Notably, this
+    enables support for `set<ObjectWithADoubleField>`.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/203

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -280,12 +280,12 @@ impl Context {
             },
             Type::Optional(def) => {
                 let option = self.option_ident(this_type);
-                let item = self.rust_type(this_type, def.item_type());
+                let item = self.rust_type_inner(this_type, def.item_type(), key);
                 quote!(#option<#item>)
             }
             Type::List(def) => {
                 let vec = self.vec_ident(this_type);
-                let item = self.rust_type(this_type, def.item_type());
+                let item = self.rust_type_inner(this_type, def.item_type(), key);
                 quote!(#vec<#item>)
             }
             Type::Set(def) => {
@@ -612,7 +612,7 @@ impl Context {
             }
             Type::List(def) => {
                 let into_iterator = self.into_iterator_ident(this_type);
-                let item_type = self.rust_type(this_type, def.item_type());
+                let item_type = self.rust_type_inner(this_type, def.item_type(), key);
                 CollectionSetterBounds::Generic {
                     argument_bound: quote!(#into_iterator<Item = #item_type>),
                     assign_rhs: quote!(#value_ident.into_iter().collect()),
@@ -792,12 +792,9 @@ impl Context {
     pub fn is_double(&self, def: &Type) -> bool {
         match def {
             Type::Primitive(PrimitiveType::Double) => true,
-            Type::Primitive(_)
-            | Type::Optional(_)
-            | Type::List(_)
-            | Type::Set(_)
-            | Type::Map(_)
-            | Type::Reference(_) => false,
+            Type::Optional(def) => self.is_double(def.item_type()),
+            Type::List(def) => self.is_double(def.item_type()),
+            Type::Primitive(_) | Type::Set(_) | Type::Map(_) | Type::Reference(_) => false,
             Type::External(def) => self.is_double(def.fallback()),
         }
     }

--- a/conjure-codegen/src/example_types/another/different_package.rs
+++ b/conjure-codegen/src/example_types/another/different_package.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Different package.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct DifferentPackage {}
 impl DifferentPackage {
     /// Constructs a new instance of the type.

--- a/conjure-codegen/src/example_types/product/alias_as_map_key_example.rs
+++ b/conjure-codegen/src/example_types/product/alias_as_map_key_example.rs
@@ -1,7 +1,8 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AliasAsMapKeyExample {
     strings: std::collections::BTreeMap<
         super::StringAliasExample,

--- a/conjure-codegen/src/example_types/product/aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/aliased_binary.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct AliasedBinary(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for AliasedBinary {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/aliased_string.rs
+++ b/conjure-codegen/src/example_types/product/aliased_string.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct AliasedString(pub String);
 impl std::fmt::Display for AliasedString {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/any_example.rs
+++ b/conjure-codegen/src/example_types/product/any_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnyExample {
     any: conjure_object::Any,
 }

--- a/conjure-codegen/src/example_types/product/any_map_example.rs
+++ b/conjure-codegen/src/example_types/product/any_map_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnyMapExample {
     items: std::collections::BTreeMap<String, conjure_object::Any>,
 }

--- a/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BearerTokenAliasExample(pub conjure_object::BearerToken);
 impl conjure_object::Plain for BearerTokenAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/bearer_token_example.rs
+++ b/conjure-codegen/src/example_types/product/bearer_token_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BearerTokenExample {
     bearer_token_value: conjure_object::BearerToken,
 }

--- a/conjure-codegen/src/example_types/product/binary_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BinaryAliasExample(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for BinaryAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/binary_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BinaryExample {
     binary: conjure_object::ByteBuf,
 }

--- a/conjure-codegen/src/example_types/product/boolean_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/boolean_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BooleanAliasExample(pub bool);
 impl std::fmt::Display for BooleanAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/boolean_example.rs
+++ b/conjure-codegen/src/example_types/product/boolean_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct BooleanExample {
     coin: bool,
 }

--- a/conjure-codegen/src/example_types/product/covariant_list_example.rs
+++ b/conjure-codegen/src/example_types/product/covariant_list_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CovariantListExample {
     items: Vec<conjure_object::Any>,
     external_items: Vec<String>,

--- a/conjure-codegen/src/example_types/product/covariant_optional_example.rs
+++ b/conjure-codegen/src/example_types/product/covariant_optional_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CovariantOptionalExample {
     item: Option<conjure_object::Any>,
 }

--- a/conjure-codegen/src/example_types/product/create_dataset_request.rs
+++ b/conjure-codegen/src/example_types/product/create_dataset_request.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateDatasetRequest {
     file_system_id: String,
     path: String,

--- a/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
+++ b/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BackingFileSystem {
     file_system_id: String,
     base_uri: String,

--- a/conjure-codegen/src/example_types/product/datasets/dataset.rs
+++ b/conjure-codegen/src/example_types/product/datasets/dataset.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Dataset {
     file_system_id: String,
     rid: conjure_object::ResourceIdentifier,

--- a/conjure-codegen/src/example_types/product/date_time_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/date_time_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DateTimeAliasExample(pub conjure_object::DateTime<conjure_object::Utc>);
 impl std::fmt::Display for DateTimeAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/date_time_example.rs
+++ b/conjure-codegen/src/example_types/product/date_time_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct DateTimeExample {
     datetime: conjure_object::DateTime<conjure_object::Utc>,
 }

--- a/conjure-codegen/src/example_types/product/double_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/double_alias_example.rs
@@ -1,6 +1,15 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Default)]
-pub struct DoubleAliasExample(pub f64);
+#[derive(Debug, Clone, Copy, conjure_object::private::Educe, Default)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DoubleAliasExample(
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
+    pub f64,
+);
 impl std::fmt::Display for DoubleAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, fmt)
@@ -16,12 +25,6 @@ impl conjure_object::FromPlain for DoubleAliasExample {
     #[inline]
     fn from_plain(s: &str) -> Result<DoubleAliasExample, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(DoubleAliasExample)
-    }
-}
-impl conjure_object::AsDouble for DoubleAliasExample {
-    #[inline]
-    fn as_double(&self) -> f64 {
-        conjure_object::AsDouble::as_double(&self.0)
     }
 }
 impl std::ops::Deref for DoubleAliasExample {

--- a/conjure-codegen/src/example_types/product/double_example.rs
+++ b/conjure-codegen/src/example_types/product/double_example.rs
@@ -1,8 +1,15 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy)]
+#[derive(Debug, Clone, conjure_object::private::Educe, Copy)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DoubleExample {
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     double_value: f64,
 }
 impl DoubleExample {

--- a/conjure-codegen/src/example_types/product/empty_object_example.rs
+++ b/conjure-codegen/src/example_types/product/empty_object_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct EmptyObjectExample {}
 impl EmptyObjectExample {
     /// Constructs a new instance of the type.

--- a/conjure-codegen/src/example_types/product/enum_field_example.rs
+++ b/conjure-codegen/src/example_types/product/enum_field_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnumFieldExample {
     enum_: super::EnumExample,
 }

--- a/conjure-codegen/src/example_types/product/integer_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/integer_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct IntegerAliasExample(pub i32);
 impl std::fmt::Display for IntegerAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/integer_example.rs
+++ b/conjure-codegen/src/example_types/product/integer_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct IntegerExample {
     integer: i32,
 }

--- a/conjure-codegen/src/example_types/product/invalid_service_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_service_definition.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Invalid Conjure service definition.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvalidServiceDefinition {
     service_name: String,
     service_def: conjure_object::Any,

--- a/conjure-codegen/src/example_types/product/invalid_type_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_type_definition.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Invalid Conjure type definition.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvalidTypeDefinition {
     type_name: String,
     type_def: conjure_object::Any,

--- a/conjure-codegen/src/example_types/product/java_compilation_failed.rs
+++ b/conjure-codegen/src/example_types/product/java_compilation_failed.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Failed to compile Conjure definition to Java code.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct JavaCompilationFailed {}
 impl JavaCompilationFailed {
     /// Constructs a new instance of the type.

--- a/conjure-codegen/src/example_types/product/list_example.rs
+++ b/conjure-codegen/src/example_types/product/list_example.rs
@@ -1,7 +1,8 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListExample {
     items: Vec<String>,
     primitive_items: Vec<i32>,

--- a/conjure-codegen/src/example_types/product/list_example.rs
+++ b/conjure-codegen/src/example_types/product/list_example.rs
@@ -6,6 +6,12 @@ use std::fmt;
 pub struct ListExample {
     items: Vec<String>,
     primitive_items: Vec<i32>,
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     double_items: Vec<f64>,
 }
 impl ListExample {

--- a/conjure-codegen/src/example_types/product/many_field_example.rs
+++ b/conjure-codegen/src/example_types/product/many_field_example.rs
@@ -1,10 +1,17 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ManyFieldExample {
     string: String,
     integer: i32,
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     double_value: f64,
     optional_item: Option<String>,
     items: Vec<String>,

--- a/conjure-codegen/src/example_types/product/map_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/map_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct MapAliasExample(pub std::collections::BTreeMap<String, conjure_object::Any>);
 impl std::ops::Deref for MapAliasExample {
     type Target = std::collections::BTreeMap<String, conjure_object::Any>;

--- a/conjure-codegen/src/example_types/product/map_example.rs
+++ b/conjure-codegen/src/example_types/product/map_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapExample {
     items: std::collections::BTreeMap<String, String>,
 }

--- a/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct NestedAliasedBinary(pub super::AliasedBinary);
 impl conjure_object::Plain for NestedAliasedBinary {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct NestedStringAliasExample(pub super::StringAliasExample);
 impl std::fmt::Display for NestedStringAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/optional_example.rs
+++ b/conjure-codegen/src/example_types/product/optional_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OptionalExample {
     item: Option<String>,
 }

--- a/conjure-codegen/src/example_types/product/primitive_optionals_example.rs
+++ b/conjure-codegen/src/example_types/product/primitive_optionals_example.rs
@@ -4,6 +4,12 @@ use std::fmt;
 #[derive(Debug, Clone, conjure_object::private::Educe)]
 #[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrimitiveOptionalsExample {
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     num: Option<f64>,
     bool: Option<bool>,
     integer: Option<i32>,

--- a/conjure-codegen/src/example_types/product/primitive_optionals_example.rs
+++ b/conjure-codegen/src/example_types/product/primitive_optionals_example.rs
@@ -1,7 +1,8 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrimitiveOptionalsExample {
     num: Option<f64>,
     bool: Option<bool>,

--- a/conjure-codegen/src/example_types/product/reference_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/reference_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReferenceAliasExample(pub super::AnyExample);
 impl std::ops::Deref for ReferenceAliasExample {
     type Target = super::AnyExample;

--- a/conjure-codegen/src/example_types/product/reserved_key_example.rs
+++ b/conjure-codegen/src/example_types/product/reserved_key_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReservedKeyExample {
     package: String,
     interface: String,

--- a/conjure-codegen/src/example_types/product/rid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/rid_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RidAliasExample(pub conjure_object::ResourceIdentifier);
 impl std::fmt::Display for RidAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/rid_example.rs
+++ b/conjure-codegen/src/example_types/product/rid_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RidExample {
     rid_value: conjure_object::ResourceIdentifier,
 }

--- a/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct SafeLongAliasExample(pub conjure_object::SafeLong);
 impl std::fmt::Display for SafeLongAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/safe_long_example.rs
+++ b/conjure-codegen/src/example_types/product/safe_long_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct SafeLongExample {
     safe_long_value: conjure_object::SafeLong,
 }

--- a/conjure-codegen/src/example_types/product/set_example.rs
+++ b/conjure-codegen/src/example_types/product/set_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetExample {
     items: std::collections::BTreeSet<String>,
 }

--- a/conjure-codegen/src/example_types/product/single_union.rs
+++ b/conjure-codegen/src/example_types/product/single_union.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SingleUnion {
     Foo(String),
     /// An unknown variant.

--- a/conjure-codegen/src/example_types/product/string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/string_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct StringAliasExample(pub String);
 impl std::fmt::Display for StringAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/string_example.rs
+++ b/conjure-codegen/src/example_types/product/string_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StringExample {
     string: String,
 }

--- a/conjure-codegen/src/example_types/product/union_.rs
+++ b/conjure-codegen/src/example_types/product/union_.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Union {
     Foo(String),
     Bar(i32),

--- a/conjure-codegen/src/example_types/product/union_type_example.rs
+++ b/conjure-codegen/src/example_types/product/union_type_example.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UnionTypeExample {
     ///Docs for when UnionTypeExample is of type StringExample.
     StringExample(super::StringExample),

--- a/conjure-codegen/src/example_types/product/uuid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/uuid_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UuidAliasExample(pub conjure_object::Uuid);
 impl std::fmt::Display for UuidAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/example_types/product/uuid_example.rs
+++ b/conjure-codegen/src/example_types/product/uuid_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct UuidExample {
     uuid: conjure_object::Uuid,
 }

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -71,6 +71,15 @@
 //! Many of these are exposed by the `conjure-object` crate, which is a required dependency of crates containing the
 //! generated code.
 //!
+//! ### `double`
+//!
+//! Rust's `f64` type does not implement `Ord`, `Eq`, or `Hash`, which requires some special casing. Sets and maps keyed
+//! directly by `double` are represented as `BTreeSet<DoubleKey>` and `BTreeMap<DoubleKey, T>`, where the
+//! [`DoubleKey`](conjure_object::DoubleKey) type wraps `f64` and implements those traits by ordering `NaN` greater
+//! than all other values and equal to itself.
+//!
+//! Conjure aliases, objects, and unions wrapping `double` types have trait implementations which use the same logic.
+//!
 //! ## Objects
 //!
 //! Conjure objects turn into Rust structs along with builders used to construct them:
@@ -105,9 +114,8 @@
 //! assert_eq!(object.coin(), true);
 //! ```
 //!
-//! The generated structs implement `Debug`, `Clone`, `PartialEq`, `PartialOrd`, `Serialize`, and `Deserialize`. They
-//! also implement `Eq`, `Ord`, and `Hash` if they do not contain a `double` value, and `Copy` if they consist entirely
-//! of copyable primitive types.
+//! The generated structs implement `Debug`, `Clone`, `PartialEq`, Eq, `PartialOrd`, `Ord`, `Hash`, `Serialize`, and
+//! `Deserialize`. They `Copy` if they consist entirely of copyable primitive types.
 //!
 //! ## Unions
 //!
@@ -133,9 +141,9 @@
 //! }
 //! ```
 //!
-//! The generated enums implement `Debug`, `Clone`, `PartialEq`, `PartialOrd`, `Serialize`, and `Deserialize`. They
-//! also implement `Eq`, `Ord`, and `Hash` if they do not contain a `double` value. Union variants which are themselves
-//! unions are boxed in the generated enum to avoid self-referential type definitions.
+//! The generated enums implement `Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash`, `Serialize`, and
+//! `Deserialize`. Union variants which are themselves unions are boxed in the generated enum to avoid self-referential
+//! type definitions.
 //!
 //! ## Enums
 //!
@@ -165,10 +173,9 @@
 //! assert!(alias_value.starts_with("hello"));
 //! ```
 //!
-//! The generated structs implement `Deref`, `DerefMut`, `Debug`, `Clone`, `PartialEq`, `PartialOrd`, `Serialize`, and
-//! `Deserialize`. They also implement `Eq`, `Ord`, and `Hash` if they do not contain a `double` value, `Copy` if they
-//! wrap a copyable primitive type, `Default` if they wrap a type implementing `Default`, `Display` if they wrap a
-//! type implementing `Display`, and `AsDouble` if they wrap an `f64`.
+//! The generated structs implement `Deref`, `DerefMut`, `Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`,
+//! `Hash`, `Serialize`, and `Deserialize`. They also implement `Copy` if they wrap a copyable primitive type, `Default`
+//! if they wrap a type implementing `Default`, and `Display` if they wrap a type implementing `Display`.
 //!
 //! ## Errors
 //!

--- a/conjure-codegen/src/types/alias_definition.rs
+++ b/conjure-codegen/src/types/alias_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AliasDefinition {
     type_name: Box<super::TypeName>,
     alias: Box<super::Type>,

--- a/conjure-codegen/src/types/argument_definition.rs
+++ b/conjure-codegen/src/types/argument_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ArgumentDefinition {
     arg_name: super::ArgumentName,
     type_: Box<super::Type>,

--- a/conjure-codegen/src/types/argument_name.rs
+++ b/conjure-codegen/src/types/argument_name.rs
@@ -1,6 +1,6 @@
 use conjure_object::serde::{ser, de};
 ///Must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed argument names: "fooBar", "build2Request". Disallowed names: "FooBar", "2BuildRequest".
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ArgumentName(pub String);
 impl std::fmt::Display for ArgumentName {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/types/auth_type.rs
+++ b/conjure-codegen/src/types/auth_type.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AuthType {
     Header(super::HeaderAuthType),
     Cookie(super::CookieAuthType),

--- a/conjure-codegen/src/types/body_parameter_type.rs
+++ b/conjure-codegen/src/types/body_parameter_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct BodyParameterType {}
 impl BodyParameterType {
     /// Constructs a new instance of the type.

--- a/conjure-codegen/src/types/conjure_definition.rs
+++ b/conjure-codegen/src/types/conjure_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConjureDefinition {
     version: i32,
     errors: Vec<super::ErrorDefinition>,

--- a/conjure-codegen/src/types/cookie_auth_type.rs
+++ b/conjure-codegen/src/types/cookie_auth_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CookieAuthType {
     cookie_name: String,
 }

--- a/conjure-codegen/src/types/documentation.rs
+++ b/conjure-codegen/src/types/documentation.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Documentation(pub String);
 impl std::fmt::Display for Documentation {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/types/endpoint_definition.rs
+++ b/conjure-codegen/src/types/endpoint_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EndpointDefinition {
     endpoint_name: super::EndpointName,
     http_method: super::HttpMethod,

--- a/conjure-codegen/src/types/endpoint_name.rs
+++ b/conjure-codegen/src/types/endpoint_name.rs
@@ -1,6 +1,6 @@
 use conjure_object::serde::{ser, de};
 ///Should be in lowerCamelCase.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct EndpointName(pub String);
 impl std::fmt::Display for EndpointName {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/types/enum_definition.rs
+++ b/conjure-codegen/src/types/enum_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnumDefinition {
     type_name: Box<super::TypeName>,
     values: Vec<super::EnumValueDefinition>,

--- a/conjure-codegen/src/types/enum_value_definition.rs
+++ b/conjure-codegen/src/types/enum_value_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnumValueDefinition {
     value: String,
     docs: Option<super::Documentation>,

--- a/conjure-codegen/src/types/error_definition.rs
+++ b/conjure-codegen/src/types/error_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ErrorDefinition {
     error_name: Box<super::TypeName>,
     docs: Option<super::Documentation>,

--- a/conjure-codegen/src/types/error_namespace.rs
+++ b/conjure-codegen/src/types/error_namespace.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ErrorNamespace(pub String);
 impl std::fmt::Display for ErrorNamespace {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/types/external_reference.rs
+++ b/conjure-codegen/src/types/external_reference.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExternalReference {
     external_reference: Box<super::TypeName>,
     fallback: Box<super::Type>,

--- a/conjure-codegen/src/types/field_definition.rs
+++ b/conjure-codegen/src/types/field_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FieldDefinition {
     field_name: super::FieldName,
     type_: Box<super::Type>,

--- a/conjure-codegen/src/types/field_name.rs
+++ b/conjure-codegen/src/types/field_name.rs
@@ -1,6 +1,6 @@
 use conjure_object::serde::{ser, de};
 ///Should be in lowerCamelCase, but kebab-case and snake_case are also permitted.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct FieldName(pub String);
 impl std::fmt::Display for FieldName {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/types/header_auth_type.rs
+++ b/conjure-codegen/src/types/header_auth_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct HeaderAuthType {}
 impl HeaderAuthType {
     /// Constructs a new instance of the type.

--- a/conjure-codegen/src/types/header_parameter_type.rs
+++ b/conjure-codegen/src/types/header_parameter_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HeaderParameterType {
     param_id: super::ParameterId,
 }

--- a/conjure-codegen/src/types/http_path.rs
+++ b/conjure-codegen/src/types/http_path.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct HttpPath(pub String);
 impl std::fmt::Display for HttpPath {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/types/list_type.rs
+++ b/conjure-codegen/src/types/list_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListType {
     item_type: Box<super::Type>,
 }

--- a/conjure-codegen/src/types/map_type.rs
+++ b/conjure-codegen/src/types/map_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapType {
     key_type: Box<super::Type>,
     value_type: Box<super::Type>,

--- a/conjure-codegen/src/types/object_definition.rs
+++ b/conjure-codegen/src/types/object_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ObjectDefinition {
     type_name: Box<super::TypeName>,
     fields: Vec<super::FieldDefinition>,

--- a/conjure-codegen/src/types/optional_type.rs
+++ b/conjure-codegen/src/types/optional_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OptionalType {
     item_type: Box<super::Type>,
 }

--- a/conjure-codegen/src/types/parameter_id.rs
+++ b/conjure-codegen/src/types/parameter_id.rs
@@ -1,6 +1,6 @@
 use conjure_object::serde::{ser, de};
 ///For header parameters, the parameter id must be in Upper-Kebab-Case. For query parameters, the parameter id must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ParameterId(pub String);
 impl std::fmt::Display for ParameterId {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/conjure-codegen/src/types/parameter_type.rs
+++ b/conjure-codegen/src/types/parameter_type.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ParameterType {
     Body(super::BodyParameterType),
     Header(super::HeaderParameterType),

--- a/conjure-codegen/src/types/path_parameter_type.rs
+++ b/conjure-codegen/src/types/path_parameter_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct PathParameterType {}
 impl PathParameterType {
     /// Constructs a new instance of the type.

--- a/conjure-codegen/src/types/query_parameter_type.rs
+++ b/conjure-codegen/src/types/query_parameter_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryParameterType {
     param_id: super::ParameterId,
 }

--- a/conjure-codegen/src/types/service_definition.rs
+++ b/conjure-codegen/src/types/service_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ServiceDefinition {
     service_name: Box<super::TypeName>,
     endpoints: Vec<super::EndpointDefinition>,

--- a/conjure-codegen/src/types/set_type.rs
+++ b/conjure-codegen/src/types/set_type.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetType {
     item_type: Box<super::Type>,
 }

--- a/conjure-codegen/src/types/type_.rs
+++ b/conjure-codegen/src/types/type_.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Type {
     Primitive(super::PrimitiveType),
     Optional(super::OptionalType),

--- a/conjure-codegen/src/types/type_definition.rs
+++ b/conjure-codegen/src/types/type_definition.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TypeDefinition {
     Alias(super::AliasDefinition),
     Enum(super::EnumDefinition),

--- a/conjure-codegen/src/types/type_name.rs
+++ b/conjure-codegen/src/types/type_name.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TypeName {
     name: String,
     package: String,

--- a/conjure-codegen/src/types/union_definition.rs
+++ b/conjure-codegen/src/types/union_definition.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnionDefinition {
     type_name: Box<super::TypeName>,
     union_: Vec<super::FieldDefinition>,

--- a/conjure-error/src/types/conflict.rs
+++ b/conjure-error/src/types/conflict.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `CONFLICT` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct Conflict {}
 impl Conflict {
     /// Constructs a new instance of the type.

--- a/conjure-error/src/types/failed_precondition.rs
+++ b/conjure-error/src/types/failed_precondition.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `FAILED_PRECONDITION` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct FailedPrecondition {}
 impl FailedPrecondition {
     /// Constructs a new instance of the type.

--- a/conjure-error/src/types/internal.rs
+++ b/conjure-error/src/types/internal.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `INTERNAL` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct Internal {}
 impl Internal {
     /// Constructs a new instance of the type.

--- a/conjure-error/src/types/invalid_argument.rs
+++ b/conjure-error/src/types/invalid_argument.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `INVALID_ARGUMENT` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct InvalidArgument {}
 impl InvalidArgument {
     /// Constructs a new instance of the type.

--- a/conjure-error/src/types/not_found.rs
+++ b/conjure-error/src/types/not_found.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `NOT_FOUND` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct NotFound {}
 impl NotFound {
     /// Constructs a new instance of the type.

--- a/conjure-error/src/types/permission_denied.rs
+++ b/conjure-error/src/types/permission_denied.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `PERMISSION_DENIED` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct PermissionDenied {}
 impl PermissionDenied {
     /// Constructs a new instance of the type.

--- a/conjure-error/src/types/request_entity_too_large.rs
+++ b/conjure-error/src/types/request_entity_too_large.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `REQUEST_ENTITY_TOO_LARGE` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct RequestEntityTooLarge {}
 impl RequestEntityTooLarge {
     /// Constructs a new instance of the type.

--- a/conjure-error/src/types/serializable_error.rs
+++ b/conjure-error/src/types/serializable_error.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///The JSON-serializable representation of an error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SerializableError {
     error_code: super::ErrorCode,
     error_name: String,

--- a/conjure-error/src/types/timeout.rs
+++ b/conjure-error/src/types/timeout.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///A generic `TIMEOUT` error.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct Timeout {}
 impl Timeout {
     /// Constructs a new instance of the type.

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -11,8 +11,15 @@ readme = "../README.md"
 [dependencies]
 base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
+educe = { version = "0.4", default-features = false, features = [
+    "Hash",
+    "PartialEq",
+    "Eq",
+    "PartialOrd",
+    "Ord",
+] }
 lazy_static = "1.0"
-ordered-float = { version = "3.0", features = ["serde"] }
+ordered-float = { version = "3", features = ["serde"] }
 regex = { version = "1.3", default-features = false, features = ["std"] }
 serde = "1.0"
 serde_bytes = "0.11"

--- a/conjure-object/src/lib.rs
+++ b/conjure-object/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::any::Any;
 #[doc(inline)]
 pub use crate::bearer_token::BearerToken;
 #[doc(inline)]
-pub use crate::double_key::{AsDouble, DoubleKey};
+pub use crate::double_key::DoubleKey;
 #[doc(inline)]
 pub use crate::plain::{FromPlain, Plain, ToPlain};
 #[doc(inline)]

--- a/conjure-object/src/private.rs
+++ b/conjure-object/src/private.rs
@@ -15,9 +15,9 @@ pub use educe::Educe;
 use ordered_float::OrderedFloat;
 use serde::de::{self, IntoDeserializer};
 use std::cmp::Ordering;
-use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
+use std::{fmt, mem};
 
 pub trait DoubleOps {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering>;
@@ -53,6 +53,116 @@ impl DoubleOps for f64 {
         H: Hasher,
     {
         OrderedFloat(*self).hash(hasher)
+    }
+}
+
+impl<T> DoubleOps for Option<T>
+where
+    T: DoubleOps,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (Some(a), Some(b)) => a.partial_cmp(b),
+            (Some(_), None) => Some(Ordering::Greater),
+            (None, Some(_)) => Some(Ordering::Less),
+            (None, None) => Some(Ordering::Equal),
+        }
+    }
+
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Some(a), Some(b)) => a.cmp(b),
+            (Some(_), None) => Ordering::Greater,
+            (None, Some(_)) => Ordering::Less,
+            (None, None) => Ordering::Equal,
+        }
+    }
+
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Some(a), Some(b)) => a.eq(b),
+            (Some(_), None) | (None, Some(_)) => false,
+            (None, None) => true,
+        }
+    }
+
+    #[inline]
+    fn hash<H>(&self, hasher: &mut H)
+    where
+        H: Hasher,
+    {
+        mem::discriminant(self).hash(hasher);
+        if let Some(v) = self {
+            v.hash(hasher);
+        }
+    }
+}
+
+impl<T> DoubleOps for Vec<T>
+where
+    T: DoubleOps,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let l = usize::min(self.len(), other.len());
+
+        let lhs = &self[..l];
+        let rhs = &other[..l];
+
+        for i in 0..l {
+            match lhs[i].partial_cmp(&rhs[i]) {
+                Some(Ordering::Equal) => {}
+                v => return v,
+            }
+        }
+
+        self.len().partial_cmp(&other.len())
+    }
+
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        let l = usize::min(self.len(), other.len());
+
+        let lhs = &self[..l];
+        let rhs = &other[..l];
+
+        for i in 0..l {
+            match lhs[i].cmp(&rhs[i]) {
+                Ordering::Equal => {}
+                v => return v,
+            }
+        }
+
+        self.len().cmp(&other.len())
+    }
+
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        for i in 0..self.len() {
+            if !self[i].eq(&other[i]) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    #[inline]
+    fn hash<H>(&self, hasher: &mut H)
+    where
+        H: Hasher,
+    {
+        self.len().hash(hasher);
+        for v in self {
+            v.hash(hasher);
+        }
     }
 }
 

--- a/conjure-test/src/test/objects.rs
+++ b/conjure-test/src/test/objects.rs
@@ -382,12 +382,12 @@ fn double_keys() {
         .insert_double_set(DoubleKey(1.5))
         .insert_double_set(DoubleKey(f64::INFINITY))
         .insert_double_set(DoubleKey(f64::NAN))
-        .insert_alias_map(DoubleKey(DoubleAlias(1.5)), 1)
-        .insert_alias_map(DoubleKey(DoubleAlias(f64::INFINITY)), 2)
-        .insert_alias_map(DoubleKey(DoubleAlias(f64::NAN)), 3)
-        .insert_alias_set(DoubleKey(DoubleAlias(1.5)))
-        .insert_alias_set(DoubleKey(DoubleAlias(f64::INFINITY)))
-        .insert_alias_set(DoubleKey(DoubleAlias(f64::NAN)))
+        .insert_alias_map(DoubleAlias(1.5), 1)
+        .insert_alias_map(DoubleAlias(f64::INFINITY), 2)
+        .insert_alias_map(DoubleAlias(f64::NAN), 3)
+        .insert_alias_set(DoubleAlias(1.5))
+        .insert_alias_set(DoubleAlias(f64::INFINITY))
+        .insert_alias_set(DoubleAlias(f64::NAN))
         .build();
     test_serde(&value, json);
 }

--- a/conjure-test/src/test/objects.rs
+++ b/conjure-test/src/test/objects.rs
@@ -131,10 +131,10 @@ fn unions() {
         r#"{"type": "object", "object": {"foo": 1}}"#,
     );
 
-    let unknown_json = r#"{"type": "double", "double": 14.3}"#;
+    let unknown_json = r#"{"type": "foobar", "foobar": 14.3}"#;
     let unknown_value = deserialize::<TestUnion>(unknown_json);
     match &unknown_value {
-        TestUnion::Unknown(v) => assert_eq!(v.type_(), "double"),
+        TestUnion::Unknown(v) => assert_eq!(v.type_(), "foobar"),
         _ => panic!("invalid variant"),
     }
     test_ser(&unknown_value, unknown_json);
@@ -442,6 +442,43 @@ fn nested_maps() {
         .insert_maps(
             "a".to_string(),
             BTreeMap::from([("hello".to_string(), "world".to_string())]),
+        )
+        .build();
+    test_serde(&value, json);
+}
+
+#[test]
+fn set_of_objects_with_doubles() {
+    let json = r#"
+    {
+        "set": [
+            {
+                "integer": 1,
+                "double": 1.5,
+                "string": "hi"
+            },
+            {
+                "integer": 2,
+                "double": "NaN",
+                "string": "hello"
+            }
+        ]
+    }
+    "#;
+    let value = SetOfObjectsWithDoubles::builder()
+        .insert_set(
+            AllRequiredFields::builder()
+                .integer(1)
+                .double(1.5)
+                .string("hi")
+                .build(),
+        )
+        .insert_set(
+            AllRequiredFields::builder()
+                .integer(2)
+                .double(f64::NAN)
+                .string("hello")
+                .build(),
         )
         .build();
     test_serde(&value, json);

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -301,6 +301,38 @@
             }
           }
         }
+      }, {
+        "fieldName" : "listSet",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "list",
+              "list" : {
+                "itemType" : {
+                  "type" : "primitive",
+                  "primitive" : "DOUBLE"
+                }
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "setSet",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "set",
+              "set" : {
+                "itemType" : {
+                  "type" : "primitive",
+                  "primitive" : "DOUBLE"
+                }
+              }
+            }
+          }
+        }
       } ]
     }
   }, {
@@ -983,6 +1015,37 @@
           "package" : "com.palantir.conjure"
         }
       }
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "WrappedDoubles",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "optional",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "DOUBLE"
+            }
+          }
+        }
+      }, {
+        "fieldName" : "list",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "DOUBLE"
+            }
+          }
+        }
+      } ]
     }
   }, {
     "type" : "object",

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -751,6 +751,29 @@
     "type" : "object",
     "object" : {
       "typeName" : {
+        "name" : "SetOfObjectsWithDoubles",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "set",
+        "type" : {
+          "type" : "set",
+          "set" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "AllRequiredFields",
+                "package" : "com.palantir.conjure"
+              }
+            }
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
         "name" : "SuperpackageObject",
         "package" : "com.palantir.conjure"
       },
@@ -807,6 +830,12 @@
         "type" : {
           "type" : "primitive",
           "primitive" : "INTEGER"
+        }
+      }, {
+        "fieldName" : "double",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DOUBLE"
         }
       }, {
         "fieldName" : "string",

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -20,6 +20,7 @@ types:
       TestUnion:
         union:
           integer: integer
+          double: double
           string: string
           object:
             type: TestObject
@@ -133,6 +134,9 @@ types:
       NestedMap:
         fields:
           maps: map<string, map<string, string>>
+      SetOfObjectsWithDoubles:
+        fields:
+          set: set<AllRequiredFields>
     errors:
       SimpleError:
         namespace: Test

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -125,6 +125,12 @@ types:
           doubleSet: set<double>
           aliasMap: map<DoubleAlias, integer>
           aliasSet: set<DoubleAlias>
+          listSet: set<list<double>>
+          setSet: set<set<double>>
+      WrappedDoubles:
+        fields:
+          optional: optional<double>
+          list: list<double>
       BooleanKeys:
         fields:
           booleanMap: map<boolean, integer>

--- a/example-api/src/another/different_package.rs
+++ b/example-api/src/another/different_package.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Different package.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct DifferentPackage {}
 impl DifferentPackage {
     /// Constructs a new instance of the type.

--- a/example-api/src/product/alias_as_map_key_example.rs
+++ b/example-api/src/product/alias_as_map_key_example.rs
@@ -1,7 +1,8 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AliasAsMapKeyExample {
     strings: std::collections::BTreeMap<
         super::StringAliasExample,

--- a/example-api/src/product/aliased_binary.rs
+++ b/example-api/src/product/aliased_binary.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct AliasedBinary(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for AliasedBinary {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/aliased_string.rs
+++ b/example-api/src/product/aliased_string.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct AliasedString(pub String);
 impl std::fmt::Display for AliasedString {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/any_example.rs
+++ b/example-api/src/product/any_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnyExample {
     any: conjure_object::Any,
 }

--- a/example-api/src/product/any_map_example.rs
+++ b/example-api/src/product/any_map_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnyMapExample {
     items: std::collections::BTreeMap<String, conjure_object::Any>,
 }

--- a/example-api/src/product/bearer_token_alias_example.rs
+++ b/example-api/src/product/bearer_token_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BearerTokenAliasExample(pub conjure_object::BearerToken);
 impl conjure_object::Plain for BearerTokenAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/bearer_token_example.rs
+++ b/example-api/src/product/bearer_token_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BearerTokenExample {
     bearer_token_value: conjure_object::BearerToken,
 }

--- a/example-api/src/product/binary_alias_example.rs
+++ b/example-api/src/product/binary_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BinaryAliasExample(pub conjure_object::ByteBuf);
 impl conjure_object::Plain for BinaryAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/binary_example.rs
+++ b/example-api/src/product/binary_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BinaryExample {
     binary: conjure_object::ByteBuf,
 }

--- a/example-api/src/product/boolean_alias_example.rs
+++ b/example-api/src/product/boolean_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct BooleanAliasExample(pub bool);
 impl std::fmt::Display for BooleanAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/boolean_example.rs
+++ b/example-api/src/product/boolean_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct BooleanExample {
     coin: bool,
 }

--- a/example-api/src/product/covariant_list_example.rs
+++ b/example-api/src/product/covariant_list_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CovariantListExample {
     items: Vec<conjure_object::Any>,
     external_items: Vec<String>,

--- a/example-api/src/product/covariant_optional_example.rs
+++ b/example-api/src/product/covariant_optional_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CovariantOptionalExample {
     item: Option<conjure_object::Any>,
 }

--- a/example-api/src/product/create_dataset_request.rs
+++ b/example-api/src/product/create_dataset_request.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateDatasetRequest {
     file_system_id: String,
     path: String,

--- a/example-api/src/product/datasets/backing_file_system.rs
+++ b/example-api/src/product/datasets/backing_file_system.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BackingFileSystem {
     file_system_id: String,
     base_uri: String,

--- a/example-api/src/product/datasets/dataset.rs
+++ b/example-api/src/product/datasets/dataset.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Dataset {
     file_system_id: String,
     rid: conjure_object::ResourceIdentifier,

--- a/example-api/src/product/date_time_alias_example.rs
+++ b/example-api/src/product/date_time_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DateTimeAliasExample(pub conjure_object::DateTime<conjure_object::Utc>);
 impl std::fmt::Display for DateTimeAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/date_time_example.rs
+++ b/example-api/src/product/date_time_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct DateTimeExample {
     datetime: conjure_object::DateTime<conjure_object::Utc>,
 }

--- a/example-api/src/product/double_alias_example.rs
+++ b/example-api/src/product/double_alias_example.rs
@@ -1,6 +1,15 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Default)]
-pub struct DoubleAliasExample(pub f64);
+#[derive(Debug, Clone, Copy, conjure_object::private::Educe, Default)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DoubleAliasExample(
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
+    pub f64,
+);
 impl std::fmt::Display for DoubleAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.0, fmt)
@@ -16,12 +25,6 @@ impl conjure_object::FromPlain for DoubleAliasExample {
     #[inline]
     fn from_plain(s: &str) -> Result<DoubleAliasExample, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(DoubleAliasExample)
-    }
-}
-impl conjure_object::AsDouble for DoubleAliasExample {
-    #[inline]
-    fn as_double(&self) -> f64 {
-        conjure_object::AsDouble::as_double(&self.0)
     }
 }
 impl std::ops::Deref for DoubleAliasExample {

--- a/example-api/src/product/double_example.rs
+++ b/example-api/src/product/double_example.rs
@@ -1,8 +1,15 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy)]
+#[derive(Debug, Clone, conjure_object::private::Educe, Copy)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DoubleExample {
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     double_value: f64,
 }
 impl DoubleExample {

--- a/example-api/src/product/empty_object_example.rs
+++ b/example-api/src/product/empty_object_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct EmptyObjectExample {}
 impl EmptyObjectExample {
     /// Constructs a new instance of the type.

--- a/example-api/src/product/enum_field_example.rs
+++ b/example-api/src/product/enum_field_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnumFieldExample {
     enum_: super::EnumExample,
 }

--- a/example-api/src/product/integer_alias_example.rs
+++ b/example-api/src/product/integer_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct IntegerAliasExample(pub i32);
 impl std::fmt::Display for IntegerAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/integer_example.rs
+++ b/example-api/src/product/integer_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct IntegerExample {
     integer: i32,
 }

--- a/example-api/src/product/invalid_service_definition.rs
+++ b/example-api/src/product/invalid_service_definition.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Invalid Conjure service definition.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvalidServiceDefinition {
     service_name: String,
     service_def: conjure_object::Any,

--- a/example-api/src/product/invalid_type_definition.rs
+++ b/example-api/src/product/invalid_type_definition.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Invalid Conjure type definition.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvalidTypeDefinition {
     type_name: String,
     type_def: conjure_object::Any,

--- a/example-api/src/product/java_compilation_failed.rs
+++ b/example-api/src/product/java_compilation_failed.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 ///Failed to compile Conjure definition to Java code.
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct JavaCompilationFailed {}
 impl JavaCompilationFailed {
     /// Constructs a new instance of the type.

--- a/example-api/src/product/list_example.rs
+++ b/example-api/src/product/list_example.rs
@@ -1,7 +1,8 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListExample {
     items: Vec<String>,
     primitive_items: Vec<i32>,

--- a/example-api/src/product/list_example.rs
+++ b/example-api/src/product/list_example.rs
@@ -6,6 +6,12 @@ use std::fmt;
 pub struct ListExample {
     items: Vec<String>,
     primitive_items: Vec<i32>,
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     double_items: Vec<f64>,
 }
 impl ListExample {

--- a/example-api/src/product/many_field_example.rs
+++ b/example-api/src/product/many_field_example.rs
@@ -1,10 +1,17 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ManyFieldExample {
     string: String,
     integer: i32,
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     double_value: f64,
     optional_item: Option<String>,
     items: Vec<String>,

--- a/example-api/src/product/map_alias_example.rs
+++ b/example-api/src/product/map_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct MapAliasExample(pub std::collections::BTreeMap<String, conjure_object::Any>);
 impl std::ops::Deref for MapAliasExample {
     type Target = std::collections::BTreeMap<String, conjure_object::Any>;

--- a/example-api/src/product/map_example.rs
+++ b/example-api/src/product/map_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapExample {
     items: std::collections::BTreeMap<String, String>,
 }

--- a/example-api/src/product/nested_aliased_binary.rs
+++ b/example-api/src/product/nested_aliased_binary.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct NestedAliasedBinary(pub super::AliasedBinary);
 impl conjure_object::Plain for NestedAliasedBinary {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/nested_string_alias_example.rs
+++ b/example-api/src/product/nested_string_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct NestedStringAliasExample(pub super::StringAliasExample);
 impl std::fmt::Display for NestedStringAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/optional_example.rs
+++ b/example-api/src/product/optional_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OptionalExample {
     item: Option<String>,
 }

--- a/example-api/src/product/primitive_optionals_example.rs
+++ b/example-api/src/product/primitive_optionals_example.rs
@@ -4,6 +4,12 @@ use std::fmt;
 #[derive(Debug, Clone, conjure_object::private::Educe)]
 #[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrimitiveOptionalsExample {
+    #[educe(
+        PartialEq(trait = "conjure_object::private::DoubleOps"),
+        PartialOrd(trait = "conjure_object::private::DoubleOps"),
+        Ord(trait = "conjure_object::private::DoubleOps"),
+        Hash(trait = "conjure_object::private::DoubleOps"),
+    )]
     num: Option<f64>,
     bool: Option<bool>,
     integer: Option<i32>,

--- a/example-api/src/product/primitive_optionals_example.rs
+++ b/example-api/src/product/primitive_optionals_example.rs
@@ -1,7 +1,8 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, conjure_object::private::Educe)]
+#[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrimitiveOptionalsExample {
     num: Option<f64>,
     bool: Option<bool>,

--- a/example-api/src/product/reference_alias_example.rs
+++ b/example-api/src/product/reference_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReferenceAliasExample(pub super::AnyExample);
 impl std::ops::Deref for ReferenceAliasExample {
     type Target = super::AnyExample;

--- a/example-api/src/product/reserved_key_example.rs
+++ b/example-api/src/product/reserved_key_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReservedKeyExample {
     package: String,
     interface: String,

--- a/example-api/src/product/rid_alias_example.rs
+++ b/example-api/src/product/rid_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RidAliasExample(pub conjure_object::ResourceIdentifier);
 impl std::fmt::Display for RidAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/rid_example.rs
+++ b/example-api/src/product/rid_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RidExample {
     rid_value: conjure_object::ResourceIdentifier,
 }

--- a/example-api/src/product/safe_long_alias_example.rs
+++ b/example-api/src/product/safe_long_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct SafeLongAliasExample(pub conjure_object::SafeLong);
 impl std::fmt::Display for SafeLongAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/safe_long_example.rs
+++ b/example-api/src/product/safe_long_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct SafeLongExample {
     safe_long_value: conjure_object::SafeLong,
 }

--- a/example-api/src/product/set_example.rs
+++ b/example-api/src/product/set_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetExample {
     items: std::collections::BTreeSet<String>,
 }

--- a/example-api/src/product/single_union.rs
+++ b/example-api/src/product/single_union.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SingleUnion {
     Foo(String),
     /// An unknown variant.

--- a/example-api/src/product/string_alias_example.rs
+++ b/example-api/src/product/string_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct StringAliasExample(pub String);
 impl std::fmt::Display for StringAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/string_example.rs
+++ b/example-api/src/product/string_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StringExample {
     string: String,
 }

--- a/example-api/src/product/union_.rs
+++ b/example-api/src/product/union_.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Union {
     Foo(String),
     Bar(i32),

--- a/example-api/src/product/union_type_example.rs
+++ b/example-api/src/product/union_type_example.rs
@@ -2,7 +2,7 @@ use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UnionTypeExample {
     ///Docs for when UnionTypeExample is of type StringExample.
     StringExample(super::StringExample),

--- a/example-api/src/product/uuid_alias_example.rs
+++ b/example-api/src/product/uuid_alias_example.rs
@@ -1,5 +1,5 @@
 use conjure_object::serde::{ser, de};
-#[derive(Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UuidAliasExample(pub conjure_object::Uuid);
 impl std::fmt::Display for UuidAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/example-api/src/product/uuid_example.rs
+++ b/example-api/src/product/uuid_example.rs
@@ -1,7 +1,7 @@
 use conjure_object::serde::{ser, de};
 use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct UuidExample {
     uuid: conjure_object::Uuid,
 }


### PR DESCRIPTION
## Before this PR
We had some special support for `double` values used as keys and set elements, but missed multiple corner cases.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
All generated types implement `Ord`, `Eq`, and `Hash`. Notably, this enables support for `set<ObjectWithADoubleField>`.
==COMMIT_MSG==

We could have used the `DoubleKey` type everywhere and just used the normal `#[derive(Eq)]` etc, but I decided to make things a bit nicer for users by only using `DoubleKey` for `set<double>` and `map<double, T>` specifically. Aliases, objects, and unions wrapping `double` work with `f64` directly and have custom derive behavior.

## Possible downsides?
This is a breaking change. We could make it opt-in via a flag, but we're going to need to cut a major version bump anyways to pick up #200 so we might as well avoid the extra complexity.

Closes #195