### PR TITLE
allow a content-type header on requests without a body

### DIFF
--- a/changelog/@unreleased/pr-205.v2.yml
+++ b/changelog/@unreleased/pr-205.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: allow a content-type header on requests without a body
+  links:
+  - https://github.com/palantir/conjure-rust/pull/205

--- a/conjure-http/src/private/server.rs
+++ b/conjure-http/src/private/server.rs
@@ -241,13 +241,7 @@ fn parse_auth_inner(
 }
 
 pub fn decode_empty_request<I>(parts: &request::Parts, _body: I) -> Result<(), Error> {
-    if parts.headers.contains_key(CONTENT_TYPE) {
-        return Err(Error::service_safe(
-            "unexpected Content-Type",
-            InvalidArgument::new(),
-        ));
-    }
-
+    // nothing to do, just consume the body
     Ok(())
 }
 

--- a/conjure-http/src/private/server.rs
+++ b/conjure-http/src/private/server.rs
@@ -240,7 +240,7 @@ fn parse_auth_inner(
         .map_err(|e| Error::service_safe(e, PermissionDenied::new()))
 }
 
-pub fn decode_empty_request<I>(parts: &request::Parts, _body: I) -> Result<(), Error> {
+pub fn decode_empty_request<I>(_parts: &request::Parts, _body: I) -> Result<(), Error> {
     // nothing to do, just consume the body
     Ok(())
 }


### PR DESCRIPTION
conjure-typescript will send a content-type and the http spec doesn't disallow it.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

