### PR TITLE
Fix codegen for no-arg endpoints with a request context

### DIFF
--- a/changelog/@unreleased/pr-227.v2.yml
+++ b/changelog/@unreleased/pr-227.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixed code generation for endpoints with no arguments and a request
+    context.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/227

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 syn = "1"
 
-conjure-object = { version = "3.3.0", path = "../conjure-object" }
-conjure-serde = { version = "3.3.0", path = "../conjure-serde" }
-conjure-error = { version = "3.3.0", optional = true, path = "../conjure-error" }
-conjure-http = { version = "3.3.0", optional = true, path = "../conjure-http" }
+conjure-object = { version = "3.4.0", path = "../conjure-object" }
+conjure-serde = { version = "3.4.0", path = "../conjure-serde" }
+conjure-error = { version = "3.4.0", optional = true, path = "../conjure-error" }
+conjure-http = { version = "3.4.0", optional = true, path = "../conjure-http" }

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -735,7 +735,7 @@ fn handle(
     }));
 
     if has_request_context(endpoint) {
-        args.push(request_context.clone());
+        args.push(quote!(#request_context));
     }
 
     let await_ = match style {

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,4 +12,4 @@ readme = "../README.md"
 serde = "1.0"
 uuid = { version = "1.1", features = ["v4"] }
 
-conjure-object = { version = "3.3.0", path = "../conjure-object" }
+conjure-object = { version = "3.4.0", path = "../conjure-object" }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,6 +20,6 @@ percent-encoding = "2.1"
 pin-utils = "0.1"
 serde = "1.0"
 
-conjure-error = { version = "3.3.0", path = "../conjure-error" }
-conjure-object = { version = "3.3.0", path = "../conjure-object" }
-conjure-serde = { version = "3.3.0", path = "../conjure-serde" }
+conjure-error = { version = "3.4.0", path = "../conjure-error" }
+conjure-object = { version = "3.4.0", path = "../conjure-object" }
+conjure-serde = { version = "3.4.0", path = "../conjure-serde" }

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 
-conjure-codegen = { version = "3.3.0", path = "../conjure-codegen" }
+conjure-codegen = { version = "3.4.0", path = "../conjure-codegen" }

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -160,6 +160,8 @@ test_service_handler! {
     fn deprecated(&self) -> Result<(), Error>;
 
     fn context(&self, arg: Option<String>, request_context: RequestContext<'_>) -> Result<(), Error>;
+
+    fn context_no_args(&self, request_context: RequestContext<'_>) -> Result<(), Error>;
 }
 
 impl TestServiceHandler {

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -1774,6 +1774,13 @@
       } ],
       "markers" : [ ],
       "tags" : [ "server-request-context" ]
+    }, {
+      "endpointName" : "contextNoArgs",
+      "httpMethod" : "GET",
+      "httpPath" : "/test/contextNoArgs",
+      "args" : [ ],
+      "markers" : [ ],
+      "tags" : [ "server-request-context" ]
     } ]
   }, {
     "serviceName" : {

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -319,3 +319,7 @@ services:
           arg:
             type: optional<string>
             param-type: query
+      contextNoArgs:
+        http: GET /contextNoArgs
+        tags:
+          - server-request-context

--- a/example-api/Cargo.toml
+++ b/example-api/Cargo.toml
@@ -4,6 +4,6 @@ version = '0.1.0'
 edition = '2018'
 
 [dependencies]
-conjure-error = '3.3.0'
-conjure-http = '3.3.0'
-conjure-object = '3.3.0'
+conjure-error = '3.4.0'
+conjure-http = '3.4.0'
+conjure-object = '3.4.0'


### PR DESCRIPTION
## Before this PR
We would render syntactically invalid Rust for endpoints that had no arguments except for a request context. Rendering would bail out with an `expected expression` error.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed code generation for endpoints with no arguments and a request context.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

