### PR TITLE
Convert endpoint codegen over to conjure-macros

### DIFF
--- a/changelog/@unreleased/pr-292.v2.yml
+++ b/changelog/@unreleased/pr-292.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: Convert endpoint codegen over to conjure-macros
+  links:
+  - https://github.com/palantir/conjure-rust/pull/292

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -928,10 +928,6 @@ impl Context {
         self.prelude_ident(name, "Into", "std::convert::Into")
     }
 
-    pub fn iterator_ident(&self, name: &TypeName) -> TokenStream {
-        self.prelude_ident(name, "Iterator", "std::iterator::Iterator")
-    }
-
     #[allow(clippy::wrong_self_convention)]
     pub fn into_iterator_ident(&self, name: &TypeName) -> TokenStream {
         self.prelude_ident(name, "IntoIterator", "std::iter::IntoIterator")
@@ -939,10 +935,6 @@ impl Context {
 
     pub fn default_ident(&self, name: &TypeName) -> TokenStream {
         self.prelude_ident(name, "Default", "std::default::Default")
-    }
-
-    pub fn sync_ident(&self, name: &TypeName) -> TokenStream {
-        self.prelude_ident(name, "Sync", "std::marker::Sync")
     }
 
     pub fn send_ident(&self, name: &TypeName) -> TokenStream {

--- a/conjure-codegen/src/example_types/another/mod.rs
+++ b/conjure-codegen/src/example_types/another/mod.rs
@@ -3,7 +3,7 @@ pub use self::different_package::DifferentPackage;
 #[doc(inline)]
 pub use self::test_service::{
     TestServiceClient, TestServiceAsyncClient, TestService, AsyncTestService,
-    TestServiceEndpoints,
+    TestServiceEndpoints, AsyncTestServiceEndpoints,
 };
 pub mod different_package;
 pub mod test_service;

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1173,8 +1173,10 @@ where
         conjure_http::private::decode_empty_response(response_)
     }
 }
+use conjure_http::endpoint;
 ///A Markdown description of the service.
-pub trait TestService<I, O> {
+#[conjure_http::conjure_endpoints(name = "TestService")]
+pub trait TestService<#[request_body] I, #[response_writer] O> {
     ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     ///The body type returned by the `get_aliased_raw_data` method.
@@ -1182,8 +1184,15 @@ pub trait TestService<I, O> {
     ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     ///Returns a mapping from file system id to backing file system configuration.
+    #[endpoint(
+        method = GET,
+        path = "/catalog/fileSystems",
+        name = "getFileSystems",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_file_systems(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<
         std::collections::BTreeMap<
@@ -1192,118 +1201,367 @@ pub trait TestService<I, O> {
         >,
         conjure_http::private::Error,
     >;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets",
+        name = "createDataset",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn create_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         request: super::super::product::CreateDatasetRequest,
+        #[header(
+            name = "Test-Header",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "testHeaderArg"
+        )]
         test_header_arg: String,
     ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}",
+        name = "getDataset",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<
         Option<super::super::product::datasets::Dataset>,
         conjure_http::private::Error,
     >;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw",
+        name = "getRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
     fn get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Self::GetRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-aliased",
+        name = "getAliasedRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
     fn get_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-maybe",
+        name = "maybeGetRawData",
+        produces = conjure_http::server::conjure::OptionalBinaryResponseSerializer
+    )]
     fn maybe_get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Option<Self::MaybeGetRawDataBody>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/string-aliased",
+        name = "getAliasedString",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn get_aliased_string(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<super::super::product::AliasedString, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw",
+        name = "uploadRawData"
+    )]
     fn upload_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
     ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw-aliased",
+        name = "uploadAliasedRawData"
+    )]
     fn upload_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
     ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches",
+        name = "getBranches",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_branches(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
     ///Gets all branches of this dataset.
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        name = "getBranchesDeprecated",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_branches_deprecated(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        name = "resolveBranch",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn resolve_branch(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
+        #[path(
+            name = "branch",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         branch: String,
     ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/testParam",
+        name = "testParam",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn test_param(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-query-params",
+        name = "testQueryParams",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
     ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-no-response-query-params",
+        name = "testNoResponseQueryParams"
+    )]
     fn test_no_response_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
     ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/boolean",
+        name = "testBoolean",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_boolean(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<bool, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/double",
+        name = "testDouble",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<f64, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/integer",
+        name = "testInteger",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_integer(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/optional",
+        name = "testPostOptional",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn test_post_optional(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(
+            deserializer = conjure_http::server::conjure::OptionalRequestDeserializer,
+            log_as = "maybeString"
+        )]
         maybe_string: Option<String>,
     ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/optional-integer-double",
+        name = "testOptionalIntegerAndDouble"
+    )]
     fn test_optional_integer_and_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[query(
+            name = "maybeInteger",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeInteger"
+        )]
         maybe_integer: Option<i32>,
+        #[query(
+            name = "maybeDouble",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeDouble"
+        )]
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error>;
 }
 ///A Markdown description of the service.
-pub trait AsyncTestService<I, O> {
+#[conjure_http::conjure_endpoints(name = "TestService")]
+pub trait AsyncTestService<#[request_body] I, #[response_writer] O> {
     ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
     ///The body type returned by the `get_aliased_raw_data` method.
@@ -1311,2093 +1569,378 @@ pub trait AsyncTestService<I, O> {
     ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
     ///Returns a mapping from file system id to backing file system configuration.
-    fn get_file_systems(
+    #[endpoint(
+        method = GET,
+        path = "/catalog/fileSystems",
+        name = "getFileSystems",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_file_systems(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
+    ) -> Result<
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
         >,
-    > + Send;
-    fn create_dataset(
+        conjure_http::private::Error,
+    >;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets",
+        name = "createDataset",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn create_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         request: super::super::product::CreateDatasetRequest,
+        #[header(
+            name = "Test-Header",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "testHeaderArg"
+        )]
         test_header_arg: String,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            super::super::product::datasets::Dataset,
-            conjure_http::private::Error,
-        >,
-    > + Send;
-    fn get_dataset(
+    ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}",
+        name = "getDataset",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        >,
-    > + Send;
-    fn get_raw_data(
+    ) -> Result<
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    >;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw",
+        name = "getRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
+    async fn get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Self::GetRawDataBody, conjure_http::private::Error>,
-    > + Send;
-    fn get_aliased_raw_data(
+    ) -> Result<Self::GetRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-aliased",
+        name = "getAliasedRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
+    async fn get_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>,
-    > + Send;
-    fn maybe_get_raw_data(
+    ) -> Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-maybe",
+        name = "maybeGetRawData",
+        produces = conjure_http::server::conjure::OptionalBinaryResponseSerializer
+    )]
+    async fn maybe_get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<Self::MaybeGetRawDataBody>, conjure_http::private::Error>,
-    > + Send;
-    fn get_aliased_string(
+    ) -> Result<Option<Self::MaybeGetRawDataBody>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/string-aliased",
+        name = "getAliasedString",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn get_aliased_string(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            super::super::product::AliasedString,
-            conjure_http::private::Error,
-        >,
-    > + Send;
-    fn upload_raw_data(
+    ) -> Result<super::super::product::AliasedString, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw",
+        name = "uploadRawData"
+    )]
+    async fn upload_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-    fn upload_aliased_raw_data(
+    ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw-aliased",
+        name = "uploadAliasedRawData"
+    )]
+    async fn upload_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-    fn get_branches(
+    ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches",
+        name = "getBranches",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_branches(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<std::collections::BTreeSet<String>, conjure_http::private::Error>,
-    > + Send;
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
     ///Gets all branches of this dataset.
-    fn get_branches_deprecated(
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        name = "getBranchesDeprecated",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_branches_deprecated(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<std::collections::BTreeSet<String>, conjure_http::private::Error>,
-    > + Send;
-    fn resolve_branch(
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        name = "resolveBranch",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn resolve_branch(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
+        #[path(
+            name = "branch",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         branch: String,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<String>, conjure_http::private::Error>,
-    > + Send;
-    fn test_param(
+    ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/testParam",
+        name = "testParam",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn test_param(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<String>, conjure_http::private::Error>,
-    > + Send;
-    fn test_query_params(
+    ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-query-params",
+        name = "testQueryParams",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<i32, conjure_http::private::Error>,
-    > + Send;
-    fn test_no_response_query_params(
+    ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-no-response-query-params",
+        name = "testNoResponseQueryParams"
+    )]
+    async fn test_no_response_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-    fn test_boolean(
+    ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/boolean",
+        name = "testBoolean",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_boolean(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<bool, conjure_http::private::Error>,
-    > + Send;
-    fn test_double(
+    ) -> Result<bool, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/double",
+        name = "testDouble",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<f64, conjure_http::private::Error>,
-    > + Send;
-    fn test_integer(
+    ) -> Result<f64, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/integer",
+        name = "testInteger",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_integer(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<i32, conjure_http::private::Error>,
-    > + Send;
-    fn test_post_optional(
+    ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/optional",
+        name = "testPostOptional",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn test_post_optional(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(
+            deserializer = conjure_http::server::conjure::OptionalRequestDeserializer,
+            log_as = "maybeString"
+        )]
         maybe_string: Option<String>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<String>, conjure_http::private::Error>,
-    > + Send;
-    fn test_optional_integer_and_double(
+    ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/optional-integer-double",
+        name = "testOptionalIntegerAndDouble"
+    )]
+    async fn test_optional_integer_and_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[query(
+            name = "maybeInteger",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeInteger"
+        )]
         maybe_integer: Option<i32>,
+        #[query(
+            name = "maybeDouble",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeDouble"
+        )]
         maybe_double: Option<f64>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-}
-pub struct TestServiceEndpoints<T>(conjure_http::private::Arc<T>);
-impl<T> TestServiceEndpoints<T> {
-    /// Creates a new resource.
-    pub fn new(handler: T) -> TestServiceEndpoints<T> {
-        TestServiceEndpoints(conjure_http::private::Arc::new(handler))
-    }
-}
-impl<T, I, O> conjure_http::server::Service<I, O> for TestServiceEndpoints<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn endpoints(
-        &self,
-        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
-    ) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
-        vec![
-            Box::new(GetFileSystemsEndpoint_(self.0.clone())),
-            Box::new(CreateDatasetEndpoint_(self.0.clone())),
-            Box::new(GetDatasetEndpoint_(self.0.clone())),
-            Box::new(GetRawDataEndpoint_(self.0.clone())),
-            Box::new(GetAliasedRawDataEndpoint_(self.0.clone())),
-            Box::new(MaybeGetRawDataEndpoint_(self.0.clone())),
-            Box::new(GetAliasedStringEndpoint_(self.0.clone())),
-            Box::new(UploadRawDataEndpoint_(self.0.clone())),
-            Box::new(UploadAliasedRawDataEndpoint_(self.0.clone())),
-            Box::new(GetBranchesEndpoint_(self.0.clone())),
-            Box::new(GetBranchesDeprecatedEndpoint_(self.0.clone())),
-            Box::new(ResolveBranchEndpoint_(self.0.clone())),
-            Box::new(TestParamEndpoint_(self.0.clone())),
-            Box::new(TestQueryParamsEndpoint_(self.0.clone())),
-            Box::new(TestNoResponseQueryParamsEndpoint_(self.0.clone())),
-            Box::new(TestBooleanEndpoint_(self.0.clone())),
-            Box::new(TestDoubleEndpoint_(self.0.clone())),
-            Box::new(TestIntegerEndpoint_(self.0.clone())),
-            Box::new(TestPostOptionalEndpoint_(self.0.clone())),
-            Box::new(TestOptionalIntegerAndDoubleEndpoint_(self.0.clone())),
-        ]
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncService<I, O> for TestServiceEndpoints<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    fn endpoints(
-        &self,
-        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
-    ) -> Vec<conjure_http::server::BoxAsyncEndpoint<'_, I, O>> {
-        vec![
-            conjure_http::server::BoxAsyncEndpoint::new(GetFileSystemsEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(CreateDatasetEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetDatasetEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetAliasedRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(MaybeGetRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetAliasedStringEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(UploadRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(UploadAliasedRawDataEndpoint_(self
-            .0.clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetBranchesEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetBranchesDeprecatedEndpoint_(self
-            .0.clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(ResolveBranchEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestParamEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestQueryParamsEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestNoResponseQueryParamsEndpoint_(self
-            .0.clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestBooleanEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestDoubleEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestIntegerEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestPostOptionalEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestOptionalIntegerAndDoubleEndpoint_(self
-            .0.clone())),
-        ]
-    }
-}
-struct GetFileSystemsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetFileSystemsEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("fileSystems"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/fileSystems"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getFileSystems"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetFileSystemsEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_file_systems(auth_)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetFileSystemsEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_file_systems(auth_).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct CreateDatasetEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for CreateDatasetEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "createDataset"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for CreateDatasetEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let request = conjure_http::private::decode_serializable_request(
-            &parts_,
-            body_,
-        )?;
-        let test_header_arg = conjure_http::private::parse_required_header(
-            &parts_,
-            "testHeaderArg",
-            "Test-Header",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.create_dataset(auth_, request, test_header_arg)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for CreateDatasetEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let request = conjure_http::private::async_decode_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let test_header_arg = conjure_http::private::parse_required_header(
-            &parts_,
-            "testHeaderArg",
-            "Test-Header",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.create_dataset(auth_, request, test_header_arg).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct GetDatasetEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetDatasetEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getDataset"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetDatasetEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_dataset(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetDatasetEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_dataset(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct GetRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("raw"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/raw"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_binary_response(response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(response_))
-    }
-}
-struct GetAliasedRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetAliasedRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("raw-aliased"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/raw-aliased"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getAliasedRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_binary_response(response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetAliasedRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(response_))
-    }
-}
-struct MaybeGetRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for MaybeGetRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("raw-maybe"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/raw-maybe"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "maybeGetRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for MaybeGetRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_optional_binary_response(response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for MaybeGetRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_optional_binary_response(response_))
-    }
-}
-struct GetAliasedStringEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetAliasedStringEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("string-aliased"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/string-aliased"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getAliasedString"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedStringEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_string(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetAliasedStringEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_string(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct UploadRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for UploadRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("upload-raw"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/upload-raw"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "uploadRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_raw_data(auth_, input)?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for UploadRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_raw_data(auth_, input).await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
-}
-struct UploadAliasedRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for UploadAliasedRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("upload-raw-aliased"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/upload-raw-aliased"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "uploadAliasedRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadAliasedRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_aliased_raw_data(auth_, input)?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for UploadAliasedRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_aliased_raw_data(auth_, input).await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
-}
-struct GetBranchesEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetBranchesEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("branches"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/branches"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getBranches"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetBranchesEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct GetBranchesDeprecatedEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetBranchesDeprecatedEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("branchesDeprecated"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/branchesDeprecated"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getBranchesDeprecated"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        Some("use getBranches instead")
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesDeprecatedEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches_deprecated(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for GetBranchesDeprecatedEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches_deprecated(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct ResolveBranchEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for ResolveBranchEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("branches"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("branch"),
-                regex: Some(conjure_http::private::Cow::Borrowed(".+")),
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("resolve"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "resolveBranch"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for ResolveBranchEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.resolve_branch(auth_, dataset_rid, branch)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for ResolveBranchEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.resolve_branch(auth_, dataset_rid, branch).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct TestParamEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestParamEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("testParam"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/testParam"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testParam"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestParamEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_param(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestParamEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_param(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct TestQueryParamsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestQueryParamsEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("test-query-params"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/test-query-params"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testQueryParams"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestQueryParamsEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self
-            .0
-            .test_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestQueryParamsEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::async_decode_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self
-            .0
-            .test_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )
-            .await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestNoResponseQueryParamsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata
-for TestNoResponseQueryParamsEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("test-no-response-query-params"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/test-no-response-query-params"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testNoResponseQueryParams"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O>
-for TestNoResponseQueryParamsEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0
-            .test_no_response_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for TestNoResponseQueryParamsEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::async_decode_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0
-            .test_no_response_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )
-            .await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
-}
-struct TestBooleanEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestBooleanEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("boolean"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/boolean"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testBoolean"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestBooleanEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_boolean(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestBooleanEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_boolean(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestDoubleEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("double"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/double"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testDouble"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestDoubleEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_double(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestDoubleEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_double(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestIntegerEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestIntegerEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("integer"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/integer"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testInteger"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestIntegerEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_integer(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestIntegerEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_integer(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestPostOptionalEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestPostOptionalEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("optional"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/optional"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testPostOptional"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestPostOptionalEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let maybe_string = conjure_http::private::decode_optional_serializable_request(
-            &parts_,
-            body_,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.test_post_optional(auth_, maybe_string)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestPostOptionalEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let maybe_string = conjure_http::private::async_decode_optional_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.test_post_optional(auth_, maybe_string).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct TestOptionalIntegerAndDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata
-for TestOptionalIntegerAndDoubleEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("optional-integer-double"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/optional-integer-double"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testOptionalIntegerAndDouble"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O>
-for TestOptionalIntegerAndDoubleEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let mut maybe_integer: Option<i32> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeInteger",
-            "maybeInteger",
-            &mut maybe_integer,
-        )?;
-        let mut maybe_double: Option<f64> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeDouble",
-            "maybeDouble",
-            &mut maybe_double,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        self.0.test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for TestOptionalIntegerAndDoubleEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let mut maybe_integer: Option<i32> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeInteger",
-            "maybeInteger",
-            &mut maybe_integer,
-        )?;
-        let mut maybe_double: Option<f64> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeDouble",
-            "maybeDouble",
-            &mut maybe_double,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        self.0
-            .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)
-            .await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
+    ) -> Result<(), conjure_http::private::Error>;
 }

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -501,6 +501,7 @@ impl Config {
                     context.type_name(def.service_name().name()).to_string(),
                     format!("Async{}", def.service_name().name()),
                     format!("{}Endpoints", def.service_name().name()),
+                    format!("Async{}Endpoints", def.service_name().name()),
                 ],
                 contents,
             };

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -216,7 +216,7 @@ fn auth_arg(endpoint: &EndpointDefinition) -> TokenStream {
 fn arg(ctx: &Context, def: &ServiceDefinition, arg: &ArgumentDefinition) -> TokenStream {
     let name = ctx.field_name(arg.arg_name());
 
-    let log_as = if name == &**arg.arg_name() {
+    let log_as = if name == **arg.arg_name() {
         quote!()
     } else {
         let log_as = &**arg.arg_name();

--- a/conjure-codegen/src/servers.rs
+++ b/conjure-codegen/src/servers.rs
@@ -1,8 +1,6 @@
 use crate::context::Context;
-use crate::http_paths::{self, PathSegment};
 use crate::types::{
-    ArgumentDefinition, AuthType, EndpointDefinition, HeaderParameterType, ParameterType,
-    QueryParameterType, ServiceDefinition, Type,
+    ArgumentDefinition, AuthType, EndpointDefinition, ParameterType, ServiceDefinition, Type,
 };
 use heck::ToUpperCamelCase;
 use proc_macro2::{Ident, TokenStream};
@@ -17,18 +15,18 @@ enum Style {
 pub fn generate(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
     let sync_trait = generate_trait(ctx, def, Style::Sync);
     let async_trait = generate_trait(ctx, def, Style::Async);
-    let resource = generate_resource(ctx, def);
 
     quote! {
+        use conjure_http::endpoint;
+
         #sync_trait
         #async_trait
-
-        #resource
     }
 }
 
 fn generate_trait(ctx: &Context, def: &ServiceDefinition, style: Style) -> TokenStream {
     let docs = ctx.docs(def.docs());
+    let service_name = def.service_name().name();
     let name = trait_name(ctx, def, style);
     let params = params(ctx, def);
 
@@ -44,6 +42,7 @@ fn generate_trait(ctx: &Context, def: &ServiceDefinition, style: Style) -> Token
 
     quote! {
         #docs
+        #[conjure_http::conjure_endpoints(name = #service_name)]
         pub trait #name #params {
             #(#binary_types)*
 
@@ -62,10 +61,16 @@ fn trait_name(ctx: &Context, def: &ServiceDefinition, style: Style) -> Ident {
 fn params(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
     let mut params = vec![];
     if service_has_binary_request_body(ctx, def) {
-        params.push(quote!(I));
+        params.push(quote! {
+                #[request_body]
+                I
+        });
     }
     if service_has_binary_response_body(ctx, def) {
-        params.push(quote!(O));
+        params.push(quote! {
+                #[response_writer]
+                O
+        });
     }
 
     if params.is_empty() {
@@ -142,47 +147,161 @@ fn generate_trait_endpoint(
     style: Style,
 ) -> TokenStream {
     let docs = ctx.docs(endpoint.docs());
+    let method = endpoint
+        .http_method()
+        .as_str()
+        .parse::<TokenStream>()
+        .unwrap();
+    let path = &**endpoint.http_path();
+    let endpoint_name = &**endpoint.endpoint_name();
+    let async_ = match style {
+        Style::Async => quote!(async),
+        Style::Sync => quote!(),
+    };
     let name = ctx.field_name(endpoint.endpoint_name());
+    let produces = match endpoint.returns() {
+        Some(ty) => {
+            let produces = produces(ctx, ty);
+            quote!(, produces = #produces)
+        }
+        None => quote!(),
+    };
+
     let auth_arg = auth_arg(endpoint);
     let args = endpoint.args().iter().map(|a| arg(ctx, def, a));
     let request_context_arg = request_context_arg(endpoint);
+
     let result = ctx.result_ident(def.service_name());
+
     let ret_ty = rust_return_type(ctx, def, endpoint, &return_type(ctx, endpoint));
     let ret_ty = quote!(#result<#ret_ty, conjure_http::private::Error>);
-    let ret_ty = match style {
-        Style::Async => quote! {
-            impl conjure_http::private::Future<Output = #ret_ty> + Send
-        },
-        Style::Sync => ret_ty,
-    };
 
     // ignore deprecation since the endpoint has to be implemented regardless
     quote! {
         #docs
-        fn #name(&self #auth_arg #(, #args)* #request_context_arg) -> #ret_ty;
+        #[endpoint(method = #method, path = #path, name = #endpoint_name #produces)]
+        #async_ fn #name(&self #auth_arg #(, #args)* #request_context_arg) -> #ret_ty;
+    }
+}
+
+fn produces(ctx: &Context, ty: &Type) -> TokenStream {
+    match ctx.is_optional(ty) {
+        Some(inner) if ctx.is_binary(inner) => {
+            quote!(conjure_http::server::conjure::OptionalBinaryResponseSerializer)
+        }
+        _ if ctx.is_binary(ty) => quote!(conjure_http::server::conjure::BinaryResponseSerializer),
+        _ if ctx.is_iterable(ty) => {
+            quote!(conjure_http::server::conjure::CollectionResponseSerializer)
+        }
+        _ => quote!(conjure_http::server::StdResponseSerializer),
     }
 }
 
 fn auth_arg(endpoint: &EndpointDefinition) -> TokenStream {
     match endpoint.auth() {
-        Some(_) => quote!(, auth_: conjure_object::BearerToken),
+        Some(auth) => {
+            let params = match auth {
+                AuthType::Header(_) => quote!(),
+                AuthType::Cookie(cookie) => {
+                    let name = &cookie.cookie_name();
+                    quote!((cookie_name = #name))
+                }
+            };
+            quote!(, #[auth #params] auth_: conjure_object::BearerToken)
+        }
         None => quote!(),
     }
 }
 
 fn arg(ctx: &Context, def: &ServiceDefinition, arg: &ArgumentDefinition) -> TokenStream {
     let name = ctx.field_name(arg.arg_name());
+
+    let log_as = if name == &**arg.arg_name() {
+        quote!()
+    } else {
+        let log_as = &**arg.arg_name();
+        quote!(, log_as = #log_as)
+    };
+
+    let safe = if ctx.is_safe_arg(arg) {
+        quote!(, safe)
+    } else {
+        quote!()
+    };
+
+    let attr = match arg.param_type() {
+        ParameterType::Body(_) => {
+            let deserializer = if ctx.is_optional(arg.type_()).is_some() {
+                let mut decoder =
+                    quote!(conjure_http::server::conjure::OptionalRequestDeserializer);
+                let dealiased = ctx.dealiased_type(arg.type_());
+                if dealiased != arg.type_() {
+                    let dealiased = ctx.rust_type(def.service_name(), dealiased);
+                    decoder =
+                        quote!(conjure_http::server::FromRequestDeserializer<#decoder, #dealiased>)
+                }
+                decoder
+            } else if ctx.is_binary(arg.type_()) {
+                quote!(conjure_http::server::conjure::BinaryRequestDeserializer)
+            } else {
+                quote!(conjure_http::server::StdRequestDeserializer)
+            };
+            quote!(#[body(deserializer = #deserializer #log_as #safe)])
+        }
+        ParameterType::Header(header) => {
+            let name = &**header.param_id();
+            let decoder = if ctx.is_optional(arg.type_()).is_some() {
+                optional_decoder(ctx, def, arg.type_())
+            } else {
+                quote!(conjure_http::server::conjure::FromPlainDecoder)
+            };
+            quote!(#[header(name = #name, decoder = #decoder #log_as #safe)])
+        }
+        ParameterType::Path(_) => {
+            let name = &**arg.arg_name();
+            quote! {
+                #[path(
+                    name = #name,
+                    decoder = conjure_http::server::conjure::FromPlainDecoder
+                    #log_as
+                    #safe
+                )]
+            }
+        }
+        ParameterType::Query(query) => {
+            let name = &**query.param_id();
+            let decoder = if ctx.is_optional(arg.type_()).is_some() {
+                optional_decoder(ctx, def, arg.type_())
+            } else if ctx.is_iterable(arg.type_()) {
+                quote!(conjure_http::server::conjure::FromPlainSeqDecoder<_>)
+            } else {
+                quote!(conjure_http::server::conjure::FromPlainDecoder)
+            };
+            quote!(#[query(name = #name, decoder = #decoder #log_as #safe)])
+        }
+    };
+
     let ty = if ctx.is_binary(arg.type_()) {
         quote!(I)
     } else {
         ctx.rust_type(def.service_name(), arg.type_())
     };
-    quote!(#name: #ty)
+    quote!(#attr #name: #ty)
+}
+
+fn optional_decoder(ctx: &Context, def: &ServiceDefinition, ty: &Type) -> TokenStream {
+    let mut decoder = quote!(conjure_http::server::conjure::FromPlainOptionDecoder);
+    let dealiased = ctx.dealiased_type(ty);
+    if dealiased != ty {
+        let dealiased = ctx.rust_type(def.service_name(), dealiased);
+        decoder = quote!(conjure_http::server::FromDecoder<#decoder, #dealiased>)
+    }
+    decoder
 }
 
 fn request_context_arg(endpoint: &EndpointDefinition) -> TokenStream {
     if has_request_context(endpoint) {
-        quote!(, request_context_: conjure_http::server::RequestContext<'_>)
+        quote!(, #[context] request_context_: conjure_http::server::RequestContext<'_>)
     } else {
         quote!()
     }
@@ -227,576 +346,9 @@ enum ReturnType<'a> {
     OptionalBinary,
 }
 
-fn generate_resource(ctx: &Context, def: &ServiceDefinition) -> TokenStream {
-    let name = service_name(ctx, def);
-    let sync_service_impl = generate_service_impl(ctx, def, Style::Sync);
-    let async_service_impl = generate_service_impl(ctx, def, Style::Async);
-
-    let endpoints = def
-        .endpoints()
-        .iter()
-        .map(|e| generate_endpoint(ctx, def, e));
-
-    quote! {
-        pub struct #name<T>(conjure_http::private::Arc<T>);
-
-        impl<T> #name<T> {
-            /// Creates a new resource.
-            pub fn new(handler: T) -> #name<T> {
-                #name(conjure_http::private::Arc::new(handler))
-            }
-        }
-
-        #sync_service_impl
-        #async_service_impl
-        #(#endpoints)*
-    }
-}
-
-fn service_name(ctx: &Context, def: &ServiceDefinition) -> Ident {
-    ctx.type_name(&format!("{}Endpoints", def.service_name().name()))
-}
-
-fn generate_service_impl(ctx: &Context, def: &ServiceDefinition, style: Style) -> TokenStream {
-    let name = service_name(ctx, def);
-    let service_trait_name = match style {
-        Style::Async => quote!(AsyncService),
-        Style::Sync => quote!(Service),
-    };
-    let trait_name = trait_name(ctx, def, style);
-    let params = params(ctx, def);
-    let sync = ctx.sync_ident(def.service_name());
-    let send = ctx.send_ident(def.service_name());
-    let input_trait = input_trait(ctx, def, style);
-    let i_traits = match style {
-        Style::Async => quote!(+ #sync + #send),
-        Style::Sync => quote!(),
-    };
-    let result = ctx.result_ident(def.service_name());
-    let vec = ctx.vec_ident(def.service_name());
-    let endpoint_name = match style {
-        Style::Async => quote!(conjure_http::server::BoxAsyncEndpoint<'_, I, O>),
-        Style::Sync => {
-            let box_ = ctx.box_ident(def.service_name());
-            quote!(#box_<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>)
-        }
-    };
-
-    let endpoint_instances = def
-        .endpoints()
-        .iter()
-        .map(|e| create_endpoint(ctx, def, e, style));
-
-    quote! {
-        impl<T, I, O> conjure_http::server::#service_trait_name<I, O> for #name<T>
-        where
-            T: #trait_name #params + 'static + #sync + #send,
-            I: #input_trait<Item = #result<conjure_http::private::Bytes, conjure_http::private::Error>> #i_traits,
-        {
-            fn endpoints(
-                &self,
-                _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
-            ) -> #vec<#endpoint_name> {
-                vec![
-                    #(#endpoint_instances,)*
-                ]
-            }
-        }
-    }
-}
-
-fn endpoint_trait_name(style: Style) -> TokenStream {
-    match style {
-        Style::Async => quote!(AsyncEndpoint),
-        Style::Sync => quote!(Endpoint),
-    }
-}
-
-fn input_trait(ctx: &Context, def: &ServiceDefinition, style: Style) -> TokenStream {
-    match style {
-        Style::Async => quote!(conjure_http::private::Stream),
-        Style::Sync => ctx.iterator_ident(def.service_name()),
-    }
-}
-
-fn generate_endpoint(
-    ctx: &Context,
-    def: &ServiceDefinition,
-    endpoint: &EndpointDefinition,
-) -> TokenStream {
-    let name = endpoint_name(ctx, endpoint);
-    let endpoint_metadata = generate_endpoint_metadata(ctx, def, endpoint);
-    let endpoint_impl = generate_endpoint_impl(ctx, def, endpoint, Style::Sync);
-    let async_endpoint_impl = generate_endpoint_impl(ctx, def, endpoint, Style::Async);
-
-    quote! {
-        struct #name<T>(conjure_http::private::Arc<T>);
-
-        #endpoint_metadata
-        #endpoint_impl
-        #async_endpoint_impl
-    }
-}
-
-fn generate_endpoint_metadata(
-    ctx: &Context,
-    service: &ServiceDefinition,
-    endpoint: &EndpointDefinition,
-) -> TokenStream {
-    let endpoint_name = endpoint_name(ctx, endpoint);
-
-    let some = ctx.some_ident(service.service_name());
-    let none = ctx.none_ident(service.service_name());
-    let option = ctx.option_ident(service.service_name());
-
-    let method = endpoint
-        .http_method()
-        .as_str()
-        .parse::<TokenStream>()
-        .unwrap();
-
-    let path = http_paths::parse(endpoint.http_path()).map(|segment| match segment {
-        PathSegment::Literal(lit) => quote! {
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed(#lit),
-            )
-        },
-        PathSegment::Parameter { name, regex } => {
-            let regex = match regex {
-                Some(regex) => {
-                    quote!(#some(conjure_http::private::Cow::Borrowed(#regex)))
-                }
-                None => quote!(#none),
-            };
-            quote! {
-                conjure_http::server::PathSegment::Parameter {
-                    name: conjure_http::private::Cow::Borrowed(#name),
-                    regex: #regex,
-                }
-            }
-        }
-    });
-
-    let template = &***endpoint.http_path();
-    let service_name = service.service_name().name();
-    let name = &***endpoint.endpoint_name();
-
-    let deprecated = match endpoint.deprecated() {
-        Some(deprecated) => {
-            let deprecated = &***deprecated;
-            quote!(#some(#deprecated))
-        }
-        None => quote!(#none),
-    };
-
-    quote! {
-        impl<T> conjure_http::server::EndpointMetadata for #endpoint_name<T> {
-            fn method(&self) -> conjure_http::private::Method {
-                conjure_http::private::Method::#method
-            }
-
-            fn path(&self) -> &[conjure_http::server::PathSegment] {
-                &[#(#path,)*]
-            }
-
-            fn template(&self) -> &str {
-                #template
-            }
-
-            fn service_name(&self) -> &str{
-                #service_name
-            }
-
-            fn name(&self) -> &str{
-                #name
-            }
-
-            fn deprecated(&self) -> #option<&str> {
-                #deprecated
-            }
-        }
-    }
-}
-
-fn endpoint_name(ctx: &Context, endpoint: &EndpointDefinition) -> TokenStream {
-    let name = ctx.type_name(endpoint.endpoint_name());
-    format!("{}Endpoint_", name).parse().unwrap()
-}
-
-fn generate_endpoint_impl(
-    ctx: &Context,
-    def: &ServiceDefinition,
-    endpoint: &EndpointDefinition,
-    style: Style,
-) -> TokenStream {
-    let endpoint_name = endpoint_name(ctx, endpoint);
-    let endpoint_trait_name = endpoint_trait_name(style);
-    let trait_name = trait_name(ctx, def, style);
-    let trait_params = params(ctx, def);
-    let sync = ctx.sync_ident(def.service_name());
-    let send = ctx.send_ident(def.service_name());
-    let input_trait = input_trait(ctx, def, style);
-    let result = ctx.result_ident(def.service_name());
-
-    let i_bounds = match style {
-        Style::Async => {
-            quote!(+ #sync + #send)
-        }
-        Style::Sync => quote!(),
-    };
-
-    let asyncness = match style {
-        Style::Async => quote!(async),
-        Style::Sync => quote!(),
-    };
-    let response_body = match style {
-        Style::Async => quote!(conjure_http::server::AsyncResponseBody),
-        Style::Sync => quote!(conjure_http::server::ResponseBody),
-    };
-
-    let parts = quote!(parts_);
-    let body = quote!(body_);
-    let response_extensions = if has_safe_params(ctx, endpoint) || has_request_context(endpoint) {
-        quote!(response_extensions_)
-    } else {
-        quote!(_response_extensions)
-    };
-    let safe_params = quote!(safe_params_);
-    let query_params = quote!(query_params_);
-    let auth = quote!(auth_);
-    let response = quote!(response_);
-
-    let make_query_params = if has_query_params(endpoint) {
-        quote! {
-            let #query_params = conjure_http::private::parse_query_params(&#parts);
-        }
-    } else {
-        quote!()
-    };
-
-    let make_safe_params = if has_safe_params(ctx, endpoint) {
-        quote! {
-            #response_extensions.insert(conjure_http::SafeParams::new());
-            let #safe_params = #response_extensions.get_mut::<conjure_http::SafeParams>().unwrap();
-        }
-    } else {
-        quote!()
-    };
-
-    let consume_empty_body = if has_body_param(endpoint) {
-        quote!()
-    } else {
-        quote! {
-            conjure_http::private::decode_empty_request(&#parts, #body)?;
-        }
-    };
-
-    let args = endpoint.args().iter().map(|arg| {
-        let variable = ctx.field_name(arg.arg_name());
-
-        let parse = match arg.param_type() {
-            ParameterType::Path(_) => parse_path_arg(ctx, arg, &parts),
-            ParameterType::Query(param) => parse_query_arg(ctx, def, arg, param, &query_params),
-            ParameterType::Header(param) => parse_header_arg(ctx, def, arg, param, &parts),
-            ParameterType::Body(_) => parse_body_arg(ctx, arg, &parts, &body, style),
-        };
-
-        let put_safe = if ctx.is_safe_arg(arg) {
-            let name = &***arg.arg_name();
-            quote! {
-                #safe_params.insert(#name, &#variable);
-            }
-        } else {
-            quote!()
-        };
-
-        quote! {
-            #parse
-            #put_safe
-        }
-    });
-
-    let make_auth = match endpoint.auth() {
-        Some(auth_type) => parse_auth(auth_type, &parts, &auth),
-        None => quote!(),
-    };
-
-    let request_context = quote!(request_context_);
-    let make_request_context = if has_request_context(endpoint) {
-        quote! {
-            let #request_context = conjure_http::server::RequestContext::new(
-                #parts,
-                #response_extensions,
-            );
-        }
-    } else {
-        quote!()
-    };
-
-    let assign_response = if endpoint.returns().is_some() {
-        quote!(let #response = )
-    } else {
-        quote!()
-    };
-
-    let handle = handle(ctx, endpoint, &auth, &request_context, style);
-
-    let make_response = make_response(ctx, endpoint, &response, style);
-    let ok = ctx.ok_ident(def.service_name());
-
-    quote! {
-        impl<T, I, O> conjure_http::server::#endpoint_trait_name<I, O> for #endpoint_name<T>
-        where
-            T: #trait_name #trait_params + 'static + #sync + #send,
-            I: #input_trait<Item = #result<conjure_http::private::Bytes, conjure_http::private::Error>> #i_bounds,
-        {
-            #asyncness fn handle(
-                &self,
-                request: conjure_http::private::Request<I>,
-                #response_extensions: &mut conjure_http::private::Extensions,
-            ) -> #result<conjure_http::private::Response<#response_body<O>>, conjure_http::private::Error>
-            {
-                let (#parts, #body) = request.into_parts();
-                #make_query_params
-                #make_safe_params
-                #(#args)*
-                #make_auth
-                #consume_empty_body
-                #make_request_context
-
-                #assign_response #handle?;
-
-                #ok(#make_response)
-            }
-        }
-    }
-}
-
-fn has_safe_params(ctx: &Context, endpoint: &EndpointDefinition) -> bool {
-    endpoint.args().iter().any(|arg| ctx.is_safe_arg(arg))
-}
-
-fn has_query_params(endpoint: &EndpointDefinition) -> bool {
-    endpoint
-        .args()
-        .iter()
-        .any(|arg| matches!(arg.param_type(), ParameterType::Query { .. }))
-}
-
-fn has_body_param(endpoint: &EndpointDefinition) -> bool {
-    endpoint
-        .args()
-        .iter()
-        .any(|arg| matches!(arg.param_type(), ParameterType::Body { .. }))
-}
-
 fn has_request_context(endpoint: &EndpointDefinition) -> bool {
     endpoint
         .tags()
         .iter()
         .any(|t| t == "server-request-context")
-}
-
-fn parse_path_arg(ctx: &Context, arg: &ArgumentDefinition, parts: &TokenStream) -> TokenStream {
-    let name = ctx.field_name(arg.arg_name());
-    let param_name = &***arg.arg_name();
-    quote! {
-        let #name = conjure_http::private::parse_path_param(&#parts, #param_name)?;
-    }
-}
-
-fn parse_query_arg(
-    ctx: &Context,
-    def: &ServiceDefinition,
-    arg: &ArgumentDefinition,
-    param: &QueryParameterType,
-    query_params: &TokenStream,
-) -> TokenStream {
-    let name = ctx.field_name(arg.arg_name());
-    let param_name = &***arg.arg_name();
-    let id = &***param.param_id();
-    let ty = ctx.rust_type(def.service_name(), arg.type_());
-    let default = ctx.default_ident(def.service_name());
-
-    if ctx.is_optional(arg.type_()).is_some() {
-        quote! {
-            let mut #name: #ty = #default::default();
-            conjure_http::private::parse_optional_query_param(&#query_params, #param_name, #id, &mut #name)?;
-        }
-    } else if ctx.is_list(arg.type_()) {
-        quote! {
-            let mut #name: #ty = #default::default();
-            conjure_http::private::parse_list_query_param(&#query_params, #param_name, #id, &mut #name)?;
-        }
-    } else if ctx.is_set(arg.type_()) {
-        quote! {
-            let mut #name: #ty = #default::default();
-            conjure_http::private::parse_set_query_param(&#query_params, #param_name, #id, &mut #name)?;
-        }
-    } else {
-        quote! {
-            let #name = conjure_http::private::parse_query_param(&#query_params, #param_name, #id)?;
-        }
-    }
-}
-
-fn parse_header_arg(
-    ctx: &Context,
-    def: &ServiceDefinition,
-    arg: &ArgumentDefinition,
-    param: &HeaderParameterType,
-    parts: &TokenStream,
-) -> TokenStream {
-    let name = ctx.field_name(arg.arg_name());
-    let id = &***param.param_id();
-
-    let arg_name = &***arg.arg_name();
-
-    if ctx.is_optional(arg.type_()).is_some() {
-        let ty = ctx.rust_type(def.service_name(), arg.type_());
-        let default = ctx.default_ident(def.service_name());
-        quote! {
-            let mut #name: #ty = #default::default();
-            conjure_http::private::parse_optional_header(&#parts, #arg_name, #id, &mut #name)?;
-        }
-    } else {
-        quote! {
-            let #name = conjure_http::private::parse_required_header(&#parts, #arg_name, #id)?;
-        }
-    }
-}
-
-fn parse_body_arg(
-    ctx: &Context,
-    arg: &ArgumentDefinition,
-    parts: &TokenStream,
-    body: &TokenStream,
-    style: Style,
-) -> TokenStream {
-    let name = ctx.field_name(arg.arg_name());
-
-    let call = if ctx.is_optional(arg.type_()).is_some() {
-        match style {
-            Style::Async => {
-                quote!(async_decode_optional_serializable_request(&#parts, #body).await)
-            }
-            Style::Sync => quote!(decode_optional_serializable_request(&#parts, #body)),
-        }
-    } else if ctx.is_binary(arg.type_()) {
-        quote!(decode_binary_request(&#parts, #body))
-    } else {
-        match style {
-            Style::Async => quote!(async_decode_serializable_request(&#parts, #body).await),
-            Style::Sync => quote!(decode_serializable_request(&#parts, #body)),
-        }
-    };
-
-    quote! {
-        let #name = conjure_http::private::#call?;
-    }
-}
-
-fn parse_auth(auth_type: &AuthType, parts: &TokenStream, auth: &TokenStream) -> TokenStream {
-    let parser = match auth_type {
-        AuthType::Cookie(cookie) => {
-            let prefix = format!("{}=", cookie.cookie_name());
-            quote!(parse_cookie_auth(&#parts, #prefix))
-        }
-        AuthType::Header(_) => quote!(parse_header_auth(&#parts)),
-    };
-
-    quote! {
-        let #auth = conjure_http::private::#parser?;
-    }
-}
-
-fn handle(
-    ctx: &Context,
-    endpoint: &EndpointDefinition,
-    auth: &TokenStream,
-    request_context: &TokenStream,
-    style: Style,
-) -> TokenStream {
-    let name = ctx.field_name(endpoint.endpoint_name());
-
-    let mut args = vec![];
-
-    if endpoint.auth().is_some() {
-        args.push(quote!(#auth));
-    }
-
-    args.extend(endpoint.args().iter().map(|a| {
-        let name = ctx.field_name(a.arg_name());
-        quote!(#name)
-    }));
-
-    if has_request_context(endpoint) {
-        args.push(quote!(#request_context));
-    }
-
-    let await_ = match style {
-        Style::Async => quote!(.await),
-        Style::Sync => quote!(),
-    };
-
-    quote! {
-        self.0 .#name(#(#args),*) #await_
-    }
-}
-
-fn make_response(
-    ctx: &Context,
-    endpoint: &EndpointDefinition,
-    response: &TokenStream,
-    style: Style,
-) -> TokenStream {
-    let call = match endpoint.returns() {
-        Some(ty) => match ctx.is_optional(ty) {
-            Some(inner) if ctx.is_binary(inner) => match style {
-                Style::Async => {
-                    quote!(async_encode_optional_binary_response(#response))
-                }
-                Style::Sync => {
-                    quote!(encode_optional_binary_response(#response))
-                }
-            },
-            _ if ctx.is_binary(ty) => match style {
-                Style::Async => quote!(async_encode_binary_response(#response)),
-                Style::Sync => quote!(encode_binary_response(#response)),
-            },
-            _ if ctx.is_iterable(ty) => match style {
-                Style::Async => {
-                    quote!(async_encode_default_serializable_response(&#response))
-                }
-                Style::Sync => quote!(encode_default_serializable_response(&#response)),
-            },
-            _ => match style {
-                Style::Async => quote!(async_encode_serializable_response(&#response)),
-                Style::Sync => quote!(encode_serializable_response(&#response)),
-            },
-        },
-        None => match style {
-            Style::Async => quote!(async_encode_empty_response()),
-            Style::Sync => quote!(encode_empty_response()),
-        },
-    };
-
-    quote!(conjure_http::private::#call)
-}
-
-fn create_endpoint(
-    ctx: &Context,
-    def: &ServiceDefinition,
-    endpoint: &EndpointDefinition,
-    style: Style,
-) -> TokenStream {
-    let wrapper = match style {
-        Style::Async => quote!(conjure_http::server::BoxAsyncEndpoint),
-        Style::Sync => ctx.box_ident(def.service_name()),
-    };
-    let handler = endpoint_name(ctx, endpoint);
-
-    quote! {
-        #wrapper::new(#handler(self.0.clone()))
-    }
 }

--- a/conjure-http/Cargo.toml
+++ b/conjure-http/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/palantir/conjure-rust"
 readme = "../README.md"
 
 [features]
-macros = ["conjure-macros"]
+default = ["macros"]
+macros = ["dep:conjure-macros"]
 
 [dependencies]
 bytes = "1.0"

--- a/conjure-http/src/private/server.rs
+++ b/conjure-http/src/private/server.rs
@@ -1,43 +1,16 @@
-use crate::private::{async_read_body, read_body, APPLICATION_JSON, APPLICATION_OCTET_STREAM};
 use crate::server::{
-    AsyncDeserializeRequest, AsyncResponseBody, AsyncSerializeResponse, AsyncWriteBody,
-    BoxAsyncWriteBody, ConjureRuntime, DecodeHeader, DecodeParam, DeserializeRequest, ResponseBody,
-    SerializeResponse, WriteBody,
+    AsyncDeserializeRequest, AsyncResponseBody, AsyncSerializeResponse, ConjureRuntime,
+    DecodeHeader, DecodeParam, DeserializeRequest, ResponseBody, SerializeResponse,
 };
 use crate::PathParams;
-use bytes::Bytes;
-use conjure_error::{Error, InvalidArgument, PermissionDenied};
-use conjure_object::{BearerToken, FromPlain};
-use conjure_serde::json;
-use futures_core::Stream;
-use http::header::{HeaderName, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, COOKIE};
-use http::{request, HeaderMap};
-use http::{Response, StatusCode};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+use conjure_error::{Error, PermissionDenied};
+use conjure_object::BearerToken;
+use http::header::{HeaderName, AUTHORIZATION, COOKIE};
+use http::{request, HeaderMap, Response};
 use std::borrow::Cow;
-use std::collections::{BTreeSet, HashMap};
-use std::error;
+use std::collections::HashMap;
 
 pub const SERIALIZABLE_REQUEST_SIZE_LIMIT: usize = 50 * 1024 * 1024;
-
-pub fn parse_path_param<T>(parts: &request::Parts, param: &str) -> Result<T, Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    let path_params = parts
-        .extensions
-        .get::<PathParams>()
-        .expect("PathParams missing from request");
-    let value = &path_params[param];
-    let value = percent_encoding::percent_decode_str(value)
-        .decode_utf8()
-        .map_err(|e| {
-            Error::service_safe(e, InvalidArgument::new()).with_safe_param("param", param)
-        })?;
-    from_plain(&value, param)
-}
 
 pub fn path_param<T, D>(
     runtime: &ConjureRuntime,
@@ -58,15 +31,6 @@ where
         .map(percent_encoding::percent_decode_str)
         .map(|v| v.decode_utf8_lossy());
     D::decode(runtime, params).map_err(|e| e.with_safe_param("param", log_as))
-}
-
-fn from_plain<T>(s: &str, param: &str) -> Result<T, Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    T::from_plain(s)
-        .map_err(|e| Error::service_safe(e, InvalidArgument::new()).with_safe_param("param", param))
 }
 
 pub fn parse_query_params(parts: &request::Parts) -> HashMap<Cow<'_, str>, Vec<Cow<'_, str>>> {
@@ -96,104 +60,6 @@ where
     D::decode(runtime, values).map_err(|e| e.with_safe_param("param", log_as))
 }
 
-pub fn parse_query_param<T>(
-    query_params: &HashMap<Cow<'_, str>, Vec<Cow<'_, str>>>,
-    param: &str,
-    param_id: &str,
-) -> Result<T, Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    let values = &query_params[param_id];
-    if values.len() != 1 {
-        return Err(Error::service_safe(
-            "expected exactly 1 query parameter",
-            InvalidArgument::new(),
-        )
-        .with_safe_param("actual", values.len())
-        .with_safe_param("param", param));
-    }
-
-    from_plain(&values[0], param)
-}
-
-pub fn parse_optional_query_param<T>(
-    query_params: &HashMap<Cow<'_, str>, Vec<Cow<'_, str>>>,
-    param: &str,
-    param_id: &str,
-    value: &mut Option<T>,
-) -> Result<(), Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    let values = match query_params.get(param_id) {
-        Some(values) => values,
-        None => return Ok(()),
-    };
-
-    if values.len() != 1 {
-        return Err(Error::service_safe(
-            "expected exactly 1 query parameter",
-            InvalidArgument::new(),
-        )
-        .with_safe_param("actual", values.len())
-        .with_safe_param("param", param));
-    }
-
-    let parsed = from_plain(&values[0], param)?;
-    *value = Some(parsed);
-
-    Ok(())
-}
-
-pub fn parse_list_query_param<T>(
-    query_params: &HashMap<Cow<'_, str>, Vec<Cow<'_, str>>>,
-    param: &str,
-    param_id: &str,
-    value: &mut Vec<T>,
-) -> Result<(), Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    let values = match query_params.get(param_id) {
-        Some(values) => values,
-        None => return Ok(()),
-    };
-
-    for query_param in values {
-        let parsed = from_plain(query_param, param)?;
-        value.push(parsed);
-    }
-
-    Ok(())
-}
-
-pub fn parse_set_query_param<T>(
-    query_params: &HashMap<Cow<'_, str>, Vec<Cow<'_, str>>>,
-    param: &str,
-    param_id: &str,
-    value: &mut BTreeSet<T>,
-) -> Result<(), Error>
-where
-    T: FromPlain + Ord,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    let values = match query_params.get(param_id) {
-        Some(values) => values,
-        None => return Ok(()),
-    };
-
-    for query_param in values {
-        let parsed = from_plain(query_param, param)?;
-        value.insert(parsed);
-    }
-
-    Ok(())
-}
-
 pub fn header_param<T, D>(
     runtime: &ConjureRuntime,
     parts: &request::Parts,
@@ -205,54 +71,6 @@ where
 {
     D::decode(runtime, parts.headers.get_all(header))
         .map_err(|e| e.with_safe_param("param", log_as))
-}
-
-pub fn parse_required_header<T>(
-    parts: &request::Parts,
-    param: &str,
-    param_id: &str,
-) -> Result<T, Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    parts
-        .headers
-        .get(param_id)
-        .ok_or_else(|| {
-            Error::service_safe("required header parameter missing", InvalidArgument::new())
-                .with_safe_param("param", param)
-        })
-        .and_then(|h| parse_header(h, param))
-}
-
-pub fn parse_optional_header<T>(
-    parts: &request::Parts,
-    param: &str,
-    param_id: &str,
-    value: &mut Option<T>,
-) -> Result<(), Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    if let Some(header) = parts.headers.get(param_id) {
-        let header = parse_header(header, param)?;
-        *value = Some(header);
-    }
-
-    Ok(())
-}
-
-fn parse_header<T>(header: &HeaderValue, param: &str) -> Result<T, Error>
-where
-    T: FromPlain,
-    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
-{
-    header
-        .to_str()
-        .map_err(|e| Error::service_safe(e, InvalidArgument::new()).with_safe_param("param", param))
-        .and_then(|h| from_plain(h, param))
 }
 
 pub fn parse_cookie_auth(parts: &request::Parts, prefix: &str) -> Result<BearerToken, Error> {
@@ -317,88 +135,6 @@ where
         .map_err(|e| e.with_safe_param("param", log_as))
 }
 
-pub fn decode_empty_request<I>(_parts: &request::Parts, _body: I) -> Result<(), Error> {
-    // nothing to do, just consume the body
-    Ok(())
-}
-
-pub fn decode_serializable_request<I, T>(parts: &request::Parts, body: I) -> Result<T, Error>
-where
-    I: Iterator<Item = Result<Bytes, Error>>,
-    T: DeserializeOwned,
-{
-    check_deserializable_request_headers(parts)?;
-    let body = read_body(body, Some(SERIALIZABLE_REQUEST_SIZE_LIMIT))?;
-
-    json::server_from_slice(&body).map_err(|e| Error::service(e, InvalidArgument::new()))
-}
-
-pub async fn async_decode_serializable_request<I, T>(
-    parts: &request::Parts,
-    body: I,
-) -> Result<T, Error>
-where
-    I: Stream<Item = Result<Bytes, Error>>,
-    T: DeserializeOwned,
-{
-    check_deserializable_request_headers(parts)?;
-    let body = async_read_body(body, Some(SERIALIZABLE_REQUEST_SIZE_LIMIT)).await?;
-
-    json::server_from_slice(&body).map_err(|e| Error::service(e, InvalidArgument::new()))
-}
-
-fn check_deserializable_request_headers(parts: &request::Parts) -> Result<(), Error> {
-    if parts.headers.get(CONTENT_TYPE) != Some(&APPLICATION_JSON) {
-        return Err(Error::service_safe(
-            "unexpected Content-Type",
-            InvalidArgument::new(),
-        ));
-    }
-
-    Ok(())
-}
-
-pub fn decode_optional_serializable_request<I, T>(
-    parts: &request::Parts,
-    body: I,
-) -> Result<T, Error>
-where
-    I: Iterator<Item = Result<Bytes, Error>>,
-    T: DeserializeOwned + Default,
-{
-    if !parts.headers.contains_key(CONTENT_TYPE) {
-        return Ok(T::default());
-    }
-
-    decode_serializable_request(parts, body)
-}
-
-pub async fn async_decode_optional_serializable_request<I, T>(
-    parts: &request::Parts,
-    body: I,
-) -> Result<T, Error>
-where
-    I: Stream<Item = Result<Bytes, Error>>,
-    T: DeserializeOwned + Default,
-{
-    if !parts.headers.contains_key(CONTENT_TYPE) {
-        return Ok(T::default());
-    }
-
-    async_decode_serializable_request(parts, body).await
-}
-
-pub fn decode_binary_request<I>(parts: &request::Parts, body: I) -> Result<I, Error> {
-    if parts.headers.get(CONTENT_TYPE) != Some(&APPLICATION_OCTET_STREAM) {
-        return Err(Error::service_safe(
-            "unexpected Content-Type",
-            InvalidArgument::new(),
-        ));
-    }
-
-    Ok(body)
-}
-
 pub fn response<S, T, W>(
     runtime: &ConjureRuntime,
     request_headers: &HeaderMap,
@@ -419,120 +155,4 @@ where
     S: AsyncSerializeResponse<T, W>,
 {
     S::serialize(runtime, request_headers, value)
-}
-
-pub fn encode_empty_response<O>() -> Response<ResponseBody<O>> {
-    inner_encode_empty_response(ResponseBody::Empty)
-}
-
-pub fn async_encode_empty_response<O>() -> Response<AsyncResponseBody<O>> {
-    inner_encode_empty_response(AsyncResponseBody::Empty)
-}
-
-fn inner_encode_empty_response<B>(body: B) -> Response<B> {
-    let mut response = Response::new(body);
-    *response.status_mut() = StatusCode::NO_CONTENT;
-
-    response
-}
-
-pub fn encode_serializable_response<T, O>(value: &T) -> Response<ResponseBody<O>>
-where
-    T: Serialize,
-{
-    inner_encode_serializable_response(value, ResponseBody::Fixed)
-}
-
-pub fn async_encode_serializable_response<T, O>(value: &T) -> Response<AsyncResponseBody<O>>
-where
-    T: Serialize,
-{
-    inner_encode_serializable_response(value, AsyncResponseBody::Fixed)
-}
-
-fn inner_encode_serializable_response<T, B, F>(value: &T, make_body: F) -> Response<B>
-where
-    T: Serialize,
-    F: FnOnce(Bytes) -> B,
-{
-    let body = json::to_vec(value).expect("Conjure types can serialize to JSON");
-    let len = body.len();
-
-    let mut response = Response::new(make_body(Bytes::from(body)));
-    response
-        .headers_mut()
-        .insert(CONTENT_TYPE, APPLICATION_JSON);
-    response
-        .headers_mut()
-        .insert(CONTENT_LENGTH, HeaderValue::from(len));
-
-    response
-}
-
-pub fn encode_default_serializable_response<T, O>(value: &T) -> Response<ResponseBody<O>>
-where
-    T: Serialize + Default + PartialEq,
-{
-    if value == &T::default() {
-        encode_empty_response()
-    } else {
-        encode_serializable_response(value)
-    }
-}
-
-pub fn async_encode_default_serializable_response<T, O>(value: &T) -> Response<AsyncResponseBody<O>>
-where
-    T: Serialize + Default + PartialEq,
-{
-    if value == &T::default() {
-        async_encode_empty_response()
-    } else {
-        async_encode_serializable_response(value)
-    }
-}
-
-pub fn encode_binary_response<T, O>(value: T) -> Response<ResponseBody<O>>
-where
-    T: WriteBody<O> + 'static,
-{
-    let mut response = Response::new(ResponseBody::Streaming(Box::new(value)));
-    response
-        .headers_mut()
-        .insert(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
-
-    response
-}
-
-pub fn async_encode_binary_response<T, O>(value: T) -> Response<AsyncResponseBody<O>>
-where
-    T: AsyncWriteBody<O> + 'static + Send,
-{
-    let mut response = Response::new(AsyncResponseBody::Streaming(BoxAsyncWriteBody::new(value)));
-    response
-        .headers_mut()
-        .insert(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
-
-    response
-}
-
-pub fn encode_optional_binary_response<T, O>(value: Option<T>) -> Response<ResponseBody<O>>
-where
-    T: WriteBody<O> + 'static,
-{
-    match value {
-        Some(value) => encode_binary_response(value),
-        None => encode_empty_response(),
-    }
-}
-
-pub fn async_encode_optional_binary_response<T, O>(
-    value: Option<T>,
-) -> Response<AsyncResponseBody<O>>
-where
-    T: AsyncWriteBody<O> + 'static + Send,
-{
-    match value {
-        Some(value) => async_encode_binary_response(value),
-        None => async_encode_empty_response(),
-    }
 }

--- a/conjure-macros/src/endpoints.rs
+++ b/conjure-macros/src/endpoints.rs
@@ -203,7 +203,7 @@ fn generate_endpoint(service: &Service, endpoint: &Endpoint) -> TokenStream {
     quote! {
         struct #name<T> {
             handler: conjure_http::private::Arc<T>,
-            runtime: conjure_http::private::Arc<ConjureRuntime>,
+            runtime: conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
         }
 
         #metadata

--- a/example-api/src/another/mod.rs
+++ b/example-api/src/another/mod.rs
@@ -3,7 +3,7 @@ pub use self::different_package::DifferentPackage;
 #[doc(inline)]
 pub use self::test_service::{
     TestServiceClient, TestServiceAsyncClient, TestService, AsyncTestService,
-    TestServiceEndpoints,
+    TestServiceEndpoints, AsyncTestServiceEndpoints,
 };
 pub mod different_package;
 pub mod test_service;

--- a/example-api/src/another/test_service.rs
+++ b/example-api/src/another/test_service.rs
@@ -1173,8 +1173,10 @@ where
         conjure_http::private::decode_empty_response(response_)
     }
 }
+use conjure_http::endpoint;
 ///A Markdown description of the service.
-pub trait TestService<I, O> {
+#[conjure_http::conjure_endpoints(name = "TestService")]
+pub trait TestService<#[request_body] I, #[response_writer] O> {
     ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     ///The body type returned by the `get_aliased_raw_data` method.
@@ -1182,8 +1184,15 @@ pub trait TestService<I, O> {
     ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     ///Returns a mapping from file system id to backing file system configuration.
+    #[endpoint(
+        method = GET,
+        path = "/catalog/fileSystems",
+        name = "getFileSystems",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_file_systems(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<
         std::collections::BTreeMap<
@@ -1192,118 +1201,367 @@ pub trait TestService<I, O> {
         >,
         conjure_http::private::Error,
     >;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets",
+        name = "createDataset",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn create_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         request: super::super::product::CreateDatasetRequest,
+        #[header(
+            name = "Test-Header",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "testHeaderArg"
+        )]
         test_header_arg: String,
     ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}",
+        name = "getDataset",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<
         Option<super::super::product::datasets::Dataset>,
         conjure_http::private::Error,
     >;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw",
+        name = "getRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
     fn get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Self::GetRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-aliased",
+        name = "getAliasedRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
     fn get_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-maybe",
+        name = "maybeGetRawData",
+        produces = conjure_http::server::conjure::OptionalBinaryResponseSerializer
+    )]
     fn maybe_get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Option<Self::MaybeGetRawDataBody>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/string-aliased",
+        name = "getAliasedString",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn get_aliased_string(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<super::super::product::AliasedString, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw",
+        name = "uploadRawData"
+    )]
     fn upload_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
     ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw-aliased",
+        name = "uploadAliasedRawData"
+    )]
     fn upload_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
     ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches",
+        name = "getBranches",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_branches(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
     ///Gets all branches of this dataset.
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        name = "getBranchesDeprecated",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn get_branches_deprecated(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        name = "resolveBranch",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn resolve_branch(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
+        #[path(
+            name = "branch",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         branch: String,
     ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/testParam",
+        name = "testParam",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn test_param(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-query-params",
+        name = "testQueryParams",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
     ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-no-response-query-params",
+        name = "testNoResponseQueryParams"
+    )]
     fn test_no_response_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
     ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/boolean",
+        name = "testBoolean",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_boolean(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<bool, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/double",
+        name = "testDouble",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<f64, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/integer",
+        name = "testInteger",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
     fn test_integer(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
     ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/optional",
+        name = "testPostOptional",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
     fn test_post_optional(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(
+            deserializer = conjure_http::server::conjure::OptionalRequestDeserializer,
+            log_as = "maybeString"
+        )]
         maybe_string: Option<String>,
     ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/optional-integer-double",
+        name = "testOptionalIntegerAndDouble"
+    )]
     fn test_optional_integer_and_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[query(
+            name = "maybeInteger",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeInteger"
+        )]
         maybe_integer: Option<i32>,
+        #[query(
+            name = "maybeDouble",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeDouble"
+        )]
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error>;
 }
 ///A Markdown description of the service.
-pub trait AsyncTestService<I, O> {
+#[conjure_http::conjure_endpoints(name = "TestService")]
+pub trait AsyncTestService<#[request_body] I, #[response_writer] O> {
     ///The body type returned by the `get_raw_data` method.
     type GetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
     ///The body type returned by the `get_aliased_raw_data` method.
@@ -1311,2093 +1569,378 @@ pub trait AsyncTestService<I, O> {
     ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
     ///Returns a mapping from file system id to backing file system configuration.
-    fn get_file_systems(
+    #[endpoint(
+        method = GET,
+        path = "/catalog/fileSystems",
+        name = "getFileSystems",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_file_systems(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            std::collections::BTreeMap<
-                String,
-                super::super::product::datasets::BackingFileSystem,
-            >,
-            conjure_http::private::Error,
+    ) -> Result<
+        std::collections::BTreeMap<
+            String,
+            super::super::product::datasets::BackingFileSystem,
         >,
-    > + Send;
-    fn create_dataset(
+        conjure_http::private::Error,
+    >;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets",
+        name = "createDataset",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn create_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         request: super::super::product::CreateDatasetRequest,
+        #[header(
+            name = "Test-Header",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "testHeaderArg"
+        )]
         test_header_arg: String,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            super::super::product::datasets::Dataset,
-            conjure_http::private::Error,
-        >,
-    > + Send;
-    fn get_dataset(
+    ) -> Result<super::super::product::datasets::Dataset, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}",
+        name = "getDataset",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_dataset(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            Option<super::super::product::datasets::Dataset>,
-            conjure_http::private::Error,
-        >,
-    > + Send;
-    fn get_raw_data(
+    ) -> Result<
+        Option<super::super::product::datasets::Dataset>,
+        conjure_http::private::Error,
+    >;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw",
+        name = "getRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
+    async fn get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Self::GetRawDataBody, conjure_http::private::Error>,
-    > + Send;
-    fn get_aliased_raw_data(
+    ) -> Result<Self::GetRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-aliased",
+        name = "getAliasedRawData",
+        produces = conjure_http::server::conjure::BinaryResponseSerializer
+    )]
+    async fn get_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>,
-    > + Send;
-    fn maybe_get_raw_data(
+    ) -> Result<Self::GetAliasedRawDataBody, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/raw-maybe",
+        name = "maybeGetRawData",
+        produces = conjure_http::server::conjure::OptionalBinaryResponseSerializer
+    )]
+    async fn maybe_get_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<Self::MaybeGetRawDataBody>, conjure_http::private::Error>,
-    > + Send;
-    fn get_aliased_string(
+    ) -> Result<Option<Self::MaybeGetRawDataBody>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/string-aliased",
+        name = "getAliasedString",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn get_aliased_string(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<
-            super::super::product::AliasedString,
-            conjure_http::private::Error,
-        >,
-    > + Send;
-    fn upload_raw_data(
+    ) -> Result<super::super::product::AliasedString, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw",
+        name = "uploadRawData"
+    )]
+    async fn upload_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-    fn upload_aliased_raw_data(
+    ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/datasets/upload-raw-aliased",
+        name = "uploadAliasedRawData"
+    )]
+    async fn upload_aliased_raw_data(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::conjure::BinaryRequestDeserializer)]
         input: I,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-    fn get_branches(
+    ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches",
+        name = "getBranches",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_branches(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<std::collections::BTreeSet<String>, conjure_http::private::Error>,
-    > + Send;
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
     ///Gets all branches of this dataset.
-    fn get_branches_deprecated(
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branchesDeprecated",
+        name = "getBranchesDeprecated",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn get_branches_deprecated(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<std::collections::BTreeSet<String>, conjure_http::private::Error>,
-    > + Send;
-    fn resolve_branch(
+    ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve",
+        name = "resolveBranch",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn resolve_branch(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
+        #[path(
+            name = "branch",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         branch: String,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<String>, conjure_http::private::Error>,
-    > + Send;
-    fn test_param(
+    ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/datasets/{datasetRid}/testParam",
+        name = "testParam",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn test_param(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[path(
+            name = "datasetRid",
+            decoder = conjure_http::server::conjure::FromPlainDecoder,
+            log_as = "datasetRid"
+        )]
         dataset_rid: conjure_object::ResourceIdentifier,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<String>, conjure_http::private::Error>,
-    > + Send;
-    fn test_query_params(
+    ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-query-params",
+        name = "testQueryParams",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<i32, conjure_http::private::Error>,
-    > + Send;
-    fn test_no_response_query_params(
+    ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/test-no-response-query-params",
+        name = "testNoResponseQueryParams"
+    )]
+    async fn test_no_response_query_params(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(deserializer = conjure_http::server::StdRequestDeserializer)]
         query: String,
+        #[query(
+            name = "different",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         something: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "optionalMiddle",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalMiddle"
+        )]
         optional_middle: Option<conjure_object::ResourceIdentifier>,
+        #[query(
+            name = "implicit",
+            decoder = conjure_http::server::conjure::FromPlainDecoder
+        )]
         implicit: conjure_object::ResourceIdentifier,
+        #[query(
+            name = "setEnd",
+            decoder = conjure_http::server::conjure::FromPlainSeqDecoder<_>,
+            log_as = "setEnd"
+        )]
         set_end: std::collections::BTreeSet<String>,
+        #[query(
+            name = "optionalEnd",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "optionalEnd"
+        )]
         optional_end: Option<conjure_object::ResourceIdentifier>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-    fn test_boolean(
+    ) -> Result<(), conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/boolean",
+        name = "testBoolean",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_boolean(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<bool, conjure_http::private::Error>,
-    > + Send;
-    fn test_double(
+    ) -> Result<bool, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/double",
+        name = "testDouble",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<f64, conjure_http::private::Error>,
-    > + Send;
-    fn test_integer(
+    ) -> Result<f64, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/integer",
+        name = "testInteger",
+        produces = conjure_http::server::StdResponseSerializer
+    )]
+    async fn test_integer(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<i32, conjure_http::private::Error>,
-    > + Send;
-    fn test_post_optional(
+    ) -> Result<i32, conjure_http::private::Error>;
+    #[endpoint(
+        method = POST,
+        path = "/catalog/optional",
+        name = "testPostOptional",
+        produces = conjure_http::server::conjure::CollectionResponseSerializer
+    )]
+    async fn test_post_optional(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[body(
+            deserializer = conjure_http::server::conjure::OptionalRequestDeserializer,
+            log_as = "maybeString"
+        )]
         maybe_string: Option<String>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<Option<String>, conjure_http::private::Error>,
-    > + Send;
-    fn test_optional_integer_and_double(
+    ) -> Result<Option<String>, conjure_http::private::Error>;
+    #[endpoint(
+        method = GET,
+        path = "/catalog/optional-integer-double",
+        name = "testOptionalIntegerAndDouble"
+    )]
+    async fn test_optional_integer_and_double(
         &self,
+        #[auth]
         auth_: conjure_object::BearerToken,
+        #[query(
+            name = "maybeInteger",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeInteger"
+        )]
         maybe_integer: Option<i32>,
+        #[query(
+            name = "maybeDouble",
+            decoder = conjure_http::server::conjure::FromPlainOptionDecoder,
+            log_as = "maybeDouble"
+        )]
         maybe_double: Option<f64>,
-    ) -> impl conjure_http::private::Future<
-        Output = Result<(), conjure_http::private::Error>,
-    > + Send;
-}
-pub struct TestServiceEndpoints<T>(conjure_http::private::Arc<T>);
-impl<T> TestServiceEndpoints<T> {
-    /// Creates a new resource.
-    pub fn new(handler: T) -> TestServiceEndpoints<T> {
-        TestServiceEndpoints(conjure_http::private::Arc::new(handler))
-    }
-}
-impl<T, I, O> conjure_http::server::Service<I, O> for TestServiceEndpoints<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn endpoints(
-        &self,
-        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
-    ) -> Vec<Box<dyn conjure_http::server::Endpoint<I, O> + Sync + Send>> {
-        vec![
-            Box::new(GetFileSystemsEndpoint_(self.0.clone())),
-            Box::new(CreateDatasetEndpoint_(self.0.clone())),
-            Box::new(GetDatasetEndpoint_(self.0.clone())),
-            Box::new(GetRawDataEndpoint_(self.0.clone())),
-            Box::new(GetAliasedRawDataEndpoint_(self.0.clone())),
-            Box::new(MaybeGetRawDataEndpoint_(self.0.clone())),
-            Box::new(GetAliasedStringEndpoint_(self.0.clone())),
-            Box::new(UploadRawDataEndpoint_(self.0.clone())),
-            Box::new(UploadAliasedRawDataEndpoint_(self.0.clone())),
-            Box::new(GetBranchesEndpoint_(self.0.clone())),
-            Box::new(GetBranchesDeprecatedEndpoint_(self.0.clone())),
-            Box::new(ResolveBranchEndpoint_(self.0.clone())),
-            Box::new(TestParamEndpoint_(self.0.clone())),
-            Box::new(TestQueryParamsEndpoint_(self.0.clone())),
-            Box::new(TestNoResponseQueryParamsEndpoint_(self.0.clone())),
-            Box::new(TestBooleanEndpoint_(self.0.clone())),
-            Box::new(TestDoubleEndpoint_(self.0.clone())),
-            Box::new(TestIntegerEndpoint_(self.0.clone())),
-            Box::new(TestPostOptionalEndpoint_(self.0.clone())),
-            Box::new(TestOptionalIntegerAndDoubleEndpoint_(self.0.clone())),
-        ]
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncService<I, O> for TestServiceEndpoints<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    fn endpoints(
-        &self,
-        _: &conjure_http::private::Arc<conjure_http::server::ConjureRuntime>,
-    ) -> Vec<conjure_http::server::BoxAsyncEndpoint<'_, I, O>> {
-        vec![
-            conjure_http::server::BoxAsyncEndpoint::new(GetFileSystemsEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(CreateDatasetEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetDatasetEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetAliasedRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(MaybeGetRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetAliasedStringEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(UploadRawDataEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(UploadAliasedRawDataEndpoint_(self
-            .0.clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetBranchesEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(GetBranchesDeprecatedEndpoint_(self
-            .0.clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(ResolveBranchEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestParamEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestQueryParamsEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestNoResponseQueryParamsEndpoint_(self
-            .0.clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestBooleanEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestDoubleEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestIntegerEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestPostOptionalEndpoint_(self.0
-            .clone())),
-            conjure_http::server::BoxAsyncEndpoint::new(TestOptionalIntegerAndDoubleEndpoint_(self
-            .0.clone())),
-        ]
-    }
-}
-struct GetFileSystemsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetFileSystemsEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("fileSystems"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/fileSystems"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getFileSystems"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetFileSystemsEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_file_systems(auth_)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetFileSystemsEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_file_systems(auth_).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct CreateDatasetEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for CreateDatasetEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "createDataset"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for CreateDatasetEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let request = conjure_http::private::decode_serializable_request(
-            &parts_,
-            body_,
-        )?;
-        let test_header_arg = conjure_http::private::parse_required_header(
-            &parts_,
-            "testHeaderArg",
-            "Test-Header",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.create_dataset(auth_, request, test_header_arg)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for CreateDatasetEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let request = conjure_http::private::async_decode_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let test_header_arg = conjure_http::private::parse_required_header(
-            &parts_,
-            "testHeaderArg",
-            "Test-Header",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.create_dataset(auth_, request, test_header_arg).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct GetDatasetEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetDatasetEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getDataset"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetDatasetEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_dataset(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetDatasetEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_dataset(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct GetRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("raw"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/raw"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_binary_response(response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(response_))
-    }
-}
-struct GetAliasedRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetAliasedRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("raw-aliased"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/raw-aliased"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getAliasedRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_binary_response(response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetAliasedRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_binary_response(response_))
-    }
-}
-struct MaybeGetRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for MaybeGetRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("raw-maybe"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/raw-maybe"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "maybeGetRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for MaybeGetRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_optional_binary_response(response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for MaybeGetRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.maybe_get_raw_data(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_optional_binary_response(response_))
-    }
-}
-struct GetAliasedStringEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetAliasedStringEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("string-aliased"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/string-aliased"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getAliasedString"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetAliasedStringEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_string(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetAliasedStringEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_aliased_string(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct UploadRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for UploadRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("upload-raw"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/upload-raw"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "uploadRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_raw_data(auth_, input)?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for UploadRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_raw_data(auth_, input).await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
-}
-struct UploadAliasedRawDataEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for UploadAliasedRawDataEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("upload-raw-aliased"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/upload-raw-aliased"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "uploadAliasedRawData"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for UploadAliasedRawDataEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_aliased_raw_data(auth_, input)?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for UploadAliasedRawDataEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let input = conjure_http::private::decode_binary_request(&parts_, body_)?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0.upload_aliased_raw_data(auth_, input).await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
-}
-struct GetBranchesEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetBranchesEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("branches"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/branches"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getBranches"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for GetBranchesEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct GetBranchesDeprecatedEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for GetBranchesDeprecatedEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("branchesDeprecated"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/branchesDeprecated"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "getBranchesDeprecated"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        Some("use getBranches instead")
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for GetBranchesDeprecatedEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches_deprecated(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for GetBranchesDeprecatedEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.get_branches_deprecated(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct ResolveBranchEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for ResolveBranchEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("branches"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("branch"),
-                regex: Some(conjure_http::private::Cow::Borrowed(".+")),
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("resolve"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/branches/{branch:.+}/resolve"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "resolveBranch"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for ResolveBranchEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.resolve_branch(auth_, dataset_rid, branch)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for ResolveBranchEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let branch = conjure_http::private::parse_path_param(&parts_, "branch")?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.resolve_branch(auth_, dataset_rid, branch).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct TestParamEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestParamEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("datasets"),
-            ),
-            conjure_http::server::PathSegment::Parameter {
-                name: conjure_http::private::Cow::Borrowed("datasetRid"),
-                regex: None,
-            },
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("testParam"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/datasets/{datasetRid}/testParam"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testParam"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestParamEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_param(auth_, dataset_rid)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestParamEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let dataset_rid = conjure_http::private::parse_path_param(
-            &parts_,
-            "datasetRid",
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_param(auth_, dataset_rid).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct TestQueryParamsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestQueryParamsEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("test-query-params"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/test-query-params"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testQueryParams"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestQueryParamsEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self
-            .0
-            .test_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestQueryParamsEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::async_decode_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self
-            .0
-            .test_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )
-            .await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestNoResponseQueryParamsEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata
-for TestNoResponseQueryParamsEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("test-no-response-query-params"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/test-no-response-query-params"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testNoResponseQueryParams"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O>
-for TestNoResponseQueryParamsEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::decode_serializable_request(&parts_, body_)?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0
-            .test_no_response_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for TestNoResponseQueryParamsEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let query = conjure_http::private::async_decode_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let something = conjure_http::private::parse_query_param(
-            &query_params_,
-            "something",
-            "different",
-        )?;
-        let mut optional_middle: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalMiddle",
-            "optionalMiddle",
-            &mut optional_middle,
-        )?;
-        let implicit = conjure_http::private::parse_query_param(
-            &query_params_,
-            "implicit",
-            "implicit",
-        )?;
-        let mut set_end: std::collections::BTreeSet<String> = Default::default();
-        conjure_http::private::parse_set_query_param(
-            &query_params_,
-            "setEnd",
-            "setEnd",
-            &mut set_end,
-        )?;
-        let mut optional_end: Option<conjure_object::ResourceIdentifier> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "optionalEnd",
-            "optionalEnd",
-            &mut optional_end,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        self.0
-            .test_no_response_query_params(
-                auth_,
-                query,
-                something,
-                optional_middle,
-                implicit,
-                set_end,
-                optional_end,
-            )
-            .await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
-}
-struct TestBooleanEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestBooleanEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("boolean"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/boolean"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testBoolean"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestBooleanEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_boolean(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestBooleanEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_boolean(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestDoubleEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("double"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/double"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testDouble"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestDoubleEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_double(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestDoubleEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_double(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestIntegerEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestIntegerEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("integer"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/integer"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testInteger"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestIntegerEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_integer(auth_)?;
-        Ok(conjure_http::private::encode_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestIntegerEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        let response_ = self.0.test_integer(auth_).await?;
-        Ok(conjure_http::private::async_encode_serializable_response(&response_))
-    }
-}
-struct TestPostOptionalEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata for TestPostOptionalEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::POST
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("optional"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/optional"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testPostOptional"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O> for TestPostOptionalEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let maybe_string = conjure_http::private::decode_optional_serializable_request(
-            &parts_,
-            body_,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.test_post_optional(auth_, maybe_string)?;
-        Ok(conjure_http::private::encode_default_serializable_response(&response_))
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O> for TestPostOptionalEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let maybe_string = conjure_http::private::async_decode_optional_serializable_request(
-                &parts_,
-                body_,
-            )
-            .await?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        let response_ = self.0.test_post_optional(auth_, maybe_string).await?;
-        Ok(conjure_http::private::async_encode_default_serializable_response(&response_))
-    }
-}
-struct TestOptionalIntegerAndDoubleEndpoint_<T>(conjure_http::private::Arc<T>);
-impl<T> conjure_http::server::EndpointMetadata
-for TestOptionalIntegerAndDoubleEndpoint_<T> {
-    fn method(&self) -> conjure_http::private::Method {
-        conjure_http::private::Method::GET
-    }
-    fn path(&self) -> &[conjure_http::server::PathSegment] {
-        &[
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("catalog"),
-            ),
-            conjure_http::server::PathSegment::Literal(
-                conjure_http::private::Cow::Borrowed("optional-integer-double"),
-            ),
-        ]
-    }
-    fn template(&self) -> &str {
-        "/catalog/optional-integer-double"
-    }
-    fn service_name(&self) -> &str {
-        "TestService"
-    }
-    fn name(&self) -> &str {
-        "testOptionalIntegerAndDouble"
-    }
-    fn deprecated(&self) -> Option<&str> {
-        None
-    }
-}
-impl<T, I, O> conjure_http::server::Endpoint<I, O>
-for TestOptionalIntegerAndDoubleEndpoint_<T>
-where
-    T: TestService<I, O> + 'static + Sync + Send,
-    I: Iterator<
-        Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-    >,
-{
-    fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::ResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let mut maybe_integer: Option<i32> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeInteger",
-            "maybeInteger",
-            &mut maybe_integer,
-        )?;
-        let mut maybe_double: Option<f64> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeDouble",
-            "maybeDouble",
-            &mut maybe_double,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        self.0.test_optional_integer_and_double(auth_, maybe_integer, maybe_double)?;
-        Ok(conjure_http::private::encode_empty_response())
-    }
-}
-impl<T, I, O> conjure_http::server::AsyncEndpoint<I, O>
-for TestOptionalIntegerAndDoubleEndpoint_<T>
-where
-    T: AsyncTestService<I, O> + 'static + Sync + Send,
-    I: conjure_http::private::Stream<
-            Item = Result<conjure_http::private::Bytes, conjure_http::private::Error>,
-        > + Sync + Send,
-{
-    async fn handle(
-        &self,
-        request: conjure_http::private::Request<I>,
-        _response_extensions: &mut conjure_http::private::Extensions,
-    ) -> Result<
-        conjure_http::private::Response<conjure_http::server::AsyncResponseBody<O>>,
-        conjure_http::private::Error,
-    > {
-        let (parts_, body_) = request.into_parts();
-        let query_params_ = conjure_http::private::parse_query_params(&parts_);
-        let mut maybe_integer: Option<i32> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeInteger",
-            "maybeInteger",
-            &mut maybe_integer,
-        )?;
-        let mut maybe_double: Option<f64> = Default::default();
-        conjure_http::private::parse_optional_query_param(
-            &query_params_,
-            "maybeDouble",
-            "maybeDouble",
-            &mut maybe_double,
-        )?;
-        let auth_ = conjure_http::private::parse_header_auth(&parts_)?;
-        conjure_http::private::decode_empty_request(&parts_, body_)?;
-        self.0
-            .test_optional_integer_and_double(auth_, maybe_integer, maybe_double)
-            .await?;
-        Ok(conjure_http::private::async_encode_empty_response())
-    }
+    ) -> Result<(), conjure_http::private::Error>;
 }


### PR DESCRIPTION
The only user-visible change here should be that there are now separate `MyServiceEndpoints` and `AsyncMyServiceEndpoints` structs rather than just a single `MyServiceEndpoints` that handled both cases.