### PR TITLE
Add a runtime for server logic

### DIFF
--- a/changelog/@unreleased/pr-258.v2.yml
+++ b/changelog/@unreleased/pr-258.v2.yml
@@ -1,0 +1,6 @@
+type: break
+break:
+  description: Added a new argument to Conjure endpoints to enable future runtime
+    behavior customization.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/258

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1456,6 +1456,7 @@ where
 {
     fn endpoints(
         &self,
+        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
     ) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),
@@ -1490,6 +1491,7 @@ where
 {
     fn endpoints(
         &self,
+        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
     ) -> Vec<Box<dyn conjure_http::server::AsyncEndpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -288,7 +288,10 @@ fn generate_service_impl(ctx: &Context, def: &ServiceDefinition, style: Style) -
             T: #trait_name #params + 'static + #sync + #send,
             I: #input_trait<Item = #result<conjure_http::private::Bytes, conjure_http::private::Error>> #i_traits,
         {
-            fn endpoints(&self) -> #vec<#box_<dyn conjure_http::server::#endpoint_name<I, O> + Sync + Send>>
+            fn endpoints(
+                &self,
+                _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
+            ) -> #vec<#box_<dyn conjure_http::server::#endpoint_name<I, O> + Sync + Send>>
             {
                 vec![
                     #(#endpoint_instances,)*

--- a/conjure-http/src/private/server.rs
+++ b/conjure-http/src/private/server.rs
@@ -1,6 +1,8 @@
 use crate::private::{async_read_body, read_body, APPLICATION_JSON, APPLICATION_OCTET_STREAM};
 use crate::server::{
-    AsyncResponseBody, AsyncWriteBody, DecodeHeader, DecodeParam, ResponseBody, WriteBody,
+    AsyncDeserializeRequest, AsyncResponseBody, AsyncSerializeResponse, AsyncWriteBody,
+    ConjureRuntime, DecodeHeader, DecodeParam, DeserializeRequest, ResponseBody, SerializeResponse,
+    WriteBody,
 };
 use crate::PathParams;
 use bytes::Bytes;
@@ -9,7 +11,7 @@ use conjure_object::{BearerToken, FromPlain};
 use conjure_serde::json;
 use futures_core::Stream;
 use http::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, COOKIE};
-use http::request;
+use http::{request, HeaderMap};
 use http::{Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -37,9 +39,13 @@ where
     from_plain(&value, param)
 }
 
-pub fn path_param<T, D>(parts: &request::Parts, param: &str) -> Result<T, Error>
+pub fn path_param<'a, T, D>(
+    runtime: &'a ConjureRuntime,
+    parts: &request::Parts,
+    param: &str,
+) -> Result<T, Error>
 where
-    D: DecodeParam<T>,
+    D: DecodeParam<'a, T>,
 {
     let path_params = parts
         .extensions
@@ -50,7 +56,9 @@ where
         .split('/')
         .map(percent_encoding::percent_decode_str)
         .map(|v| v.decode_utf8_lossy());
-    D::decode(params).map_err(|e| e.with_safe_param("param", param))
+    D::new(runtime)
+        .decode(params)
+        .map_err(|e| e.with_safe_param("param", param))
 }
 
 fn from_plain<T>(s: &str, param: &str) -> Result<T, Error>
@@ -76,16 +84,19 @@ pub fn parse_query_params(parts: &request::Parts) -> HashMap<Cow<'_, str>, Vec<C
     map
 }
 
-pub fn query_param<T, D>(
+pub fn query_param<'a, T, D>(
+    runtime: &'a ConjureRuntime,
     query_params: &HashMap<Cow<'_, str>, Vec<Cow<'_, str>>>,
     key: &str,
     param: &str,
 ) -> Result<T, Error>
 where
-    D: DecodeParam<T>,
+    D: DecodeParam<'a, T>,
 {
     let values = query_params.get(key).into_iter().flatten();
-    D::decode(values).map_err(|e| e.with_safe_param("param", param))
+    D::new(runtime)
+        .decode(values)
+        .map_err(|e| e.with_safe_param("param", param))
 }
 
 pub fn parse_query_param<T>(
@@ -186,11 +197,18 @@ where
     Ok(())
 }
 
-pub fn header_param<T, D>(parts: &request::Parts, header: &str, param: &str) -> Result<T, Error>
+pub fn header_param<'a, T, D>(
+    runtime: &'a ConjureRuntime,
+    parts: &request::Parts,
+    header: &str,
+    param: &str,
+) -> Result<T, Error>
 where
-    D: DecodeHeader<T>,
+    D: DecodeHeader<'a, T>,
 {
-    D::decode(parts.headers.get_all(header)).map_err(|e| e.with_safe_param("param", param))
+    D::new(runtime)
+        .decode(parts.headers.get_all(header))
+        .map_err(|e| e.with_safe_param("param", param))
 }
 
 pub fn parse_required_header<T>(
@@ -277,6 +295,28 @@ fn parse_auth_inner(
         .map_err(|e| Error::service_safe(e, PermissionDenied::new()))
 }
 
+pub fn body_arg<'a, D, T, I>(
+    runtime: &'a ConjureRuntime,
+    headers: &HeaderMap,
+    body: I,
+) -> Result<T, Error>
+where
+    D: DeserializeRequest<'a, T, I>,
+{
+    D::new(runtime).deserialize(headers, body)
+}
+
+pub async fn async_body_arg<'a, D, T, I>(
+    runtime: &'a ConjureRuntime,
+    headers: &HeaderMap,
+    body: I,
+) -> Result<T, Error>
+where
+    D: AsyncDeserializeRequest<'a, T, I>,
+{
+    D::new(runtime).deserialize(headers, body).await
+}
+
 pub fn decode_empty_request<I>(_parts: &request::Parts, _body: I) -> Result<(), Error> {
     // nothing to do, just consume the body
     Ok(())
@@ -357,6 +397,28 @@ pub fn decode_binary_request<I>(parts: &request::Parts, body: I) -> Result<I, Er
     }
 
     Ok(body)
+}
+
+pub fn response<'a, S, T, W>(
+    runtime: &'a ConjureRuntime,
+    request_headers: &HeaderMap,
+    value: T,
+) -> Result<Response<ResponseBody<W>>, Error>
+where
+    S: SerializeResponse<'a, T, W>,
+{
+    S::new(runtime).serialize(request_headers, value)
+}
+
+pub fn async_response<'a, S, T, W>(
+    runtime: &'a ConjureRuntime,
+    request_headers: &HeaderMap,
+    value: T,
+) -> Result<Response<AsyncResponseBody<W>>, Error>
+where
+    S: AsyncSerializeResponse<'a, T, W>,
+{
+    S::new(runtime).serialize(request_headers, value)
 }
 
 pub fn encode_empty_response<O>() -> Response<ResponseBody<O>> {

--- a/conjure-http/src/server.rs
+++ b/conjure-http/src/server.rs
@@ -35,6 +35,7 @@ use std::ops::Deref;
 use std::pin::Pin;
 use std::str;
 use std::str::FromStr;
+use std::sync::Arc;
 
 /// Metadata about an HTTP endpoint.
 pub trait EndpointMetadata {
@@ -207,13 +208,35 @@ pub enum AsyncResponseBody<O> {
 /// A blocking Conjure service.
 pub trait Service<I, O> {
     /// Returns the endpoints in the service.
-    fn endpoints(&self) -> Vec<Box<dyn Endpoint<I, O> + Sync + Send>>;
+    fn endpoints(
+        &self,
+        runtime: &Arc<ConjureRuntime>,
+    ) -> Vec<Box<dyn Endpoint<I, O> + Sync + Send>>;
 }
 
 /// An async Conjure service.
 pub trait AsyncService<I, O> {
     /// Returns the endpoints in the service.
-    fn endpoints(&self) -> Vec<Box<dyn AsyncEndpoint<I, O> + Sync + Send>>;
+    fn endpoints(
+        &self,
+        runtime: &Arc<ConjureRuntime>,
+    ) -> Vec<Box<dyn AsyncEndpoint<I, O> + Sync + Send>>;
+}
+
+/// A type providing server logic that is configured at runtime.
+pub struct ConjureRuntime(());
+
+impl ConjureRuntime {
+    /// Creates a new runtime with default settings.
+    pub fn new() -> Self {
+        ConjureRuntime(())
+    }
+}
+
+impl Default for ConjureRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// A trait implemented by streaming bodies.
@@ -347,26 +370,34 @@ impl<T> Deref for MaybeBorrowed<'_, T> {
 
 /// A trait implemented by request body deserializers used by custom Conjure server trait
 /// implementations.
-pub trait DeserializeRequest<T, R> {
+pub trait DeserializeRequest<'a, T, R> {
+    /// Creates a new deserializer.
+    fn new(runtime: &'a ConjureRuntime) -> Self;
+
     /// Deserializes the request body.
-    fn deserialize(headers: &HeaderMap, body: R) -> Result<T, Error>;
+    fn deserialize(&self, headers: &HeaderMap, body: R) -> Result<T, Error>;
 }
 
 /// A trait implemented by response deserializers used by custom async Conjure server trait
 /// implementations.
 #[async_trait]
-pub trait AsyncDeserializeRequest<T, R> {
+pub trait AsyncDeserializeRequest<'a, T, R> {
+    /// Creates a new deserializer.
+    fn new(runtime: &'a ConjureRuntime) -> Self;
+
     /// Deserializes the request body.
-    async fn deserialize(headers: &HeaderMap, body: R) -> Result<T, Error>
+    async fn deserialize(&self, headers: &HeaderMap, body: R) -> Result<T, Error>
     where
         R: 'async_trait;
 }
 
 /// A request deserializer which acts as a Conjure-generated endpoint would.
-pub enum ConjureRequestDeserializer {}
+pub struct ConjureRequestDeserializer<'a> {
+    _runtime: &'a ConjureRuntime,
+}
 
-impl ConjureRequestDeserializer {
-    fn check_content_type(headers: &HeaderMap) -> Result<(), Error> {
+impl ConjureRequestDeserializer<'_> {
+    fn check_content_type(&self, headers: &HeaderMap) -> Result<(), Error> {
         if headers.get(CONTENT_TYPE) != Some(&APPLICATION_JSON) {
             return Err(Error::service_safe(
                 "invalid request Content-Type",
@@ -378,79 +409,113 @@ impl ConjureRequestDeserializer {
     }
 }
 
-impl<T, R> DeserializeRequest<T, R> for ConjureRequestDeserializer
+impl<'a, T, R> DeserializeRequest<'a, T, R> for ConjureRequestDeserializer<'a>
 where
     T: DeserializeOwned,
     R: Iterator<Item = Result<Bytes, Error>>,
 {
-    fn deserialize(headers: &HeaderMap, body: R) -> Result<T, Error> {
-        Self::check_content_type(headers)?;
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        ConjureRequestDeserializer { _runtime: runtime }
+    }
+
+    fn deserialize(&self, headers: &HeaderMap, body: R) -> Result<T, Error> {
+        self.check_content_type(headers)?;
         let buf = private::read_body(body, Some(SERIALIZABLE_REQUEST_SIZE_LIMIT))?;
         json::server_from_slice(&buf).map_err(|e| Error::service(e, InvalidArgument::new()))
     }
 }
 
 #[async_trait]
-impl<T, R> AsyncDeserializeRequest<T, R> for ConjureRequestDeserializer
+impl<'a, T, R> AsyncDeserializeRequest<'a, T, R> for ConjureRequestDeserializer<'a>
 where
     T: DeserializeOwned,
     R: Stream<Item = Result<Bytes, Error>> + Send,
 {
-    async fn deserialize(headers: &HeaderMap, body: R) -> Result<T, Error>
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        ConjureRequestDeserializer { _runtime: runtime }
+    }
+
+    async fn deserialize(&self, headers: &HeaderMap, body: R) -> Result<T, Error>
     where
         R: 'async_trait,
     {
-        Self::check_content_type(headers)?;
+        self.check_content_type(headers)?;
         let buf = private::async_read_body(body, Some(SERIALIZABLE_REQUEST_SIZE_LIMIT)).await?;
         json::server_from_slice(&buf).map_err(|e| Error::service(e, InvalidArgument::new()))
     }
 }
 
 /// A trait implemented by response serializers used by custom Conjure server trait implementations.
-pub trait SerializeResponse<T, W> {
+pub trait SerializeResponse<'a, T, W> {
+    /// Creates a new serializer.
+    fn new(runtime: &'a ConjureRuntime) -> Self;
+
     /// Serializes the response.
-    fn serialize(request_headers: &HeaderMap, value: T)
-        -> Result<Response<ResponseBody<W>>, Error>;
+    fn serialize(
+        &self,
+        request_headers: &HeaderMap,
+        value: T,
+    ) -> Result<Response<ResponseBody<W>>, Error>;
 }
 
 /// A trait implemented by response serializers used by custom async Conjure server trait
 /// implementations.
-pub trait AsyncSerializeResponse<T, W> {
+pub trait AsyncSerializeResponse<'a, T, W> {
+    /// Creates a new serializer.
+    fn new(runtime: &'a ConjureRuntime) -> Self;
+
     /// Serializes the response.
     fn serialize(
+        &self,
         request_headers: &HeaderMap,
         value: T,
     ) -> Result<Response<AsyncResponseBody<W>>, Error>;
 }
 
 /// A serializer which encodes `()` as an empty body and status code of `204 No Content`.
-pub enum EmptyResponseSerializer {}
+pub struct EmptyResponseSerializer<'a> {
+    _runtime: &'a ConjureRuntime,
+}
 
-impl EmptyResponseSerializer {
-    fn serialize_inner<T>(body: T) -> Result<Response<T>, Error> {
+impl EmptyResponseSerializer<'_> {
+    fn serialize_inner<T>(&self, body: T) -> Result<Response<T>, Error> {
         let mut response = Response::new(body);
         *response.status_mut() = StatusCode::NO_CONTENT;
         Ok(response)
     }
 }
 
-impl<W> SerializeResponse<(), W> for EmptyResponseSerializer {
-    fn serialize(_: &HeaderMap, _: ()) -> Result<Response<ResponseBody<W>>, Error> {
-        Self::serialize_inner(ResponseBody::Empty)
+impl<'a, W> SerializeResponse<'a, (), W> for EmptyResponseSerializer<'a> {
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        EmptyResponseSerializer { _runtime: runtime }
+    }
+
+    fn serialize(&self, _: &HeaderMap, _: ()) -> Result<Response<ResponseBody<W>>, Error> {
+        self.serialize_inner(ResponseBody::Empty)
     }
 }
 
-impl<W> AsyncSerializeResponse<(), W> for EmptyResponseSerializer {
-    fn serialize(_: &HeaderMap, _: ()) -> Result<Response<AsyncResponseBody<W>>, Error> {
-        Self::serialize_inner(AsyncResponseBody::Empty)
+impl<'a, W> AsyncSerializeResponse<'a, (), W> for EmptyResponseSerializer<'a> {
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        EmptyResponseSerializer { _runtime: runtime }
+    }
+
+    fn serialize(&self, _: &HeaderMap, _: ()) -> Result<Response<AsyncResponseBody<W>>, Error> {
+        self.serialize_inner(AsyncResponseBody::Empty)
     }
 }
 
 /// A serializer which acts like a Conjure-generated client would.
-pub enum ConjureResponseSerializer {}
+pub struct ConjureResponseSerializer<'a> {
+    _runtime: &'a ConjureRuntime,
+}
 
-impl ConjureResponseSerializer {
+impl ConjureResponseSerializer<'_> {
     fn serialize_inner<T, B>(
+        &self,
         value: T,
         make_body: impl FnOnce(Bytes) -> B,
     ) -> Result<Response<B>, Error>
@@ -468,61 +533,86 @@ impl ConjureResponseSerializer {
     }
 }
 
-impl<T, W> SerializeResponse<T, W> for ConjureResponseSerializer
+impl<'a, T, W> SerializeResponse<'a, T, W> for ConjureResponseSerializer<'a>
 where
     T: Serialize,
 {
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        ConjureResponseSerializer { _runtime: runtime }
+    }
+
     fn serialize(
+        &self,
         _request_headers: &HeaderMap,
         value: T,
     ) -> Result<Response<ResponseBody<W>>, Error> {
-        Self::serialize_inner(value, ResponseBody::Fixed)
+        self.serialize_inner(value, ResponseBody::Fixed)
     }
 }
 
-impl<T, W> AsyncSerializeResponse<T, W> for ConjureResponseSerializer
+impl<'a, T, W> AsyncSerializeResponse<'a, T, W> for ConjureResponseSerializer<'a>
 where
     T: Serialize,
 {
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        ConjureResponseSerializer { _runtime: runtime }
+    }
+
     fn serialize(
+        &self,
         _request_headers: &HeaderMap,
         value: T,
     ) -> Result<Response<AsyncResponseBody<W>>, Error> {
-        Self::serialize_inner(value, AsyncResponseBody::Fixed)
+        self.serialize_inner(value, AsyncResponseBody::Fixed)
     }
 }
 
 /// A trait implemented by header decoders used by custom Conjure server trait implementations.
-pub trait DecodeHeader<T> {
+pub trait DecodeHeader<'a, T> {
+    /// Creates a new decoder.
+    fn new(runtime: &'a ConjureRuntime) -> Self;
+
     /// Decodes the value from headers.
-    fn decode<'a, I>(headers: I) -> Result<T, Error>
+    fn decode<'b, I>(&self, headers: I) -> Result<T, Error>
     where
-        I: IntoIterator<Item = &'a HeaderValue>;
+        I: IntoIterator<Item = &'b HeaderValue>;
 }
 
 /// A trait implemented by URL parameter decoders used by custom Conjure server trait
 /// implementations.
-pub trait DecodeParam<T> {
+pub trait DecodeParam<'a, T> {
+    /// Creates a new decoder.
+    fn new(runtime: &'a ConjureRuntime) -> Self;
+
     /// Decodes the value from the sequence of values.
     ///
     /// The values have already been percent-decoded.
-    fn decode<I>(params: I) -> Result<T, Error>
+    fn decode<I>(&self, params: I) -> Result<T, Error>
     where
         I: IntoIterator,
         I::Item: AsRef<str>;
 }
 
 /// A decoder which converts a single value using its [`FromStr`] implementation.
-pub enum FromStrDecoder {}
+pub struct FromStrDecoder<'a> {
+    _runtime: &'a ConjureRuntime,
+}
 
-impl<T> DecodeHeader<T> for FromStrDecoder
+impl<'a, T> DecodeHeader<'a, T> for FromStrDecoder<'a>
 where
     T: FromStr,
     T::Err: Into<Box<dyn error::Error + Sync + Send>>,
 {
-    fn decode<'a, I>(headers: I) -> Result<T, Error>
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        FromStrDecoder { _runtime: runtime }
+    }
+
+    fn decode<'b, I>(&self, headers: I) -> Result<T, Error>
     where
-        I: IntoIterator<Item = &'a HeaderValue>,
+        I: IntoIterator<Item = &'b HeaderValue>,
     {
         only_item(headers)?
             .to_str()
@@ -532,12 +622,17 @@ where
     }
 }
 
-impl<T> DecodeParam<T> for FromStrDecoder
+impl<'a, T> DecodeParam<'a, T> for FromStrDecoder<'a>
 where
     T: FromStr,
     T::Err: Into<Box<dyn error::Error + Sync + Send>>,
 {
-    fn decode<'a, I>(params: I) -> Result<T, Error>
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        FromStrDecoder { _runtime: runtime }
+    }
+
+    fn decode<I>(&self, params: I) -> Result<T, Error>
     where
         I: IntoIterator,
         I::Item: AsRef<str>,
@@ -550,16 +645,23 @@ where
 }
 
 /// A decoder which converts an optional value using its [`FromStr`] implementation.
-pub enum FromStrOptionDecoder {}
+pub struct FromStrOptionDecoder<'a> {
+    _runtime: &'a ConjureRuntime,
+}
 
-impl<T> DecodeHeader<Option<T>> for FromStrOptionDecoder
+impl<'a, T> DecodeHeader<'a, Option<T>> for FromStrOptionDecoder<'a>
 where
     T: FromStr,
     T::Err: Into<Box<dyn error::Error + Sync + Send>>,
 {
-    fn decode<'a, I>(headers: I) -> Result<Option<T>, Error>
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        FromStrOptionDecoder { _runtime: runtime }
+    }
+
+    fn decode<'b, I>(&self, headers: I) -> Result<Option<T>, Error>
     where
-        I: IntoIterator<Item = &'a HeaderValue>,
+        I: IntoIterator<Item = &'b HeaderValue>,
     {
         let Some(header) = optional_item(headers)? else { return Ok(None) };
         let value = header
@@ -571,12 +673,17 @@ where
     }
 }
 
-impl<T> DecodeParam<Option<T>> for FromStrOptionDecoder
+impl<'a, T> DecodeParam<'a, Option<T>> for FromStrOptionDecoder<'a>
 where
     T: FromStr,
     T::Err: Into<Box<dyn error::Error + Sync + Send>>,
 {
-    fn decode<I>(params: I) -> Result<Option<T>, Error>
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        FromStrOptionDecoder { _runtime: runtime }
+    }
+
+    fn decode<I>(&self, params: I) -> Result<Option<T>, Error>
     where
         I: IntoIterator,
         I::Item: AsRef<str>,
@@ -610,17 +717,26 @@ where
 
 /// A decoder which converts a sequence of values via its [`FromStr`] implementation into a
 /// collection via a [`FromIterator`] implementation.
-pub struct FromStrSeqDecoder<U> {
+pub struct FromStrSeqDecoder<'a, U> {
+    _runtime: &'a ConjureRuntime,
     _p: PhantomData<U>,
 }
 
-impl<T, U> DecodeParam<T> for FromStrSeqDecoder<U>
+impl<'a, T, U> DecodeParam<'a, T> for FromStrSeqDecoder<'a, U>
 where
     T: FromIterator<U>,
     U: FromStr,
     U::Err: Into<Box<dyn error::Error + Sync + Send>>,
 {
-    fn decode<I>(params: I) -> Result<T, Error>
+    #[inline]
+    fn new(runtime: &'a ConjureRuntime) -> Self {
+        FromStrSeqDecoder {
+            _runtime: runtime,
+            _p: PhantomData,
+        }
+    }
+
+    fn decode<I>(&self, params: I) -> Result<T, Error>
     where
         I: IntoIterator,
         I::Item: AsRef<str>,

--- a/conjure-macros/src/lib.rs
+++ b/conjure-macros/src/lib.rs
@@ -232,8 +232,8 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// use conjure_error::Error;
 /// use conjure_http::{conjure_endpoints, endpoint};
 /// use conjure_http::server::{
-///     ConjureResponseSerializer, DeserializeRequest, FromStrOptionDecoder, ResponseBody,
-///     SerializeResponse, WriteBody,
+///     ConjureResponseSerializer, ConjureRuntime, DeserializeRequest, FromStrOptionDecoder,
+///     ResponseBody, SerializeResponse, WriteBody,
 /// };
 /// use conjure_object::BearerToken;
 /// use http::Response;
@@ -292,10 +292,14 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     fn stream_response(&self) -> Result<StreamingResponse, Error>;
 /// }
 ///
-/// enum StreamingRequestDeserializer {}
+/// struct StreamingRequestDeserializer;
 ///
-/// impl<I> DeserializeRequest<I, I> for StreamingRequestDeserializer {
-///     fn deserialize(_headers: &HeaderMap, body: I) -> Result<I, Error> {
+/// impl<'a, I> DeserializeRequest<'a, I, I> for StreamingRequestDeserializer {
+///     fn new(_: &'a ConjureRuntime) -> Self {
+///         StreamingRequestDeserializer
+///     }
+///
+///     fn deserialize(&self, _headers: &HeaderMap, body: I) -> Result<I, Error> {
 ///         Ok(body)
 ///     }
 /// }
@@ -312,13 +316,18 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// enum StreamingResponseSerializer {}
+/// struct StreamingResponseSerializer;
 ///
-/// impl<O> SerializeResponse<StreamingResponse, O> for StreamingResponseSerializer
+/// impl<'a, O> SerializeResponse<'a, StreamingResponse, O> for StreamingResponseSerializer
 /// where
 ///     O: Write,
 /// {
+///     fn new(_: &'a ConjureRuntime) -> Self {
+///         StreamingResponseSerializer
+///     }
+///
 ///     fn serialize(
+///         &self,
 ///         _request_headers: &HeaderMap,
 ///         body: StreamingResponse,
 ///     ) -> Result<Response<ResponseBody<O>>, Error> {

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -18,9 +18,9 @@ use crate::types::*;
 use async_trait::async_trait;
 use conjure_error::Error;
 use conjure_http::server::{
-    AsyncResponseBody, AsyncService, AsyncWriteBody, ConjureResponseSerializer, DeserializeRequest,
-    FromStrOptionDecoder, FromStrSeqDecoder, RequestContext, ResponseBody, SerializeResponse,
-    Service, WriteBody,
+    AsyncResponseBody, AsyncService, AsyncWriteBody, ConjureResponseSerializer, ConjureRuntime,
+    DeserializeRequest, FromStrOptionDecoder, FromStrSeqDecoder, RequestContext, ResponseBody,
+    SerializeResponse, Service, WriteBody,
 };
 use conjure_http::{PathParams, SafeParams};
 use conjure_macros::{conjure_endpoints, endpoint};
@@ -33,6 +33,7 @@ use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 use std::pin::Pin;
+use std::sync::Arc;
 
 macro_rules! test_service_handler {
     ($(
@@ -246,7 +247,7 @@ where
     T: Service<RemoteBody, Vec<u8>>,
 {
     fn send_sync(&self, name: &str) {
-        let endpoint = Service::endpoints(&self.service)
+        let endpoint = Service::endpoints(&self.service, &Arc::new(ConjureRuntime::new()))
             .into_iter()
             .find(|e| e.name() == name)
             .unwrap();
@@ -282,7 +283,7 @@ where
     T: AsyncService<RemoteBody, Vec<u8>>,
 {
     async fn send_async(&self, name: &str) {
-        let endpoint = AsyncService::endpoints(&self.service)
+        let endpoint = AsyncService::endpoints(&self.service, &Arc::new(ConjureRuntime::new()))
             .into_iter()
             .find(|e| e.name() == name)
             .unwrap();
@@ -970,21 +971,29 @@ mock! {
     }
 }
 
-enum RawRequestDeserializer {}
+struct RawRequestDeserializer;
 
-impl<I> DeserializeRequest<I, I> for RawRequestDeserializer {
-    fn deserialize(_: &HeaderMap, body: I) -> Result<I, Error> {
+impl<'a, I> DeserializeRequest<'a, I, I> for RawRequestDeserializer {
+    fn new(_: &'a ConjureRuntime) -> Self {
+        Self
+    }
+
+    fn deserialize(&self, _: &HeaderMap, body: I) -> Result<I, Error> {
         Ok(body)
     }
 }
 
-enum RawResponseSerializer {}
+struct RawResponseSerializer;
 
-impl<T, O> SerializeResponse<T, O> for RawResponseSerializer
+impl<'a, T, O> SerializeResponse<'a, T, O> for RawResponseSerializer
 where
     T: WriteBody<O> + 'static + Send,
 {
-    fn serialize(_: &HeaderMap, value: T) -> Result<Response<ResponseBody<O>>, Error> {
+    fn new(_: &'a ConjureRuntime) -> Self {
+        Self
+    }
+
+    fn serialize(&self, _: &HeaderMap, value: T) -> Result<Response<ResponseBody<O>>, Error> {
         Ok(Response::new(ResponseBody::Streaming(Box::new(value))))
     }
 }

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -1456,6 +1456,7 @@ where
 {
     fn endpoints(
         &self,
+        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
     ) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),
@@ -1490,6 +1491,7 @@ where
 {
     fn endpoints(
         &self,
+        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
     ) -> Vec<Box<dyn conjure_http::server::AsyncEndpoint<I, O> + Sync + Send>> {
         vec![
             Box::new(GetFileSystemsEndpoint_(self.0.clone())),


### PR DESCRIPTION
While the `ConjureRuntime` is currently empty, it will enable us to support things like dynamic configuration of serializable encodings and custom request body limits.

cc #182 