### PR TITLE
[stacked] Allow associated types in #[conjure_endpoints]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 version = "3.6.0"
 
 [workspace]
+resolver = "2"
 members = [
     "conjure-codegen",
     "conjure-error",

--- a/conjure-macros/src/endpoints.rs
+++ b/conjure-macros/src/endpoints.rs
@@ -610,7 +610,11 @@ impl Service {
 
         let mut endpoints = vec![];
         for item in &trait_.items {
-            match Endpoint::new(item) {
+            let TraitItem::Fn(item_fn) = item else {
+                continue;
+            };
+
+            match Endpoint::new(item_fn) {
                 Ok(endpoint) => endpoints.push(endpoint),
                 Err(e) => {
                     errors.push(e);
@@ -666,14 +670,7 @@ struct Endpoint {
 }
 
 impl Endpoint {
-    fn new(item: &TraitItem) -> Result<Self, Error> {
-        let TraitItem::Fn(item) = item else {
-            return Err(Error::new_spanned(
-                item,
-                "Conjure traits may only contain methods",
-            ));
-        };
-
+    fn new(item: &TraitItemFn) -> Result<Self, Error> {
         let mut errors = Errors::new();
 
         let mut endpoint_attrs = item

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -948,6 +948,8 @@ trait CustomStreamingService<#[request_body] I, #[response_writer] O>
 where
     O: Write,
 {
+    type StreamingResponseBody: WriteBody<O> + 'static + Send;
+
     #[endpoint(method = POST, path = "/test/stremaingRequest")]
     fn streaming_request(
         &self,
@@ -955,7 +957,7 @@ where
     ) -> Result<(), Error>;
 
     #[endpoint(method = GET, path = "/test/streamingReponse", produces = RawResponseSerializer)]
-    fn streaming_response(&self) -> Result<TestBodyWriter, Error>;
+    fn streaming_response(&self) -> Result<Self::StreamingResponseBody, Error>;
 }
 
 // We can't annotate the trait with #[mockall] due to annoying interactions with #[conjure_endpoints]
@@ -966,6 +968,8 @@ mock! {
     where
         O: Write
     {
+        type StreamingResponseBody = TestBodyWriter;
+
         fn streaming_request(&self, body: I) -> Result<(), Error>;
         fn streaming_response(&self) -> Result<TestBodyWriter, Error>;
     }


### PR DESCRIPTION
Needed to port conjure-codegen over to the macro backend.