### PR TITLE
Support request context injection into server handlers

### DIFF
--- a/changelog/@unreleased/pr-219.v2.yml
+++ b/changelog/@unreleased/pr-219.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Added support for the `server-request-context` endpoint tag to provide
+    lower level request information to the generated server handler.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/219

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 syn = "1"
 
-conjure-object = { version = "3.0.0", path = "../conjure-object" }
-conjure-serde = { version = "3.0.0", path = "../conjure-serde" }
-conjure-error = { version = "3.0.0", optional = true, path = "../conjure-error" }
-conjure-http = { version = "3.0.0", optional = true, path = "../conjure-http" }
+conjure-object = { version = "3.1.0", path = "../conjure-object" }
+conjure-serde = { version = "3.1.0", path = "../conjure-serde" }
+conjure-error = { version = "3.1.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "3.1.0", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -275,6 +275,11 @@
 //! let resource = TestServiceResource::new(TestServiceHandler);
 //! http_server.register(resource);
 //! ```
+//!
+//! ### Endpoint Tags
+//!
+//! * `server-request-context` - The generated server trait method will have an additional
+//!     `RequestContext` argument providing lower level access to request and response information.
 #![warn(clippy::all, missing_docs)]
 #![allow(clippy::needless_doctest_main)]
 #![recursion_limit = "256"]

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -458,7 +458,7 @@ fn generate_endpoint_impl(
 
     let parts = quote!(parts_);
     let body = quote!(body_);
-    let response_extensions = if has_safe_params(ctx, endpoint) {
+    let response_extensions = if has_safe_params(ctx, endpoint) || has_request_context(endpoint) {
         quote!(response_extensions_)
     } else {
         quote!(_response_extensions)

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.12"
 serde = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
-conjure-object = { version = "3.0.0", path = "../conjure-object" }
+conjure-object = { version = "3.1.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,6 +20,6 @@ percent-encoding = "2.1"
 pin-utils = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "3.0.0", path = "../conjure-error" }
-conjure-object = { version = "3.0.0", path = "../conjure-object" }
-conjure-serde = { version = "3.0.0", path = "../conjure-serde" }
+conjure-error = { version = "3.1.0", path = "../conjure-error" }
+conjure-object = { version = "3.1.0", path = "../conjure-object" }
+conjure-serde = { version = "3.1.0", path = "../conjure-serde" }

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -282,7 +282,7 @@ impl<'a> RequestContext<'a> {
         &self.request_parts.headers
     }
 
-    /// Returns a mutable reference to the request's headers.
+    /// Returns a shared reference to the request's extensions.
     #[inline]
     pub fn request_extensions(&self) -> &Extensions {
         &self.request_parts.extensions

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -16,7 +16,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use conjure_error::Error;
-use http::{Extensions, Method, Request, Response};
+use http::{request, Extensions, HeaderMap, Method, Request, Response, Uri};
 use std::borrow::Cow;
 use std::future::Future;
 use std::io::Write;
@@ -248,4 +248,55 @@ pub trait AsyncWriteBody<W> {
     /// Writes the body out, in its entirety.
     // This should not be limited to `Box<Self>`, but it otherwise can't be used as a trait object currently :(
     async fn write_body(self: Box<Self>, w: Pin<&mut W>) -> Result<(), Error>;
+}
+
+/// An object containing extra low-level contextual information about a request.
+///
+/// Conjure service endpoints declared with the `server-request-context` tag will be passed a
+/// `RequestContext` in the generated trait.
+pub struct RequestContext<'a> {
+    request_parts: request::Parts,
+    response_extensions: &'a mut Extensions,
+}
+
+impl<'a> RequestContext<'a> {
+    // This is public API but not exposed in docs since it should only be called by generated code.
+    #[doc(hidden)]
+    #[inline]
+    pub fn new(request_parts: request::Parts, response_extensions: &'a mut Extensions) -> Self {
+        RequestContext {
+            request_parts,
+            response_extensions,
+        }
+    }
+
+    /// Returns the request's URI.
+    #[inline]
+    pub fn request_uri(&self) -> &Uri {
+        &self.request_parts.uri
+    }
+
+    /// Returns a shared reference to the request's headers.
+    #[inline]
+    pub fn request_headers(&self) -> &HeaderMap {
+        &self.request_parts.headers
+    }
+
+    /// Returns a mutable reference to the request's headers.
+    #[inline]
+    pub fn request_extensions(&self) -> &Extensions {
+        &self.request_parts.extensions
+    }
+
+    /// Returns a shared reference to extensions that will be added to the response.
+    #[inline]
+    pub fn response_extensions(&self) -> &Extensions {
+        self.response_extensions
+    }
+
+    /// Returns a mutable reference to extensions that will be added to the response.
+    #[inline]
+    pub fn response_extensions_mut(&mut self) -> &mut Extensions {
+        self.response_extensions
+    }
 }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 
-conjure-codegen = { version = "3.0.0", path = "../conjure-codegen" }
+conjure-codegen = { version = "3.1.0", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -1748,6 +1748,32 @@
       "deprecated" : "Don't use this!",
       "markers" : [ ],
       "tags" : [ ]
+    }, {
+      "endpointName" : "context",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/context",
+      "args" : [ {
+        "argName" : "arg",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "paramType" : {
+          "type" : "query",
+          "query" : {
+            "paramId" : "arg"
+          }
+        },
+        "markers" : [ ],
+        "tags" : [ ]
+      } ],
+      "markers" : [ ],
+      "tags" : [ "server-request-context" ]
     } ]
   }, {
     "serviceName" : {

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -311,3 +311,11 @@ services:
       deprecated:
         http: GET /deprecated
         deprecated: Don't use this!
+      context:
+        http: GET /context
+        tags:
+          - server-request-context
+        args:
+          arg:
+            type: optional<string>
+            param-type: query

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -4,6 +4,6 @@ version = '0.1.0'
 edition = '2018'
 
 [dependencies]
-conjure-error = '3.0.0'
-conjure-http = '3.0.0'
-conjure-object = '3.0.0'
+conjure-error = '3.1.0'
+conjure-http = '3.1.0'
+conjure-object = '3.1.0'


### PR DESCRIPTION
## Before this PR
Conjure-generated handlers had no access to lower level information about the request, and in particular access to the request and response extensions for things like audit logging.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added support for the `server-request-context` endpoint tag to provide lower level request information to the generated server handler.
==COMMIT_MSG==

Closes #216
