### PR TITLE
[stacked] Box streaming request bodies

### DIFF
--- a/changelog/@unreleased/pr-268.v2.yml
+++ b/changelog/@unreleased/pr-268.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Streaming request bodies are now passed by value to the client.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/268

--- a/conjure-codegen/src/clients.rs
+++ b/conjure-codegen/src/clients.rs
@@ -124,7 +124,7 @@ fn generate_endpoint(
     let where_ = where_(ctx, style, body_arg);
 
     let request = quote!(request_);
-    let setup_request = setup_request(ctx, body_arg, style, &request);
+    let setup_request = setup_request(ctx, def, body_arg, style, &request);
 
     let method = endpoint
         .http_method()
@@ -236,6 +236,7 @@ fn return_type_name(ctx: &Context, def: &ServiceDefinition, ty: &ReturnType<'_>)
 
 fn setup_request(
     ctx: &Context,
+    def: &ServiceDefinition,
     body_arg: Option<&ArgumentDefinition>,
     style: Style,
     request: &TokenStream,
@@ -243,15 +244,14 @@ fn setup_request(
     match body_arg {
         Some(body_arg) => {
             let name = ctx.field_name(body_arg.arg_name());
+            let box_ = ctx.box_ident(def.service_name());
             if ctx.is_binary(body_arg.type_()) {
                 match style {
                     Style::Sync => quote! {
-                        let mut #name = #name;
-                        let mut #request = conjure_http::private::encode_binary_request(&mut #name as _);
+                        let mut #request = conjure_http::private::encode_binary_request(#box_::new(#name));
                     },
                     Style::Async => quote! {
-                        conjure_http::private::pin_mut!(#name);
-                        let mut #request = conjure_http::private::async_encode_binary_request(#name as _);
+                        let mut #request = conjure_http::private::async_encode_binary_request(#box_::pin(#name));
                     },
                 }
             } else {

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -224,9 +224,8 @@ where
     where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
-        conjure_http::private::pin_mut!(input);
         let mut request_ = conjure_http::private::async_encode_binary_request(
-            input as _,
+            Box::pin(input),
         );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -255,9 +254,8 @@ where
     where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
-        conjure_http::private::pin_mut!(input);
         let mut request_ = conjure_http::private::async_encode_binary_request(
-            input as _,
+            Box::pin(input),
         );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -820,8 +818,7 @@ where
     where
         U: conjure_http::client::WriteBody<T::BodyWriter>,
     {
-        let mut input = input;
-        let mut request_ = conjure_http::private::encode_binary_request(&mut input as _);
+        let mut request_ = conjure_http::private::encode_binary_request(Box::new(input));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw");
@@ -849,8 +846,7 @@ where
     where
         U: conjure_http::client::WriteBody<T::BodyWriter>,
     {
-        let mut input = input;
-        let mut request_ = conjure_http::private::encode_binary_request(&mut input as _);
+        let mut request_ = conjure_http::private::encode_binary_request(Box::new(input));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw-aliased");

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -109,7 +109,7 @@ pub enum RequestBody<'a, W> {
     /// A body already buffered in memory.
     Fixed(Bytes),
     /// A streaming body.
-    Streaming(&'a mut dyn WriteBody<W>),
+    Streaming(Box<dyn WriteBody<W> + 'a>),
 }
 
 /// The body of an async Conjure request.
@@ -119,7 +119,7 @@ pub enum AsyncRequestBody<'a, W> {
     /// A body already buffered in memory.
     Fixed(Bytes),
     /// A streaming body.
-    Streaming(Pin<&'a mut (dyn AsyncWriteBody<W> + Send)>),
+    Streaming(Pin<Box<dyn AsyncWriteBody<W> + 'a + Send>>),
 }
 
 /// A trait implemented by HTTP client implementations.

--- a/conjure-http/src/private/client/mod.rs
+++ b/conjure-http/src/private/client/mod.rs
@@ -74,12 +74,12 @@ where
     request
 }
 
-pub fn encode_binary_request<W>(body: &mut dyn WriteBody<W>) -> Request<RequestBody<'_, W>> {
+pub fn encode_binary_request<W>(body: Box<dyn WriteBody<W> + '_>) -> Request<RequestBody<'_, W>> {
     inner_encode_binary_request(body, RequestBody::Streaming)
 }
 
 pub fn async_encode_binary_request<W>(
-    body: Pin<&mut (dyn AsyncWriteBody<W> + Send)>,
+    body: Pin<Box<dyn AsyncWriteBody<W> + '_ + Send>>,
 ) -> Request<AsyncRequestBody<'_, W>> {
     inner_encode_binary_request(body, AsyncRequestBody::Streaming)
 }

--- a/conjure-macros/src/lib.rs
+++ b/conjure-macros/src/lib.rs
@@ -172,7 +172,7 @@ mod path;
 ///     #[endpoint(method = POST, path = "/streamData")]
 ///     fn upload_stream(
 ///         &self,
-///         #[body(serializer = StreamingRequestSerializer)] body: &mut StreamingRequest,
+///         #[body(serializer = StreamingRequestSerializer)] body: StreamingRequest,
 ///     ) -> Result<(), Error>;
 ///
 ///     #[endpoint(method = GET, path = "/streamData", accept = StreamingResponseDeserializer)]
@@ -197,16 +197,16 @@ mod path;
 ///
 /// enum StreamingRequestSerializer {}
 ///
-/// impl<'a, W> SerializeRequest<'a, &'a mut StreamingRequest, W> for StreamingRequestSerializer
+/// impl<W> SerializeRequest<'static, StreamingRequest, W> for StreamingRequestSerializer
 /// where
 ///     W: Write,
 /// {
-///     fn content_type(_: &&mut StreamingRequest) -> HeaderValue {
+///     fn content_type(_: &StreamingRequest) -> HeaderValue {
 ///         HeaderValue::from_static("text/plain")
 ///     }
 ///
-///     fn serialize(value: &'a mut StreamingRequest) -> Result<RequestBody<'a, W>, Error> {
-///         Ok(RequestBody::Streaming(value))
+///     fn serialize(value: StreamingRequest) -> Result<RequestBody<'static, W>, Error> {
+///         Ok(RequestBody::Streaming(Box::new(value)))
 ///     }
 /// }
 ///

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -224,9 +224,8 @@ where
     where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
-        conjure_http::private::pin_mut!(input);
         let mut request_ = conjure_http::private::async_encode_binary_request(
-            input as _,
+            Box::pin(input),
         );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -255,9 +254,8 @@ where
     where
         U: conjure_http::client::AsyncWriteBody<T::BodyWriter> + Sync + Send,
     {
-        conjure_http::private::pin_mut!(input);
         let mut request_ = conjure_http::private::async_encode_binary_request(
-            input as _,
+            Box::pin(input),
         );
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
@@ -820,8 +818,7 @@ where
     where
         U: conjure_http::client::WriteBody<T::BodyWriter>,
     {
-        let mut input = input;
-        let mut request_ = conjure_http::private::encode_binary_request(&mut input as _);
+        let mut request_ = conjure_http::private::encode_binary_request(Box::new(input));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw");
@@ -849,8 +846,7 @@ where
     where
         U: conjure_http::client::WriteBody<T::BodyWriter>,
     {
-        let mut input = input;
-        let mut request_ = conjure_http::private::encode_binary_request(&mut input as _);
+        let mut request_ = conjure_http::private::encode_binary_request(Box::new(input));
         *request_.method_mut() = conjure_http::private::http::Method::POST;
         let mut path_ = conjure_http::private::UriBuilder::new();
         path_.push_literal("/catalog/datasets/upload-raw-aliased");


### PR DESCRIPTION
## Before this PR
Streaming request bodies were passed by reference at the `Client` level, while they were passed by value in the generated Conjure code. This complicated codegen and caused inconsistencies in behavior between `conjure-codegen` and `conjure-macros`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Streaming request bodies are now passed by value to the client.
==COMMIT_MSG==

We could go further and implement a bigger change to handle https://github.com/palantir/conjure-rust-runtime/issues/146. However, this would complicate the interface even more and be only possible in the async client. Given that we don't have any use cases for full-duplex communications via Conjure clients it doesn't seem worth it.

Closes #259 

