### PR TITLE
Support new log safety declarations

### DIFF
--- a/changelog/@unreleased/pr-215.v2.yml
+++ b/changelog/@unreleased/pr-215.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Code generation now supports Conjure's new log safety declarations
+    to track safe loggable endpoint parameters.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/215

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 syn = "1"
 
-conjure-object = { version = "2.0.0", path = "../conjure-object" }
-conjure-serde = { version = "2.0.0", path = "../conjure-serde" }
-conjure-error = { version = "2.0.0", optional = true, path = "../conjure-error" }
-conjure-http = { version = "2.0.0", optional = true, path = "../conjure-http" }
+conjure-object = { version = "3.0.0", path = "../conjure-object" }
+conjure-serde = { version = "3.0.0", path = "../conjure-serde" }
+conjure-error = { version = "3.0.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "3.0.0", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/conjure-api-4.32.0.conjure.json
+++ b/conjure-codegen/conjure-api-4.32.0.conjure.json
@@ -40,6 +40,20 @@
             }
           }
         }
+      }, {
+        "fieldName" : "safety",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "LogSafety",
+                "package" : "com.palantir.conjure.spec"
+              }
+            }
+          }
+        }
       } ]
     }
   }, {
@@ -77,6 +91,20 @@
           }
         }
       }, {
+        "fieldName" : "safety",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "LogSafety",
+                "package" : "com.palantir.conjure.spec"
+              }
+            }
+          }
+        }
+      }, {
         "fieldName" : "docs",
         "type" : {
           "type" : "optional",
@@ -107,8 +135,8 @@
       }, {
         "fieldName" : "tags",
         "type" : {
-          "type" : "list",
-          "list" : {
+          "type" : "set",
+          "set" : {
             "itemType" : {
               "type" : "primitive",
               "primitive" : "STRING"
@@ -699,6 +727,20 @@
             }
           }
         }
+      }, {
+        "fieldName" : "safety",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "LogSafety",
+                "package" : "com.palantir.conjure.spec"
+              }
+            }
+          }
+        }
       } ]
     }
   }, {
@@ -787,6 +829,25 @@
           }
         }
       } ]
+    }
+  }, {
+    "type" : "enum",
+    "enum" : {
+      "typeName" : {
+        "name" : "LogSafety",
+        "package" : "com.palantir.conjure.spec"
+      },
+      "values" : [ {
+        "value" : "SAFE",
+        "docs" : "Explicitly marks an element as safe."
+      }, {
+        "value" : "UNSAFE",
+        "docs" : "Explicitly marks an element as unsafe, diallowing contents from being logged as `SAFE`."
+      }, {
+        "value" : "DO_NOT_LOG",
+        "docs" : "Marks elements that must never be logged. For example, credentials, keys, and other secrets cannot be logged because such an action would compromise security.\n"
+      } ],
+      "docs" : "Safety with regards to logging based on [safe-logging](https://github.com/palantir/safe-logging) concepts.\n"
     }
   }, {
     "type" : "object",

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -1086,8 +1086,9 @@ impl Context {
                         .or_else(|| self.type_log_safety(f.type_()))
                 })
                 // The unknown variant is unsafe to log, and we don't want log safety to vary based
-                // on the type generation configuration.
-                .fold(Some(LogSafety::Unsafe), |a, b| self.combine_safety(a, b)),
+                // on the type generation configuration. However, like conjure-java we're going to
+                // treat the unknown variant as unannotated for now to ease the rollout.
+                .fold(None, |a, b| self.combine_safety(a, b)),
         };
 
         *ctx.log_safety.borrow_mut() = CachedLogSafety::Computed(safety.clone());

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -1000,6 +1000,7 @@ impl Context {
         quote!(#(#components::)* #other_type_name)
     }
 
+    // https://github.com/palantir/conjure-java/blob/develop/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
     pub fn is_safe_arg(&self, arg: &ArgumentDefinition) -> bool {
         if let Some(log_safety) = arg.safety() {
             return *log_safety == LogSafety::Safe;

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -16,17 +16,24 @@
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 use crate::types::{
-    ConjureDefinition, Documentation, PrimitiveType, Type, TypeDefinition, TypeName,
+    ArgumentDefinition, ConjureDefinition, Documentation, LogSafety, PrimitiveType, Type,
+    TypeDefinition, TypeName,
 };
+
+enum CachedLogSafety {
+    Uncomputed,
+    Computed(Option<LogSafety>),
+}
 
 struct TypeContext {
     def: TypeDefinition,
     has_double: Cell<Option<bool>>,
     is_copy: Cell<Option<bool>>,
+    log_safety: RefCell<CachedLogSafety>,
 }
 
 pub struct Context {
@@ -71,6 +78,7 @@ impl Context {
                     def: def.clone(),
                     has_double: Cell::new(None),
                     is_copy: Cell::new(None),
+                    log_safety: RefCell::new(CachedLogSafety::Uncomputed),
                 },
             );
         }
@@ -992,13 +1000,108 @@ impl Context {
         quote!(#(#components::)* #other_type_name)
     }
 
-    pub fn is_safe_arg(&self, ty: &Type) -> bool {
+    pub fn is_safe_arg(&self, arg: &ArgumentDefinition) -> bool {
+        if let Some(log_safety) = arg.safety() {
+            return *log_safety == LogSafety::Safe;
+        }
+
+        if self.is_legacy_safe_arg(arg) {
+            return true;
+        }
+
+        self.type_log_safety(arg.type_()) == Some(LogSafety::Safe)
+    }
+
+    fn is_legacy_safe_arg(&self, arg: &ArgumentDefinition) -> bool {
+        arg.tags().iter().any(|s| s == "safe")
+            || arg.markers().iter().any(|a| self.is_legacy_safe_marker(a))
+    }
+
+    fn is_legacy_safe_marker(&self, ty: &Type) -> bool {
         match ty {
             Type::External(def) => {
                 let name = def.external_reference();
                 name.package() == "com.palantir.logsafe" && name.name() == "Safe"
             }
             _ => false,
+        }
+    }
+
+    fn type_log_safety(&self, ty: &Type) -> Option<LogSafety> {
+        match ty {
+            Type::Primitive(primitive) => self.primitive_log_safety(primitive),
+            Type::Optional(optional) => self.type_log_safety(optional.item_type()),
+            Type::List(list) => self.type_log_safety(list.item_type()),
+            Type::Set(set) => self.type_log_safety(set.item_type()),
+            Type::Map(map) => self.combine_safety(
+                self.type_log_safety(map.key_type()),
+                self.type_log_safety(map.value_type()),
+            ),
+            Type::Reference(def) => self.type_log_safety_ref(def),
+            Type::External(_) => None,
+        }
+    }
+
+    fn primitive_log_safety(&self, primitive: &PrimitiveType) -> Option<LogSafety> {
+        match primitive {
+            PrimitiveType::Bearertoken => Some(LogSafety::DoNotLog),
+            _ => None,
+        }
+    }
+
+    fn type_log_safety_ref(&self, name: &TypeName) -> Option<LogSafety> {
+        let ctx = &self.types[name];
+
+        if let CachedLogSafety::Computed(safety) = &*ctx.log_safety.borrow() {
+            return safety.clone();
+        }
+
+        // temporarily treat it as safe in case of recursive type definitions.
+        *ctx.log_safety.borrow_mut() = CachedLogSafety::Computed(Some(LogSafety::Safe));
+
+        let safety = match &ctx.def {
+            TypeDefinition::Alias(alias) => alias
+                .safety()
+                .cloned()
+                .or_else(|| self.type_log_safety(alias.alias())),
+            // We consider enums to be safe even when not compiled as exhaustive, since we assume
+            // unknown variants are simply from a future definition.
+            TypeDefinition::Enum(_) => Some(LogSafety::Safe),
+            TypeDefinition::Object(object) => object
+                .fields()
+                .iter()
+                .map(|f| {
+                    f.safety()
+                        .cloned()
+                        .or_else(|| self.type_log_safety(f.type_()))
+                })
+                .fold(Some(LogSafety::Safe), |a, b| self.combine_safety(a, b)),
+            TypeDefinition::Union(union_) => union_
+                .union_()
+                .iter()
+                .map(|f| {
+                    f.safety()
+                        .cloned()
+                        .or_else(|| self.type_log_safety(f.type_()))
+                })
+                // The unknown variant is unsafe to log, and we don't want log safety to vary based
+                // on the type generation configuration.
+                .fold(Some(LogSafety::Unsafe), |a, b| self.combine_safety(a, b)),
+        };
+
+        *ctx.log_safety.borrow_mut() = CachedLogSafety::Computed(safety.clone());
+        safety
+    }
+
+    fn combine_safety(&self, a: Option<LogSafety>, b: Option<LogSafety>) -> Option<LogSafety> {
+        match (a, b) {
+            (Some(LogSafety::DoNotLog), _) | (_, Some(LogSafety::DoNotLog)) => {
+                Some(LogSafety::DoNotLog)
+            }
+            (Some(LogSafety::Unsafe), _) | (_, Some(LogSafety::Unsafe)) => Some(LogSafety::Unsafe),
+            (Some(LogSafety::Safe), Some(LogSafety::Safe)) => Some(LogSafety::Safe),
+            // nb: we notably do not combine safe + unknown to safe
+            (Some(LogSafety::Safe), None) | (None, Some(LogSafety::Safe)) | (None, None) => None,
         }
     }
 

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -484,7 +484,7 @@ fn generate_endpoint_impl(
             ParameterType::Body(_) => parse_body_arg(ctx, arg, &parts, &body, style),
         };
 
-        let put_safe = if is_safe(ctx, arg) {
+        let put_safe = if ctx.is_safe_arg(arg) {
             let name = &***arg.arg_name();
             quote! {
                 #safe_params.insert(#name, &#variable);
@@ -544,11 +544,7 @@ fn generate_endpoint_impl(
 }
 
 fn has_safe_params(ctx: &Context, endpoint: &EndpointDefinition) -> bool {
-    endpoint.args().iter().any(|arg| is_safe(ctx, arg))
-}
-
-fn is_safe(ctx: &Context, arg: &ArgumentDefinition) -> bool {
-    arg.tags().iter().any(|s| s == "safe") || arg.markers().iter().any(|a| ctx.is_safe_arg(a))
+    endpoint.args().iter().any(|arg| ctx.is_safe_arg(arg))
 }
 
 fn has_query_params(endpoint: &EndpointDefinition) -> bool {

--- a/conjure-codegen/src/types/log_safety.rs
+++ b/conjure-codegen/src/types/log_safety.rs
@@ -1,0 +1,87 @@
+use conjure_object::serde::{ser, de};
+use std::fmt;
+use std::str;
+///Safety with regards to logging based on [safe-logging](https://github.com/palantir/safe-logging) concepts.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum LogSafety {
+    ///Explicitly marks an element as safe.
+    Safe,
+    ///Explicitly marks an element as unsafe, diallowing contents from being logged as `SAFE`.
+    Unsafe,
+    ///Marks elements that must never be logged. For example, credentials, keys, and other secrets cannot be logged because such an action would compromise security.
+    DoNotLog,
+}
+impl LogSafety {
+    /// Returns the string representation of the enum.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        match self {
+            LogSafety::Safe => "SAFE",
+            LogSafety::Unsafe => "UNSAFE",
+            LogSafety::DoNotLog => "DO_NOT_LOG",
+        }
+    }
+}
+impl fmt::Display for LogSafety {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self.as_str(), fmt)
+    }
+}
+impl conjure_object::Plain for LogSafety {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        conjure_object::Plain::fmt(self.as_str(), fmt)
+    }
+}
+impl str::FromStr for LogSafety {
+    type Err = conjure_object::plain::ParseEnumError;
+    #[inline]
+    fn from_str(v: &str) -> Result<LogSafety, conjure_object::plain::ParseEnumError> {
+        match v {
+            "SAFE" => Ok(LogSafety::Safe),
+            "UNSAFE" => Ok(LogSafety::Unsafe),
+            "DO_NOT_LOG" => Ok(LogSafety::DoNotLog),
+            _ => Err(conjure_object::plain::ParseEnumError::new()),
+        }
+    }
+}
+impl conjure_object::FromPlain for LogSafety {
+    type Err = conjure_object::plain::ParseEnumError;
+    #[inline]
+    fn from_plain(v: &str) -> Result<LogSafety, conjure_object::plain::ParseEnumError> {
+        v.parse()
+    }
+}
+impl ser::Serialize for LogSafety {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        s.serialize_str(self.as_str())
+    }
+}
+impl<'de> de::Deserialize<'de> for LogSafety {
+    fn deserialize<D>(d: D) -> Result<LogSafety, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_str(Visitor_)
+    }
+}
+struct Visitor_;
+impl<'de> de::Visitor<'de> for Visitor_ {
+    type Value = LogSafety;
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str("a string")
+    }
+    fn visit_str<E>(self, v: &str) -> Result<LogSafety, E>
+    where
+        E: de::Error,
+    {
+        match v.parse() {
+            Ok(e) => Ok(e),
+            Err(_) => {
+                Err(de::Error::unknown_variant(v, &["SAFE", "UNSAFE", "DO_NOT_LOG"]))
+            }
+        }
+    }
+}

--- a/conjure-codegen/src/types/mod.rs
+++ b/conjure-codegen/src/types/mod.rs
@@ -45,6 +45,8 @@ pub use self::http_path::HttpPath;
 #[doc(inline)]
 pub use self::list_type::ListType;
 #[doc(inline)]
+pub use self::log_safety::LogSafety;
+#[doc(inline)]
 pub use self::map_type::MapType;
 #[doc(inline)]
 pub use self::object_definition::ObjectDefinition;
@@ -95,6 +97,7 @@ pub mod header_parameter_type;
 pub mod http_method;
 pub mod http_path;
 pub mod list_type;
+pub mod log_safety;
 pub mod map_type;
 pub mod object_definition;
 pub mod optional_type;

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.12"
 serde = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
-conjure-object = { version = "2.0.0", path = "../conjure-object" }
+conjure-object = { version = "3.0.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,6 +20,6 @@ percent-encoding = "2.1"
 pin-utils = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "2.0.0", path = "../conjure-error" }
-conjure-object = { version = "2.0.0", path = "../conjure-object" }
-conjure-serde = { version = "2.0.0", path = "../conjure-serde" }
+conjure-error = { version = "3.0.0", path = "../conjure-error" }
+conjure-object = { version = "3.0.0", path = "../conjure-object" }
+conjure-serde = { version = "3.0.0", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "3", features = ["derive"] }
 
-conjure-codegen = { version = "2.0.0", path = "../conjure-codegen" }
+conjure-codegen = { version = "3.0.0", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "2.0.0"
+version = "3.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -152,8 +152,8 @@ test_service_handler! {
         unsafe_path: String,
         safe_query: String,
         unsafe_query: String,
-        safe_header: String,
-        unsafe_header: String
+        safe_header: SafeStringAlias,
+        unsafe_header: UnsafeStringAlias
     ) -> Result<(), Error>;
 
     fn deprecated(&self) -> Result<(), Error>;

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -751,6 +751,19 @@
     "type" : "alias",
     "alias" : {
       "typeName" : {
+        "name" : "SafeStringAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      },
+      "safety" : "SAFE"
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
         "name" : "SetAlias",
         "package" : "com.palantir.conjure"
       },
@@ -1015,6 +1028,19 @@
           "package" : "com.palantir.conjure"
         }
       }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "UnsafeStringAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      },
+      "safety" : "UNSAFE"
     }
   }, {
     "type" : "object",
@@ -1660,19 +1686,8 @@
             "paramId" : "safeQueryId"
           }
         },
-        "markers" : [ {
-          "type" : "external",
-          "external" : {
-            "externalReference" : {
-              "name" : "Safe",
-              "package" : "com.palantir.logsafe"
-            },
-            "fallback" : {
-              "type" : "primitive",
-              "primitive" : "ANY"
-            }
-          }
-        } ],
+        "safety" : "SAFE",
+        "markers" : [ ],
         "tags" : [ ]
       }, {
         "argName" : "unsafeQuery",
@@ -1691,8 +1706,11 @@
       }, {
         "argName" : "safeHeader",
         "type" : {
-          "type" : "primitive",
-          "primitive" : "STRING"
+          "type" : "reference",
+          "reference" : {
+            "name" : "SafeStringAlias",
+            "package" : "com.palantir.conjure"
+          }
         },
         "paramType" : {
           "type" : "header",
@@ -1700,25 +1718,16 @@
             "paramId" : "Safe-Header"
           }
         },
-        "markers" : [ {
-          "type" : "external",
-          "external" : {
-            "externalReference" : {
-              "name" : "Safe",
-              "package" : "com.palantir.logsafe"
-            },
-            "fallback" : {
-              "type" : "primitive",
-              "primitive" : "ANY"
-            }
-          }
-        } ],
+        "markers" : [ ],
         "tags" : [ ]
       }, {
         "argName" : "unsafeHeader",
         "type" : {
-          "type" : "primitive",
-          "primitive" : "STRING"
+          "type" : "reference",
+          "reference" : {
+            "name" : "UnsafeStringAlias",
+            "package" : "com.palantir.conjure"
+          }
         },
         "paramType" : {
           "type" : "header",

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -58,6 +58,12 @@ types:
         alias: optional<TestObject>
       BinaryAlias:
         alias: binary
+      SafeStringAlias:
+        alias: string
+        safety: safe
+      UnsafeStringAlias:
+        alias: string
+        safety: unsafe
       TransparentAliases:
         fields:
           optionalOfAlias: optional<IntegerAlias>
@@ -289,20 +295,17 @@ services:
             type: string
             param-type: query
             param-id: safeQueryId
-            markers:
-              - Safe
+            safety: safe
           unsafeQuery:
             type: string
             param-type: query
             param-id: unsafeQueryId
           safeHeader:
-            type: string
+            type: SafeStringAlias
             param-type: header
             param-id: Safe-Header
-            markers:
-              - Safe
           unsafeHeader:
-            type: string
+            type: UnsafeStringAlias
             param-type: header
             param-id: Unsafe-Header
       deprecated:

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -4,6 +4,6 @@ version = '0.1.0'
 edition = '2018'
 
 [dependencies]
-conjure-error = '2.0.0'
-conjure-http = '2.0.0'
-conjure-object = '2.0.0'
+conjure-error = '3.0.0'
+conjure-http = '3.0.0'
+conjure-object = '3.0.0'

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -8,6 +8,6 @@ rm -rf example-api
 rm -rf conjure-codegen/src/exmaple-types
 ./target/debug/conjure-rust generate --stripPrefix com.palantir conjure-codegen/example-types-ir.json conjure-codegen/src/example_types
 rm -rf conjure-codegen/src/types
-./target/debug/conjure-rust generate --stripPrefix com.palantir.conjure.spec --exhaustive conjure-codegen/conjure-api-4.14.0.conjure.json conjure-codegen/src/types
+./target/debug/conjure-rust generate --stripPrefix com.palantir.conjure.spec --exhaustive conjure-codegen/conjure-api-4.32.0.conjure.json conjure-codegen/src/types
 rm -rf conjure-error/src/types
 ./target/debug/conjure-rust generate --stripPrefix com.palantir.conjure.error --exhaustive conjure-error/error-types.conjure.json conjure-error/src/types


### PR DESCRIPTION
## Before this PR
We only supported detection of safe loggable endpoint parameters via the old `Safe` marker or `safe` tag.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Code generation now supports Conjure's new log safety declarations to track safe loggable endpoint parameters.
==COMMIT_MSG==
