### PR TITLE
Allow separate configuration of crate and endpoint versions

### DIFF
--- a/changelog/@unreleased/pr-224.v2.yml
+++ b/changelog/@unreleased/pr-224.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: The value used for the version of the generated crate can now be set
+    separately from the version used in client endpoint metadata.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/224

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 syn = "1"
 
-conjure-object = { version = "3.2.0", path = "../conjure-object" }
-conjure-serde = { version = "3.2.0", path = "../conjure-serde" }
-conjure-error = { version = "3.2.0", optional = true, path = "../conjure-error" }
-conjure-http = { version = "3.2.0", optional = true, path = "../conjure-http" }
+conjure-object = { version = "3.3.0", path = "../conjure-object" }
+conjure-serde = { version = "3.3.0", path = "../conjure-serde" }
+conjure-error = { version = "3.3.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "3.3.0", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -327,6 +327,7 @@ pub struct Config {
     exhaustive: bool,
     staged_builders: bool,
     strip_prefix: Option<String>,
+    version: Option<String>,
     build_crate: Option<CrateInfo>,
 }
 
@@ -343,6 +344,7 @@ impl Config {
             exhaustive: false,
             staged_builders: false,
             strip_prefix: None,
+            version: None,
             build_crate: None,
         }
     }
@@ -391,6 +393,17 @@ impl Config {
         T: Into<Option<String>>,
     {
         self.strip_prefix = strip_prefix.into();
+        self
+    }
+
+    /// Sets the version included in endpoint metadata for generated client bindings.
+    ///
+    /// Defaults to the version passed to [`Self::build_crate`], or `None` otherwise.
+    pub fn version<T>(&mut self, version: T) -> &mut Config
+    where
+        T: Into<Option<String>>,
+    {
+        self.version = version.into();
         self
     }
 
@@ -454,7 +467,9 @@ impl Config {
             self.exhaustive,
             self.staged_builders,
             self.strip_prefix.as_deref(),
-            self.build_crate.as_ref().map(|v| &*v.version),
+            self.version
+                .as_deref()
+                .or_else(|| self.build_crate.as_ref().map(|v| &*v.version)),
         );
 
         let mut root = ModuleTrie::new();

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,4 +14,4 @@ parking_lot = "0.12"
 serde = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
-conjure-object = { version = "3.2.0", path = "../conjure-object" }
+conjure-object = { version = "3.3.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,6 +20,6 @@ percent-encoding = "2.1"
 pin-utils = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "3.2.0", path = "../conjure-error" }
-conjure-object = { version = "3.2.0", path = "../conjure-object" }
-conjure-serde = { version = "3.2.0", path = "../conjure-serde" }
+conjure-error = { version = "3.3.0", path = "../conjure-error" }
+conjure-object = { version = "3.3.0", path = "../conjure-object" }
+conjure-serde = { version = "3.3.0", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conjure-rust"
 version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 
-conjure-codegen = { version = "3.2.0", path = "../conjure-codegen" }
+conjure-codegen = { version = "3.3.0", path = "../conjure-codegen" }

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -35,20 +35,27 @@ struct Args {
     #[clap(long = "stripPrefix", value_name = "prefix")]
     /// Strip a prefix from types's package paths
     strip_prefix: Option<String>,
-    /// The name of the generated crate
+    /// The name of the product
     #[clap(
         long = "productName",
         value_name = "name",
         requires = "product_version"
     )]
     product_name: Option<String>,
-    /// The version of the generated crate
+    /// The version of the product
     #[clap(
         long = "productVersion",
         value_name = "version",
         requires = "product_name"
     )]
     product_version: Option<String>,
+    /// The version of the generated crate. Defaults to `--productVersion`
+    #[clap(
+        long = "crateVersion",
+        value_name = "version",
+        requires = "product_version"
+    )]
+    crate_version: Option<String>,
     #[clap(name = "inputJson")]
     /// Path to a JSON-formatted Conjure IR file
     input_json: PathBuf,
@@ -67,8 +74,15 @@ fn main() {
     if let Some(prefix) = args.strip_prefix {
         config.strip_prefix(prefix);
     }
-    if let (Some(product_name), Some(product_version)) = (args.product_name, args.product_version) {
-        config.build_crate(&product_name, &product_version);
+    let crate_version = args
+        .crate_version
+        .as_deref()
+        .or_else(|| args.product_version.as_deref());
+    if let (Some(product_name), Some(crate_version)) = (args.product_name, crate_version) {
+        config.build_crate(&product_name, crate_version);
+    }
+    if let Some(product_version) = args.product_version {
+        config.version(product_version);
     }
     let r = config.generate_files(&args.input_json, &args.output_directory);
 

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -77,7 +77,7 @@ fn main() {
     let crate_version = args
         .crate_version
         .as_deref()
-        .or_else(|| args.product_version.as_deref());
+        .or(args.product_version.as_deref());
     if let (Some(product_name), Some(crate_version)) = (args.product_name, crate_version) {
         config.build_crate(&product_name, crate_version);
     }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conjure-serde"
 version = "3.2.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Serde Serializer and Deserializer wrappers for Conjure"
 repository = "https://github.com/palantir/conjure-rust"

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -4,6 +4,6 @@ version = '0.1.0'
 edition = '2018'
 
 [dependencies]
-conjure-error = '3.2.0'
-conjure-http = '3.2.0'
-conjure-object = '3.2.0'
+conjure-error = '3.3.0'
+conjure-http = '3.3.0'
+conjure-object = '3.3.0'


### PR DESCRIPTION
## Before this PR
The value used for the version of the generated crate and the service version in client endpoint metadata were always the same.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The value used for the version of the generated crate can now be set separately from the version used in client endpoint metadata.
==COMMIT_MSG==

We want the endpoint metadata to accurately reflect the version publishing the Conjure IR, but want the crate version to be static (e.g. `0.0.0`) to avoid unnecessarily modifying Cargo.lock.
