### PR TITLE
[stacked] Stop using #[async_trait] in conjure-macros

### DIFF
--- a/changelog/@unreleased/pr-281.v2.yml
+++ b/changelog/@unreleased/pr-281.v2.yml
@@ -1,0 +1,6 @@
+type: break
+break:
+  description: Async custom clients and endpoints no longer use the `#[async_trait]`
+    macro.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/281

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -12,7 +12,6 @@ readme = "../README.md"
 macros = ["conjure-macros"]
 
 [dependencies]
-async-trait = "0.1"
 bytes = "1.0"
 conjure-error = { version = "3.6.0", path = "../conjure-error" }
 conjure-macros = { version = "3.6.0", path = "../conjure-macros", optional = true }

--- a/conjure-http/src/private/mod.rs
+++ b/conjure-http/src/private/mod.rs
@@ -14,7 +14,6 @@
 
 pub use crate::private::client::*;
 pub use crate::private::server::*;
-pub use async_trait::async_trait;
 pub use bytes::Bytes;
 pub use conjure_error::Error;
 pub use conjure_serde::json;

--- a/conjure-macros/Cargo.toml
+++ b/conjure-macros/Cargo.toml
@@ -19,7 +19,6 @@ structmeta = "0.2.0"
 syn = { version = "2.0.15", features = ["full"] }
 
 [dev-dependencies]
-async-trait = "0.1"
 conjure-error = { path = "../conjure-error", version = "3.6.0" }
 conjure-http = { path = "../conjure-http", version = "3.6.0", features = [
     "macros",

--- a/conjure-macros/src/lib.rs
+++ b/conjure-macros/src/lib.rs
@@ -104,13 +104,12 @@ mod path;
 ///
 /// # Async
 ///
-/// Both blocking and async clients are supported. For technical reasons, async trait definitions
-/// must put the `#[conjure_client]` annotation *above* the `#[async_trait]` annotation.
+/// Both blocking and async clients are supported. For technical reasons, async method definitions
+/// will be rewritten by the macro to require the returned future be `Send`.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use async_trait::async_trait;
 /// use conjure_error::Error;
 /// use conjure_http::{conjure_client, endpoint};
 /// use conjure_http::client::{
@@ -144,7 +143,6 @@ mod path;
 /// }
 ///
 /// #[conjure_client]
-/// #[async_trait]
 /// trait MyServiceAsync {
 ///     #[endpoint(method = GET, path = "/yaks/{yak_id}", accept = ConjureResponseDeserializer)]
 ///     async fn get_yak(
@@ -302,13 +300,12 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// # Async
 ///
-/// Both blocking and async services are supported. For technical reasons, async trait definitions
-/// must put the `#[conjure_endpoints]` annotation *above* the `#[async_trait]` annotation.
+/// Both blocking and async services are supported. For technical reasons, async method definitions
+/// will be rewritten by the macro to require the returned future be `Send`.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use async_trait::async_trait;
 /// use conjure_error::Error;
 /// use conjure_http::{conjure_endpoints, endpoint};
 /// use conjure_http::server::{
@@ -339,7 +336,6 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 ///
 /// #[conjure_endpoints]
-/// #[async_trait]
 /// trait AsyncMyService {
 ///     #[endpoint(method = GET, path = "/yaks/{yak_id}", produces = ConjureResponseSerializer)]
 ///     async fn get_yak(

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -13,7 +13,6 @@ conjure-error = { path = "../conjure-error" }
 conjure-http = { path = "../conjure-http" }
 
 [dev-dependencies]
-async-trait = "0.1"
 base64 = "0.21"
 bytes = "1.0"
 conjure-macros = { path = "../conjure-macros" }

--- a/conjure-test/src/test/clients.rs
+++ b/conjure-test/src/test/clients.rs
@@ -14,7 +14,6 @@
 
 use crate::test::RemoteBody;
 use crate::types::*;
-use async_trait::async_trait;
 use conjure_error::Error;
 use conjure_http::client::{
     AsyncClient, AsyncRequestBody, AsyncService, AsyncWriteBody, Client,
@@ -270,7 +269,6 @@ trait CustomService {
 }
 
 #[conjure_client]
-#[async_trait]
 trait CustomServiceAsync {
     #[endpoint(method = GET, path = "/test/queryParams")]
     async fn query_param(


### PR DESCRIPTION
## Before this PR
Async custom clients and endpoints traits had to use the `#[async_trait]` macro.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Async custom clients and endpoints no longer use the `#[async_trait]` macro.
==COMMIT_MSG==

## Possible downsides?
Due to the lack of support for applying bounds to the anonymous future return types, the macro currently rewrites the trait definitions to add `Send` bounds to the trait definition. Still an improvement over `#[async_trait]` though.

