### PR TITLE
Implement FromIterator and From for aliases

### DIFF
--- a/changelog/@unreleased/pr-287.v2.yml
+++ b/changelog/@unreleased/pr-287.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Aliases now implement `From<T>` where `T` is their fully-dealiased
+    type, and `FromIterator` when the aliased type does.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/287

--- a/conjure-codegen/src/example_types/product/aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/aliased_binary.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for AliasedBinary {
         conjure_object::FromPlain::from_plain(s).map(AliasedBinary)
     }
 }
+impl std::convert::From<conjure_object::ByteBuf> for AliasedBinary {
+    #[inline]
+    fn from(v: conjure_object::ByteBuf) -> Self {
+        AliasedBinary(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for AliasedBinary {
     type Target = conjure_object::ByteBuf;
     #[inline]

--- a/conjure-codegen/src/example_types/product/aliased_string.rs
+++ b/conjure-codegen/src/example_types/product/aliased_string.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for AliasedString {
         conjure_object::FromPlain::from_plain(s).map(AliasedString)
     }
 }
+impl std::convert::From<String> for AliasedString {
+    #[inline]
+    fn from(v: String) -> Self {
+        AliasedString(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for AliasedString {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/bearer_token_alias_example.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for BearerTokenAliasExample {
         conjure_object::FromPlain::from_plain(s).map(BearerTokenAliasExample)
     }
 }
+impl std::convert::From<conjure_object::BearerToken> for BearerTokenAliasExample {
+    #[inline]
+    fn from(v: conjure_object::BearerToken) -> Self {
+        BearerTokenAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for BearerTokenAliasExample {
     type Target = conjure_object::BearerToken;
     #[inline]

--- a/conjure-codegen/src/example_types/product/binary_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_alias_example.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for BinaryAliasExample {
         conjure_object::FromPlain::from_plain(s).map(BinaryAliasExample)
     }
 }
+impl std::convert::From<conjure_object::ByteBuf> for BinaryAliasExample {
+    #[inline]
+    fn from(v: conjure_object::ByteBuf) -> Self {
+        BinaryAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for BinaryAliasExample {
     type Target = conjure_object::ByteBuf;
     #[inline]

--- a/conjure-codegen/src/example_types/product/boolean_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/boolean_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for BooleanAliasExample {
         conjure_object::FromPlain::from_plain(s).map(BooleanAliasExample)
     }
 }
+impl std::convert::From<bool> for BooleanAliasExample {
+    #[inline]
+    fn from(v: bool) -> Self {
+        BooleanAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for BooleanAliasExample {
     type Target = bool;
     #[inline]

--- a/conjure-codegen/src/example_types/product/date_time_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/date_time_alias_example.rs
@@ -20,6 +20,13 @@ impl conjure_object::FromPlain for DateTimeAliasExample {
         conjure_object::FromPlain::from_plain(s).map(DateTimeAliasExample)
     }
 }
+impl std::convert::From<conjure_object::DateTime<conjure_object::Utc>>
+for DateTimeAliasExample {
+    #[inline]
+    fn from(v: conjure_object::DateTime<conjure_object::Utc>) -> Self {
+        DateTimeAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for DateTimeAliasExample {
     type Target = conjure_object::DateTime<conjure_object::Utc>;
     #[inline]

--- a/conjure-codegen/src/example_types/product/double_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/double_alias_example.rs
@@ -27,6 +27,12 @@ impl conjure_object::FromPlain for DoubleAliasExample {
         conjure_object::FromPlain::from_plain(s).map(DoubleAliasExample)
     }
 }
+impl std::convert::From<f64> for DoubleAliasExample {
+    #[inline]
+    fn from(v: f64) -> Self {
+        DoubleAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for DoubleAliasExample {
     type Target = f64;
     #[inline]

--- a/conjure-codegen/src/example_types/product/integer_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/integer_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for IntegerAliasExample {
         conjure_object::FromPlain::from_plain(s).map(IntegerAliasExample)
     }
 }
+impl std::convert::From<i32> for IntegerAliasExample {
+    #[inline]
+    fn from(v: i32) -> Self {
+        IntegerAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for IntegerAliasExample {
     type Target = i32;
     #[inline]

--- a/conjure-codegen/src/example_types/product/map_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/map_alias_example.rs
@@ -1,6 +1,21 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct MapAliasExample(pub std::collections::BTreeMap<String, conjure_object::Any>);
+impl std::iter::FromIterator<(String, conjure_object::Any)> for MapAliasExample {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (String, conjure_object::Any)>,
+    {
+        MapAliasExample(std::iter::FromIterator::from_iter(iter))
+    }
+}
+impl std::convert::From<std::collections::BTreeMap<String, conjure_object::Any>>
+for MapAliasExample {
+    #[inline]
+    fn from(v: std::collections::BTreeMap<String, conjure_object::Any>) -> Self {
+        MapAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for MapAliasExample {
     type Target = std::collections::BTreeMap<String, conjure_object::Any>;
     #[inline]

--- a/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for NestedAliasedBinary {
         conjure_object::FromPlain::from_plain(s).map(NestedAliasedBinary)
     }
 }
+impl std::convert::From<conjure_object::ByteBuf> for NestedAliasedBinary {
+    #[inline]
+    fn from(v: conjure_object::ByteBuf) -> Self {
+        NestedAliasedBinary(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for NestedAliasedBinary {
     type Target = super::AliasedBinary;
     #[inline]

--- a/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/nested_string_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for NestedStringAliasExample {
         conjure_object::FromPlain::from_plain(s).map(NestedStringAliasExample)
     }
 }
+impl std::convert::From<String> for NestedStringAliasExample {
+    #[inline]
+    fn from(v: String) -> Self {
+        NestedStringAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for NestedStringAliasExample {
     type Target = super::StringAliasExample;
     #[inline]

--- a/conjure-codegen/src/example_types/product/reference_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/reference_alias_example.rs
@@ -1,6 +1,12 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReferenceAliasExample(pub super::AnyExample);
+impl std::convert::From<super::AnyExample> for ReferenceAliasExample {
+    #[inline]
+    fn from(v: super::AnyExample) -> Self {
+        ReferenceAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for ReferenceAliasExample {
     type Target = super::AnyExample;
     #[inline]

--- a/conjure-codegen/src/example_types/product/rid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/rid_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for RidAliasExample {
         conjure_object::FromPlain::from_plain(s).map(RidAliasExample)
     }
 }
+impl std::convert::From<conjure_object::ResourceIdentifier> for RidAliasExample {
+    #[inline]
+    fn from(v: conjure_object::ResourceIdentifier) -> Self {
+        RidAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for RidAliasExample {
     type Target = conjure_object::ResourceIdentifier;
     #[inline]

--- a/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/safe_long_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for SafeLongAliasExample {
         conjure_object::FromPlain::from_plain(s).map(SafeLongAliasExample)
     }
 }
+impl std::convert::From<conjure_object::SafeLong> for SafeLongAliasExample {
+    #[inline]
+    fn from(v: conjure_object::SafeLong) -> Self {
+        SafeLongAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for SafeLongAliasExample {
     type Target = conjure_object::SafeLong;
     #[inline]

--- a/conjure-codegen/src/example_types/product/string_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/string_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for StringAliasExample {
         conjure_object::FromPlain::from_plain(s).map(StringAliasExample)
     }
 }
+impl std::convert::From<String> for StringAliasExample {
+    #[inline]
+    fn from(v: String) -> Self {
+        StringAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for StringAliasExample {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/example_types/product/uuid_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/uuid_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for UuidAliasExample {
         conjure_object::FromPlain::from_plain(s).map(UuidAliasExample)
     }
 }
+impl std::convert::From<conjure_object::Uuid> for UuidAliasExample {
+    #[inline]
+    fn from(v: conjure_object::Uuid) -> Self {
+        UuidAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for UuidAliasExample {
     type Target = conjure_object::Uuid;
     #[inline]

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -174,8 +174,10 @@
 //! ```
 //!
 //! The generated structs implement `Deref`, `DerefMut`, `Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`,
-//! `Hash`, `Serialize`, and `Deserialize`. They also implement `Copy` if they wrap a copyable primitive type, `Default`
-//! if they wrap a type implementing `Default`, and `Display` if they wrap a type implementing `Display`.
+//! `Hash`, `Serialize`, and `Deserialize`. They implement `Copy` if they wrap a copyable primitive type, `Default`
+//! if they wrap a type implementing `Default`, `FromIterator` if they wrap a type implementing `FromIterator`, and
+//! `Display` if they wrap a type implementing `Display`. They also implement `From<T>`, where `T` is the fully
+//! de-aliased inner type.
 //!
 //! ## Errors
 //!

--- a/conjure-codegen/src/types/argument_name.rs
+++ b/conjure-codegen/src/types/argument_name.rs
@@ -19,6 +19,12 @@ impl conjure_object::FromPlain for ArgumentName {
         conjure_object::FromPlain::from_plain(s).map(ArgumentName)
     }
 }
+impl std::convert::From<String> for ArgumentName {
+    #[inline]
+    fn from(v: String) -> Self {
+        ArgumentName(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for ArgumentName {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/documentation.rs
+++ b/conjure-codegen/src/types/documentation.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for Documentation {
         conjure_object::FromPlain::from_plain(s).map(Documentation)
     }
 }
+impl std::convert::From<String> for Documentation {
+    #[inline]
+    fn from(v: String) -> Self {
+        Documentation(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for Documentation {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/endpoint_name.rs
+++ b/conjure-codegen/src/types/endpoint_name.rs
@@ -19,6 +19,12 @@ impl conjure_object::FromPlain for EndpointName {
         conjure_object::FromPlain::from_plain(s).map(EndpointName)
     }
 }
+impl std::convert::From<String> for EndpointName {
+    #[inline]
+    fn from(v: String) -> Self {
+        EndpointName(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for EndpointName {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/error_namespace.rs
+++ b/conjure-codegen/src/types/error_namespace.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for ErrorNamespace {
         conjure_object::FromPlain::from_plain(s).map(ErrorNamespace)
     }
 }
+impl std::convert::From<String> for ErrorNamespace {
+    #[inline]
+    fn from(v: String) -> Self {
+        ErrorNamespace(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for ErrorNamespace {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/field_name.rs
+++ b/conjure-codegen/src/types/field_name.rs
@@ -19,6 +19,12 @@ impl conjure_object::FromPlain for FieldName {
         conjure_object::FromPlain::from_plain(s).map(FieldName)
     }
 }
+impl std::convert::From<String> for FieldName {
+    #[inline]
+    fn from(v: String) -> Self {
+        FieldName(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for FieldName {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/http_path.rs
+++ b/conjure-codegen/src/types/http_path.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for HttpPath {
         conjure_object::FromPlain::from_plain(s).map(HttpPath)
     }
 }
+impl std::convert::From<String> for HttpPath {
+    #[inline]
+    fn from(v: String) -> Self {
+        HttpPath(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for HttpPath {
     type Target = String;
     #[inline]

--- a/conjure-codegen/src/types/parameter_id.rs
+++ b/conjure-codegen/src/types/parameter_id.rs
@@ -19,6 +19,12 @@ impl conjure_object::FromPlain for ParameterId {
         conjure_object::FromPlain::from_plain(s).map(ParameterId)
     }
 }
+impl std::convert::From<String> for ParameterId {
+    #[inline]
+    fn from(v: String) -> Self {
+        ParameterId(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for ParameterId {
     type Target = String;
     #[inline]

--- a/example-api/src/product/aliased_binary.rs
+++ b/example-api/src/product/aliased_binary.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for AliasedBinary {
         conjure_object::FromPlain::from_plain(s).map(AliasedBinary)
     }
 }
+impl std::convert::From<conjure_object::ByteBuf> for AliasedBinary {
+    #[inline]
+    fn from(v: conjure_object::ByteBuf) -> Self {
+        AliasedBinary(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for AliasedBinary {
     type Target = conjure_object::ByteBuf;
     #[inline]

--- a/example-api/src/product/aliased_string.rs
+++ b/example-api/src/product/aliased_string.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for AliasedString {
         conjure_object::FromPlain::from_plain(s).map(AliasedString)
     }
 }
+impl std::convert::From<String> for AliasedString {
+    #[inline]
+    fn from(v: String) -> Self {
+        AliasedString(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for AliasedString {
     type Target = String;
     #[inline]

--- a/example-api/src/product/bearer_token_alias_example.rs
+++ b/example-api/src/product/bearer_token_alias_example.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for BearerTokenAliasExample {
         conjure_object::FromPlain::from_plain(s).map(BearerTokenAliasExample)
     }
 }
+impl std::convert::From<conjure_object::BearerToken> for BearerTokenAliasExample {
+    #[inline]
+    fn from(v: conjure_object::BearerToken) -> Self {
+        BearerTokenAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for BearerTokenAliasExample {
     type Target = conjure_object::BearerToken;
     #[inline]

--- a/example-api/src/product/binary_alias_example.rs
+++ b/example-api/src/product/binary_alias_example.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for BinaryAliasExample {
         conjure_object::FromPlain::from_plain(s).map(BinaryAliasExample)
     }
 }
+impl std::convert::From<conjure_object::ByteBuf> for BinaryAliasExample {
+    #[inline]
+    fn from(v: conjure_object::ByteBuf) -> Self {
+        BinaryAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for BinaryAliasExample {
     type Target = conjure_object::ByteBuf;
     #[inline]

--- a/example-api/src/product/boolean_alias_example.rs
+++ b/example-api/src/product/boolean_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for BooleanAliasExample {
         conjure_object::FromPlain::from_plain(s).map(BooleanAliasExample)
     }
 }
+impl std::convert::From<bool> for BooleanAliasExample {
+    #[inline]
+    fn from(v: bool) -> Self {
+        BooleanAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for BooleanAliasExample {
     type Target = bool;
     #[inline]

--- a/example-api/src/product/date_time_alias_example.rs
+++ b/example-api/src/product/date_time_alias_example.rs
@@ -20,6 +20,13 @@ impl conjure_object::FromPlain for DateTimeAliasExample {
         conjure_object::FromPlain::from_plain(s).map(DateTimeAliasExample)
     }
 }
+impl std::convert::From<conjure_object::DateTime<conjure_object::Utc>>
+for DateTimeAliasExample {
+    #[inline]
+    fn from(v: conjure_object::DateTime<conjure_object::Utc>) -> Self {
+        DateTimeAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for DateTimeAliasExample {
     type Target = conjure_object::DateTime<conjure_object::Utc>;
     #[inline]

--- a/example-api/src/product/double_alias_example.rs
+++ b/example-api/src/product/double_alias_example.rs
@@ -27,6 +27,12 @@ impl conjure_object::FromPlain for DoubleAliasExample {
         conjure_object::FromPlain::from_plain(s).map(DoubleAliasExample)
     }
 }
+impl std::convert::From<f64> for DoubleAliasExample {
+    #[inline]
+    fn from(v: f64) -> Self {
+        DoubleAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for DoubleAliasExample {
     type Target = f64;
     #[inline]

--- a/example-api/src/product/integer_alias_example.rs
+++ b/example-api/src/product/integer_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for IntegerAliasExample {
         conjure_object::FromPlain::from_plain(s).map(IntegerAliasExample)
     }
 }
+impl std::convert::From<i32> for IntegerAliasExample {
+    #[inline]
+    fn from(v: i32) -> Self {
+        IntegerAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for IntegerAliasExample {
     type Target = i32;
     #[inline]

--- a/example-api/src/product/map_alias_example.rs
+++ b/example-api/src/product/map_alias_example.rs
@@ -1,6 +1,21 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct MapAliasExample(pub std::collections::BTreeMap<String, conjure_object::Any>);
+impl std::iter::FromIterator<(String, conjure_object::Any)> for MapAliasExample {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: std::iter::IntoIterator<Item = (String, conjure_object::Any)>,
+    {
+        MapAliasExample(std::iter::FromIterator::from_iter(iter))
+    }
+}
+impl std::convert::From<std::collections::BTreeMap<String, conjure_object::Any>>
+for MapAliasExample {
+    #[inline]
+    fn from(v: std::collections::BTreeMap<String, conjure_object::Any>) -> Self {
+        MapAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for MapAliasExample {
     type Target = std::collections::BTreeMap<String, conjure_object::Any>;
     #[inline]

--- a/example-api/src/product/nested_aliased_binary.rs
+++ b/example-api/src/product/nested_aliased_binary.rs
@@ -13,6 +13,12 @@ impl conjure_object::FromPlain for NestedAliasedBinary {
         conjure_object::FromPlain::from_plain(s).map(NestedAliasedBinary)
     }
 }
+impl std::convert::From<conjure_object::ByteBuf> for NestedAliasedBinary {
+    #[inline]
+    fn from(v: conjure_object::ByteBuf) -> Self {
+        NestedAliasedBinary(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for NestedAliasedBinary {
     type Target = super::AliasedBinary;
     #[inline]

--- a/example-api/src/product/nested_string_alias_example.rs
+++ b/example-api/src/product/nested_string_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for NestedStringAliasExample {
         conjure_object::FromPlain::from_plain(s).map(NestedStringAliasExample)
     }
 }
+impl std::convert::From<String> for NestedStringAliasExample {
+    #[inline]
+    fn from(v: String) -> Self {
+        NestedStringAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for NestedStringAliasExample {
     type Target = super::StringAliasExample;
     #[inline]

--- a/example-api/src/product/reference_alias_example.rs
+++ b/example-api/src/product/reference_alias_example.rs
@@ -1,6 +1,12 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReferenceAliasExample(pub super::AnyExample);
+impl std::convert::From<super::AnyExample> for ReferenceAliasExample {
+    #[inline]
+    fn from(v: super::AnyExample) -> Self {
+        ReferenceAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for ReferenceAliasExample {
     type Target = super::AnyExample;
     #[inline]

--- a/example-api/src/product/rid_alias_example.rs
+++ b/example-api/src/product/rid_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for RidAliasExample {
         conjure_object::FromPlain::from_plain(s).map(RidAliasExample)
     }
 }
+impl std::convert::From<conjure_object::ResourceIdentifier> for RidAliasExample {
+    #[inline]
+    fn from(v: conjure_object::ResourceIdentifier) -> Self {
+        RidAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for RidAliasExample {
     type Target = conjure_object::ResourceIdentifier;
     #[inline]

--- a/example-api/src/product/safe_long_alias_example.rs
+++ b/example-api/src/product/safe_long_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for SafeLongAliasExample {
         conjure_object::FromPlain::from_plain(s).map(SafeLongAliasExample)
     }
 }
+impl std::convert::From<conjure_object::SafeLong> for SafeLongAliasExample {
+    #[inline]
+    fn from(v: conjure_object::SafeLong) -> Self {
+        SafeLongAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for SafeLongAliasExample {
     type Target = conjure_object::SafeLong;
     #[inline]

--- a/example-api/src/product/string_alias_example.rs
+++ b/example-api/src/product/string_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for StringAliasExample {
         conjure_object::FromPlain::from_plain(s).map(StringAliasExample)
     }
 }
+impl std::convert::From<String> for StringAliasExample {
+    #[inline]
+    fn from(v: String) -> Self {
+        StringAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for StringAliasExample {
     type Target = String;
     #[inline]

--- a/example-api/src/product/uuid_alias_example.rs
+++ b/example-api/src/product/uuid_alias_example.rs
@@ -18,6 +18,12 @@ impl conjure_object::FromPlain for UuidAliasExample {
         conjure_object::FromPlain::from_plain(s).map(UuidAliasExample)
     }
 }
+impl std::convert::From<conjure_object::Uuid> for UuidAliasExample {
+    #[inline]
+    fn from(v: conjure_object::Uuid) -> Self {
+        UuidAliasExample(std::convert::From::from(v))
+    }
+}
 impl std::ops::Deref for UuidAliasExample {
     type Target = conjure_object::Uuid;
     #[inline]


### PR DESCRIPTION
We'll need these impls to handle endpoint parameter conversions for aliased optional and collection types.

I don't know how I feel about the `From` impls, but it feels like the least-awkward way to handle nested aliases of optional values :/