### PR TITLE
Disable chrono's time 0.1 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace.package]
+version = "3.6.0"
+
 [workspace]
 members = [
     "conjure-codegen",

--- a/changelog/@unreleased/pr-255.v2.yml
+++ b/changelog/@unreleased/pr-255.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Disable chrono's time 0.1 dependency
+  links:
+  - https://github.com/palantir/conjure-rust/pull/255

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-codegen"
-version = "3.6.0"
+version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-error/Cargo.toml
+++ b/conjure-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-error"
-version = "3.6.0"
+version.workspace = true
 authors = ["Steven Fackler <sfackler@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-http"
-version = "3.6.0"
+version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-macros/Cargo.toml
+++ b/conjure-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-macros"
-version = "3.6.0"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Macros exposed by conjure-http. Do not consume directly."

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 
 [dependencies]
 base64 = "0.21"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"] }
 educe = { version = "0.4", default-features = false, features = [
     "Hash",
     "PartialEq",

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-object"
-version = "3.6.0"
+version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-rust"
-version = "3.6.0"
+version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-serde"
-version = "3.6.0"
+version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conjure-test"
-version = "3.6.0"
+version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 


### PR DESCRIPTION
It looks like chrono is getting ready for an 0.5 release that removes the dependency entirely, but for now we can disable the old_time default feature to avoid pulling in a CVE.