### PR TITLE
fix: codegen succeeds for error type args that reference objects

### DIFF
--- a/changelog/@unreleased/pr-264.v2.yml
+++ b/changelog/@unreleased/pr-264.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Codegen succeeds for error type args that reference objects
+  links:
+  - https://github.com/palantir/conjure-rust/pull/264

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -19,6 +19,7 @@ use quote::quote;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
+use crate::errors::error_object_definition;
 use crate::types::{
     ArgumentDefinition, ConjureDefinition, Documentation, LogSafety, PrimitiveType, Type,
     TypeDefinition, TypeName,
@@ -87,7 +88,7 @@ impl Context {
             context.types.insert(
                 def.error_name().clone(),
                 TypeContext {
-                    def: TypeDefinition::Object(def.object_definition()),
+                    def: TypeDefinition::Object(error_object_definition(def)),
                     has_double: Cell::new(None),
                     is_copy: Cell::new(None),
                     log_safety: RefCell::new(CachedLogSafety::Uncomputed),

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -329,9 +329,13 @@ impl Context {
         let needs_box = match &ctx.def {
             TypeDefinition::Alias(def) => self.needs_box(def.alias()),
             TypeDefinition::Enum(_) => false,
-            TypeDefinition::Object(_) => match &self.types[this_type].def {
-                TypeDefinition::Union(_) => false,
-                _ => true,
+            TypeDefinition::Object(_) => match self.types.get(this_type) {
+                // this is not a type, e.g., it is an error
+                None => true,
+                Some(ctx) => match &ctx.def {
+                    TypeDefinition::Union(_) => false,
+                    _ => true,
+                },
             },
             TypeDefinition::Union(_) => true,
         };

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -20,8 +20,8 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 use crate::types::{
-    ArgumentDefinition, ConjureDefinition, Documentation, LogSafety, ObjectDefinition,
-    PrimitiveType, Type, TypeDefinition, TypeName,
+    ArgumentDefinition, ConjureDefinition, Documentation, LogSafety, PrimitiveType, Type,
+    TypeDefinition, TypeName,
 };
 
 enum CachedLogSafety {
@@ -87,7 +87,7 @@ impl Context {
             context.types.insert(
                 def.error_name().clone(),
                 TypeContext {
-                    def: TypeDefinition::Object(ObjectDefinition::from(def.clone())),
+                    def: TypeDefinition::Object(def.object_definition()),
                     has_double: Cell::new(None),
                     is_copy: Cell::new(None),
                     log_safety: RefCell::new(CachedLogSafety::Uncomputed),

--- a/conjure-codegen/src/errors.rs
+++ b/conjure-codegen/src/errors.rs
@@ -18,18 +18,16 @@ use crate::context::Context;
 use crate::objects;
 use crate::types::{ErrorDefinition, ObjectDefinition};
 
-impl ErrorDefinition {
-    pub fn object_definition(&self) -> ObjectDefinition {
-        ObjectDefinition::builder()
-            .type_name(self.error_name().clone())
-            .fields(self.safe_args().iter().chain(self.unsafe_args()).cloned())
-            .docs(self.docs().cloned())
-            .build()
-    }
+pub fn error_object_definition(def: &ErrorDefinition) -> ObjectDefinition {
+    ObjectDefinition::builder()
+        .type_name(def.error_name().clone())
+        .fields(def.safe_args().iter().chain(def.unsafe_args()).cloned())
+        .docs(def.docs().cloned())
+        .build()
 }
 
 pub fn generate(ctx: &Context, def: &ErrorDefinition) -> TokenStream {
-    let object = def.object_definition();
+    let object = error_object_definition(def);
     let object_def = objects::generate(ctx, &object);
     let error_type = generate_error_type(ctx, def);
 

--- a/conjure-codegen/src/errors.rs
+++ b/conjure-codegen/src/errors.rs
@@ -18,18 +18,18 @@ use crate::context::Context;
 use crate::objects;
 use crate::types::{ErrorDefinition, ObjectDefinition};
 
-impl From<ErrorDefinition> for ObjectDefinition {
-    fn from(error: ErrorDefinition) -> Self {
+impl ErrorDefinition {
+    pub fn object_definition(&self) -> ObjectDefinition {
         ObjectDefinition::builder()
-            .type_name(error.error_name().clone())
-            .fields(error.safe_args().iter().chain(error.unsafe_args()).cloned())
-            .docs(error.docs().cloned())
+            .type_name(self.error_name().clone())
+            .fields(self.safe_args().iter().chain(self.unsafe_args()).cloned())
+            .docs(self.docs().cloned())
             .build()
     }
 }
 
 pub fn generate(ctx: &Context, def: &ErrorDefinition) -> TokenStream {
-    let object = ObjectDefinition::from(def.clone());
+    let object = def.object_definition();
     let object_def = objects::generate(ctx, &object);
     let error_type = generate_error_type(ctx, def);
 

--- a/conjure-codegen/src/errors.rs
+++ b/conjure-codegen/src/errors.rs
@@ -18,12 +18,18 @@ use crate::context::Context;
 use crate::objects;
 use crate::types::{ErrorDefinition, ObjectDefinition};
 
+impl From<ErrorDefinition> for ObjectDefinition {
+    fn from(error: ErrorDefinition) -> Self {
+        ObjectDefinition::builder()
+            .type_name(error.error_name().clone())
+            .fields(error.safe_args().iter().chain(error.unsafe_args()).cloned())
+            .docs(error.docs().cloned())
+            .build()
+    }
+}
+
 pub fn generate(ctx: &Context, def: &ErrorDefinition) -> TokenStream {
-    let object = ObjectDefinition::builder()
-        .type_name(def.error_name().clone())
-        .fields(def.safe_args().iter().chain(def.unsafe_args()).cloned())
-        .docs(def.docs().cloned())
-        .build();
+    let object = ObjectDefinition::from(def.clone());
     let object_def = objects::generate(ctx, &object);
     let error_type = generate_error_type(ctx, def);
 

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -19,11 +19,16 @@ use crate::types::*;
 
 #[test]
 fn error_serialization() {
-    let error = SimpleError::new("hello", 15, false);
+    let error = SimpleError::builder()
+        .foo("hello")
+        .bar(15)
+        .ref_(SafeStringAlias("safe".to_string()))
+        .unsafe_foo(false)
+        .build();
 
     assert_eq!(error.code(), ErrorCode::Internal);
     assert_eq!(error.name(), "Test:SimpleError");
-    assert_eq!(error.safe_args(), &["bar", "foo"]);
+    assert_eq!(error.safe_args(), &["bar", "foo", "ref"]);
 
     let encoded = conjure_error::encode(&error);
 
@@ -33,6 +38,7 @@ fn error_serialization() {
     let mut params = BTreeMap::new();
     params.insert("foo".to_string(), "hello".to_string());
     params.insert("bar".to_string(), "15".to_string());
+    params.insert("ref".to_string(), "safe".to_string());
     params.insert("unsafeFoo".to_string(), "false".to_string());
     assert_eq!(*encoded.parameters(), params);
 }

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -28,7 +28,7 @@ fn error_serialization() {
 
     assert_eq!(error.code(), ErrorCode::Internal);
     assert_eq!(error.name(), "Test:SimpleError");
-    assert_eq!(error.safe_args(), &["bar", "foo", "ref"]);
+    assert_eq!(error.safe_args(), &["bar", "baz", "foo"]);
 
     let encoded = conjure_error::encode(&error);
 
@@ -38,7 +38,6 @@ fn error_serialization() {
     let mut params = BTreeMap::new();
     params.insert("foo".to_string(), "hello".to_string());
     params.insert("bar".to_string(), "15".to_string());
-    params.insert("ref".to_string(), "safe".to_string());
     params.insert("unsafeFoo".to_string(), "false".to_string());
     assert_eq!(*encoded.parameters(), params);
 }

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -19,6 +19,7 @@ use crate::types::*;
 
 #[test]
 fn error_serialization() {
+    #[allow(deprecated)]
     let error = SimpleError::builder()
         .foo("hello")
         .bar(15)

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -23,7 +23,7 @@ fn error_serialization() {
     let error = SimpleError::builder()
         .foo("hello")
         .bar(15)
-        .baz(TestObject::builder().foo(1).build())
+        .baz(EmptyObject::new())
         .unsafe_foo(false)
         .build();
 

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -22,7 +22,7 @@ fn error_serialization() {
     let error = SimpleError::builder()
         .foo("hello")
         .bar(15)
-        .ref_(SafeStringAlias("safe".to_string()))
+        .baz(TestObject::builder().foo(1).build())
         .unsafe_foo(false)
         .build();
 

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -19,7 +19,6 @@ use crate::types::*;
 
 #[test]
 fn error_serialization() {
-    #[allow(deprecated)]
     let error = SimpleError::builder()
         .foo("hello")
         .bar(15)

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -24,7 +24,7 @@
       "type" : {
         "type" : "reference",
         "reference" : {
-          "name": "TestObject",
+          "name": "EmptyObject",
           "package": "com.palantir.conjure"
         }
       }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -19,6 +19,15 @@
         "type" : "primitive",
         "primitive" : "INTEGER"
       }
+    }, {
+      "fieldName" : "ref",
+      "type" : {
+        "type" : "reference",
+        "reference" : {
+          "name": "SafeStringAlias",
+          "package": "com.palantir.conjure"
+        }
+      }
     } ],
     "unsafeArgs" : [ {
       "fieldName" : "unsafeFoo",

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -20,11 +20,11 @@
         "primitive" : "INTEGER"
       }
     }, {
-      "fieldName" : "ref",
+      "fieldName" : "baz",
       "type" : {
         "type" : "reference",
         "reference" : {
-          "name": "SafeStringAlias",
+          "name": "TestObject",
           "package": "com.palantir.conjure"
         }
       }

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -156,6 +156,7 @@ types:
         safe-args:
           foo: string
           bar: integer
+          ref: SafeStringAlias
         unsafe-args:
           unsafeFoo: boolean
 

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -156,7 +156,7 @@ types:
         safe-args:
           foo: string
           bar: integer
-          ref: SafeStringAlias
+          baz: TestObject
         unsafe-args:
           unsafeFoo: boolean
 

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -156,7 +156,7 @@ types:
         safe-args:
           foo: string
           bar: integer
-          baz: TestObject
+          baz: EmptyObject
         unsafe-args:
           unsafeFoo: boolean
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When an error is define with an argument that references an object type the generator panics: https://app.circleci.com/pipelines/github/palantir/conjure-rust/1028/workflows/fc887808-5e16-4d64-8576-d457a7719813/jobs/2726

This is because on [this line](https://github.com/palantir/conjure-rust/pull/264/files#diff-e9427ea30d64f2b4aec4a2eac1240e285deec1c4d147da111020674b32333e22L332) we check the type context of `this_type` but it doesn't exist because `this_type` actually references the error. I think this is in part because we are re-using the object generation codepath with a made up "error type" [here](https://github.com/palantir/conjure-rust/blob/4df11248d7813a646e9bf1a6f027a91ef1280815/conjure-codegen/src/errors.rs#L27).

I also noticed while testing that the object arguments are not included in the serialized parameters of the generated error type. This appears to be intentional so leaving as is for now.

## After this PR
We inject the error types as virtual object definitions in the context object so that everything resolves correctly.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
codegen succeeds for error type args that reference objects
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Technically you could reference an error type as in object in other fields/args but we expect this should be handled already when compiling from yml to the IR.

