### PR TITLE
[stacked] Support overrides of endpoint metadata in macro

### DIFF
--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -52,7 +52,7 @@ pub trait AsyncService<C> {
 /// Conjure-specific metadata about an endpoint.
 ///
 /// This is included as an extension in all `Request`s passed to blocking and async Conjure clients.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Endpoint {
     service: &'static str,
     version: Option<&'static str>,

--- a/conjure-macros/src/lib.rs
+++ b/conjure-macros/src/lib.rs
@@ -241,6 +241,11 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// For a trait named `MyService`, the macro will create a type named `MyServiceEndpoints` which
 /// implements the conjure `Service` trait.
 ///
+/// The attribute has a parameter:
+///
+/// * `name` - The value returned from the `EndpointMetadata::service_name` method. Defaults to the
+///     trait name.
+///
 /// # Parameters
 ///
 /// The trait can optionally be declared generic over the request body and response writer types by
@@ -254,6 +259,8 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// * `method` - The HTTP method (e.g. `GET`). Required.
 /// * `path` - The HTTP path template. Path parameters should be identified by `{name}` and must
 ///     make up an entire path component. Required.
+/// * `name` - The value returned from the `EndpointMetadata::name` method. Defaults to the method
+///     name.
 /// * `produces` - A type implementing `SerializeResponse` which will be used to convert the value
 ///     returned by the method into a response. Defaults to `EmptyResponseSerializer`.
 ///

--- a/conjure-macros/src/lib.rs
+++ b/conjure-macros/src/lib.rs
@@ -44,6 +44,13 @@ mod path;
 /// For a trait named `MyService`, the macro will create a type named `MyServiceClient` which
 /// implements the Conjure `Client` and `MyService` traits.
 ///
+/// The attribute has several parameters:
+///
+/// * `name` - The value of the `service` field in the `Endpoint` extension. Defaults to the trait's
+///     name.
+/// * `version` - The value of the `version` field in the `Endpoint` extension. Defaults to
+///     `Some(env!("CARGO_PKG_VERSION"))`.
+///
 /// # Parameters
 ///
 /// The trait can optionally be declared generic over the request body and response writer types by
@@ -58,6 +65,8 @@ mod path;
 /// * `method` - The HTTP method (e.g. `GET`). Required.
 /// * `path` - The HTTP path template. Path parameters should be identified by `{name}` and must
 ///     make up an entire path component. Required.
+/// * `name` - The value of the `name` field in the `Endpoint` extension. Defaults to the method's
+///     name.
 /// * `accept` - A type implementing `DeserializeResponse` which will be used to create the return
 ///     value. Defaults to returning `()`.
 ///

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -18,9 +18,9 @@ use crate::types::*;
 use async_trait::async_trait;
 use conjure_error::Error;
 use conjure_http::server::{
-    AsyncResponseBody, AsyncService, AsyncWriteBody, ConjureResponseSerializer, DeserializeRequest,
-    FromStrOptionDecoder, FromStrSeqDecoder, RequestContext, ResponseBody, SerializeResponse,
-    Service, WriteBody,
+    AsyncEndpoint, AsyncResponseBody, AsyncService, AsyncWriteBody, ConjureResponseSerializer,
+    DeserializeRequest, Endpoint, EndpointMetadata, FromStrOptionDecoder, FromStrSeqDecoder,
+    RequestContext, ResponseBody, SerializeResponse, Service, WriteBody,
 };
 use conjure_http::{PathParams, SafeParams};
 use conjure_macros::{conjure_endpoints, endpoint};
@@ -1021,4 +1021,28 @@ fn custom_streaming_response() {
     Call::new(CustomStreamingServiceEndpoints::new(mock))
         .response(TestBody::Streaming(b"hello world".to_vec()))
         .send_sync("streaming_response");
+}
+
+#[conjure_endpoints(name = "service_name")]
+trait CustomConfig {
+    #[endpoint(method = GET, path = "/path", name = "name")]
+    fn foo(&self) -> Result<(), Error>;
+}
+
+// We can't annotate the trait with #[mockall] due to annoying interactions with #[conjure_endpoints]
+mock! {
+    CustomConfig {}
+
+    impl CustomConfig for CustomConfig {
+        fn foo(&self) -> Result<(), Error>;
+    }
+}
+
+#[test]
+fn custom_config() {
+    let endpoints: Vec<Box<dyn Endpoint<RemoteBody, Vec<u8>> + Sync + Send>> =
+        CustomConfigEndpoints::new(MockCustomConfig::new()).endpoints();
+
+    assert_eq!(endpoints[0].service_name(), "service_name");
+    assert_eq!(endpoints[0].name(), "name");
 }

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -19,8 +19,8 @@ use async_trait::async_trait;
 use conjure_error::Error;
 use conjure_http::server::{
     AsyncEndpoint, AsyncResponseBody, AsyncService, AsyncWriteBody, ConjureResponseSerializer,
-    DeserializeRequest, Endpoint, EndpointMetadata, FromStrOptionDecoder, FromStrSeqDecoder,
-    RequestContext, ResponseBody, SerializeResponse, Service, WriteBody,
+    ConjureRuntime, DeserializeRequest, Endpoint, EndpointMetadata, FromStrOptionDecoder,
+    FromStrSeqDecoder, RequestContext, ResponseBody, SerializeResponse, Service, WriteBody,
 };
 use conjure_http::{PathParams, SafeParams};
 use conjure_macros::{conjure_endpoints, endpoint};
@@ -1050,7 +1050,8 @@ mock! {
 #[test]
 fn custom_config() {
     let endpoints: Vec<Box<dyn Endpoint<RemoteBody, Vec<u8>> + Sync + Send>> =
-        CustomConfigEndpoints::new(MockCustomConfig::new()).endpoints();
+        CustomConfigEndpoints::new(MockCustomConfig::new())
+            .endpoints(&Arc::new(ConjureRuntime::new()));
 
     assert_eq!(endpoints[0].service_name(), "service_name");
     assert_eq!(endpoints[0].name(), "name");


### PR DESCRIPTION
Needed to port conjure-codegen over to the macro backend.