### PR TITLE
[stacked] Allow path parameter name overrides

### DIFF
--- a/conjure-macros/src/endpoints.rs
+++ b/conjure-macros/src/endpoints.rs
@@ -411,7 +411,10 @@ fn generate_arg(
 
 fn generate_path_arg(parts: &TokenStream, arg: &Arg<PathArg>) -> TokenStream {
     let name = &arg.ident;
-    let param = arg.ident.to_string();
+    let param = match &arg.params.name {
+        Some(name) => name.value(),
+        None => arg.ident.to_string(),
+    };
     let decoder = arg.params.decoder.as_ref().map_or_else(
         || quote!(conjure_http::server::FromStrDecoder),
         |d| quote!(#d),
@@ -864,6 +867,7 @@ struct Arg<T> {
 #[derive(StructMeta, Default)]
 struct PathArg {
     safe: bool,
+    name: Option<LitStr>,
     decoder: Option<Type>,
 }
 

--- a/conjure-macros/src/lib.rs
+++ b/conjure-macros/src/lib.rs
@@ -72,10 +72,10 @@ mod path;
 ///
 /// Each method argument must have an annotation describing the type of parameter. One of:
 ///
-/// * `#[path]` - A path parameter. The path template must contain a parameter component matching
-///     the argument name.
+/// * `#[path]` - A path parameter.
 ///
 ///     Parameters:
+///     * `name` - The name of the path template parameter. Defaults to the argument name.
 ///     * `encoder` - A type implementing `EncodeParam` which will be used to encode the value into
 ///         a string. Defaults to `DisplayParamEncoder`.
 /// * `#[query]` - A query parameter.
@@ -264,10 +264,10 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// Each method argument must have an annotation describing the type of parameter. One of:
 ///
-/// * `#[path]` - A path parameter. The path template mut contain a parameter component matching
-///     the argument name.
+/// * `#[path]` - A path parameter.
 ///
 ///     Parameters:
+///     * `name` - The name of the path template parameter. Defaults to the argument name.
 ///     * `decoder` - A type implementing `DecodeParam` which will be used to decode the value.
 ///         Defaults to `FromStrDecoder`.
 ///     * `safe` - If set, the parameter will be added to the `SafeParams` response extension.

--- a/conjure-test/src/test/clients.rs
+++ b/conjure-test/src/test/clients.rs
@@ -237,10 +237,11 @@ trait CustomService {
         #[query(name = "list", encoder = DisplaySeqEncoder)] list: &[i32],
     ) -> Result<(), Error>;
 
-    #[endpoint(method = GET, path = "/test/pathParams/{foo}/raw/{multi}")]
+    #[endpoint(method = GET, path = "/test/pathParams/{foo}/{baz}/raw/{multi}")]
     fn path_param(
         &self,
         #[path] foo: &str,
+        #[path(name = "baz")] bar: i32,
         #[path(encoder = DisplaySeqEncoder)] multi: &[&str],
     ) -> Result<(), Error>;
 
@@ -277,10 +278,11 @@ trait CustomServiceAsync {
         #[query(name = "list", encoder = DisplaySeqEncoder)] list: &[i32],
     ) -> Result<(), Error>;
 
-    #[endpoint(method = GET, path = "/test/pathParams/{foo}/raw/{multi}")]
+    #[endpoint(method = GET, path = "/test/pathParams/{foo}/{baz}/raw/{multi}")]
     async fn path_param(
         &self,
         #[path] foo: &str,
+        #[path(name = "baz")] bar: i32,
         #[path(encoder = DisplaySeqEncoder)] multi: &[&str],
     ) -> Result<(), Error>;
 
@@ -324,12 +326,12 @@ fn custom_query_params() {
 fn custom_path_params() {
     let client = TestClient::new(
         Method::GET,
-        "/test/pathParams/hello%20world/raw/foo/bar%2Fbaz",
+        "/test/pathParams/hello%20world/42/raw/foo/bar%2Fbaz",
     );
 
     check_custom!(
         client,
-        client.path_param("hello world", &["foo", "bar/baz"])
+        client.path_param("hello world", 42, &["foo", "bar/baz"])
     );
 }
 

--- a/conjure-test/src/test/servers.rs
+++ b/conjure-test/src/test/servers.rs
@@ -745,8 +745,9 @@ trait CustomService {
         #[query(name = "list", decoder = FromStrSeqDecoder<_>)] list: Vec<i32>,
     ) -> Result<(), Error>;
 
-    #[endpoint(method = GET, path = "/test/pathParams/{foo}/raw")]
-    fn path_params(&self, #[path] foo: String) -> Result<(), Error>;
+    #[endpoint(method = GET, path = "/test/pathParams/{foo}/{baz}/raw")]
+    fn path_params(&self, #[path] foo: String, #[path(name = "baz")] bar: i32)
+        -> Result<(), Error>;
 
     #[endpoint(method = GET, path = "/test/headers")]
     fn headers(
@@ -792,7 +793,7 @@ mock! {
 
     impl CustomService for CustomService {
         fn query_params(&self, normal: String, list: Vec<i32>) -> Result<(), Error>;
-        fn path_params(&self, foo: String) -> Result<(), Error>;
+        fn path_params(&self, foo: String, bar: i32) -> Result<(), Error>;
         fn headers(&self, custom_header: String, optional_header: Option<i32>) -> Result<(), Error>;
         fn json_request(&self, body: String) -> Result<(), Error>;
         fn json_response(&self) -> Result<String, Error>;
@@ -836,10 +837,11 @@ fn custom_query_params() {
 fn custom_path_params() {
     let mut mock = MockCustomService::new();
     mock.expect_path_params()
-        .with(eq("hello world".to_string()))
-        .returning(|_| Ok(()));
+        .with(eq("hello world".to_string()), eq(42))
+        .returning(|_, _| Ok(()));
     Call::new(CustomServiceEndpoints::new(mock))
         .path_param("foo", "hello%20world")
+        .path_param("baz", "42")
         .send_sync("path_params");
 }
 


### PR DESCRIPTION
We'll need this to port conjure-codegen to use the macros since path parameters will be camelCase.