### PR TITLE
Add accessors to smile serializers and deserializers

### DIFF
--- a/changelog/@unreleased/pr-220.v2.yml
+++ b/changelog/@unreleased/pr-220.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Added accessors returning the IO type to Smile serializers and deserializers.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/220

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 syn = "1"
 
-conjure-object = { version = "3.1.0", path = "../conjure-object" }
-conjure-serde = { version = "3.1.0", path = "../conjure-serde" }
-conjure-error = { version = "3.1.0", optional = true, path = "../conjure-error" }
-conjure-http = { version = "3.1.0", optional = true, path = "../conjure-http" }
+conjure-object = { version = "3.2.0", path = "../conjure-object" }
+conjure-serde = { version = "3.2.0", path = "../conjure-serde" }
+conjure-error = { version = "3.2.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "3.2.0", optional = true, path = "../conjure-http" }

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.12"
 serde = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
-conjure-object = { version = "3.1.0", path = "../conjure-object" }
+conjure-object = { version = "3.2.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,6 +20,6 @@ percent-encoding = "2.1"
 pin-utils = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "3.1.0", path = "../conjure-error" }
-conjure-object = { version = "3.1.0", path = "../conjure-object" }
-conjure-serde = { version = "3.1.0", path = "../conjure-serde" }
+conjure-error = { version = "3.2.0", path = "../conjure-error" }
+conjure-object = { version = "3.2.0", path = "../conjure-object" }
+conjure-serde = { version = "3.2.0", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 
-conjure-codegen = { version = "3.1.0", path = "../conjure-codegen" }
+conjure-codegen = { version = "3.2.0", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 base64 = "0.13"
 serde = "1.0"
 serde_json = "1.0"
-serde-smile = "0.1"
+serde-smile = "0.1.2"
 
 [dev-dependencies]
 conjure-object = "1.1.0"

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-serde/src/smile/de/client.rs
+++ b/conjure-serde/src/smile/de/client.rs
@@ -83,6 +83,21 @@ impl<'de, R> ClientDeserializer<'de, R>
 where
     R: Read<'de>,
 {
+    /// Returns a shared reference to the inner reader.
+    pub fn get_ref(&self) -> &R {
+        self.0.get_ref()
+    }
+
+    /// Returns a mutable reference to the inner writer.
+    pub fn get_mut(&mut self) -> &mut R {
+        self.0.get_mut()
+    }
+
+    /// Consumes the `ClientDeserializer`, returning the inner reader.
+    pub fn into_inner(self) -> R {
+        self.0.into_inner()
+    }
+
     /// Validates that the input stream is at the end or the Smile end of stream token.
     pub fn end(&mut self) -> Result<(), Error> {
         self.0.end()

--- a/conjure-serde/src/smile/de/server.rs
+++ b/conjure-serde/src/smile/de/server.rs
@@ -83,6 +83,21 @@ impl<'de, R> ServerDeserializer<'de, R>
 where
     R: Read<'de>,
 {
+    /// Returns a shared reference to the inner reader.
+    pub fn get_ref(&self) -> &R {
+        self.0.get_ref()
+    }
+
+    /// Returns a mutable reference to the inner writer.
+    pub fn get_mut(&mut self) -> &mut R {
+        self.0.get_mut()
+    }
+
+    /// Consumes the `ServerDeserializer`, returning the inner reader.
+    pub fn into_inner(self) -> R {
+        self.0.into_inner()
+    }
+
     /// Validates that the input stream is at the end or the Smile end of stream token.
     pub fn end(&mut self) -> Result<(), Error> {
         self.0.end()

--- a/conjure-serde/src/smile/ser.rs
+++ b/conjure-serde/src/smile/ser.rs
@@ -53,6 +53,21 @@ where
             .build(writer)
             .map(Serializer)
     }
+
+    /// Returns a shared reference to the inner writer.
+    pub fn get_ref(&self) -> &W {
+        self.0.get_ref()
+    }
+
+    /// Returns a mutable reference to the inner writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        self.0.get_mut()
+    }
+
+    /// Consumes the `Serializer`, returning the inner writer.
+    pub fn into_inner(self) -> W {
+        self.0.into_inner()
+    }
 }
 
 impl<'a, W> ser::Serializer for &'a mut Serializer<W>

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "2.2.0"
+version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -4,6 +4,6 @@ version = '0.1.0'
 edition = '2018'
 
 [dependencies]
-conjure-error = '3.1.0'
-conjure-http = '3.1.0'
-conjure-object = '3.1.0'
+conjure-error = '3.2.0'
+conjure-http = '3.2.0'
+conjure-object = '3.2.0'


### PR DESCRIPTION
Smile serialization and deserialization is stateful, so when in e.g. a nonblocking context you can need to update the inner IO type while preserving the state.