### PR TITLE
Fix codegen for aliases of map<double, T> and set<double>

### DIFF
--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -278,12 +278,12 @@ impl Context {
         match def {
             Type::Primitive(_) | Type::Optional(_) => None,
             Type::Map(def) => {
-                let key = self.rust_type(this_type, def.key_type());
+                let key = self.rust_type_inner(this_type, def.key_type(), true);
                 let value = self.rust_type(this_type, def.value_type());
                 Some(quote!((#key, #value)))
             }
             Type::List(def) => Some(self.rust_type(this_type, def.item_type())),
-            Type::Set(def) => Some(self.rust_type(this_type, def.item_type())),
+            Type::Set(def) => Some(self.rust_type_inner(this_type, def.item_type(), true)),
             Type::Reference(def) => self.ref_is_from_iter(this_type, def),
             Type::External(def) => self.is_from_iter(this_type, def.fallback()),
         }

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "conjure-test"
 version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 doctest = false

--- a/conjure-test/src/test/objects.rs
+++ b/conjure-test/src/test/objects.rs
@@ -510,3 +510,17 @@ fn map_double_values() {
         .build();
     test_serde(&value, json);
 }
+
+#[test]
+fn double_alias_fromiter() {
+    let actual = [(DoubleKey(1.0), "1".to_string())]
+        .into_iter()
+        .collect::<MapDoubleAlias>();
+    assert_eq!(
+        actual,
+        MapDoubleAlias(BTreeMap::from([(DoubleKey(1.0), "1".to_string())])),
+    );
+
+    let actual = [DoubleKey(1.0)].into_iter().collect::<SetDoubleAlias>();
+    assert_eq!(actual, SetDoubleAlias(BTreeSet::from([DoubleKey(1.0)])));
+}

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -476,6 +476,27 @@
       }
     }
   }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "MapDoubleAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "map",
+        "map" : {
+          "keyType" : {
+            "type" : "primitive",
+            "primitive" : "DOUBLE"
+          },
+          "valueType" : {
+            "type" : "primitive",
+            "primitive" : "STRING"
+          }
+        }
+      }
+    }
+  }, {
     "type" : "object",
     "object" : {
       "typeName" : {
@@ -862,6 +883,23 @@
         "reference" : {
           "name" : "SetAlias",
           "package" : "com.palantir.conjure"
+        }
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "SetDoubleAlias",
+        "package" : "com.palantir.conjure"
+      },
+      "alias" : {
+        "type" : "set",
+        "set" : {
+          "itemType" : {
+            "type" : "primitive",
+            "primitive" : "DOUBLE"
+          }
         }
       }
     }

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -154,6 +154,10 @@ types:
           raw: map<string, double>
           optional: map<string, optional<double>>
           list: map<string, list<double>>
+      MapDoubleAlias:
+        alias: map<double, string>
+      SetDoubleAlias:
+        alias: set<double>
     errors:
       SimpleError:
         namespace: Test


### PR DESCRIPTION
## Before this PR
We generated a FromIter implementation that expected `f64` instead of `DoubleKey`:

```
error[E0277]: a value of type `BTreeMap<DoubleKey, bool>` cannot be built from an iterator over elements of type `(f64, bool)`
  --> /home/sfackler/code/conjure-rust-runtime/target/debug/build/conjure-verification-api-737942bf71306d38/out/conjure/types/map_double_alias_example.rs:11:31
   |
11 |         MapDoubleAliasExample(std::iter::FromIterator::from_iter(iter))
   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ value of type `BTreeMap<DoubleKey, bool>` cannot be built from `std::iter::Iterator<Item=(f64, bool)>`
   |
   = help: the trait `FromIterator<(f64, bool)>` is not implemented for `BTreeMap<DoubleKey, bool>`
   = help: the trait `FromIterator<(DoubleKey, bool)>` is implemented for `BTreeMap<DoubleKey, bool>`
   = help: for that trait implementation, expected `DoubleKey`, found `f64`
```

## After this PR
Fixed codegen for aliases of `map<double, T>` and `set<double>`.

The bad codegen hasn't hit a release, so no changelog is needed.

