### PR TITLE
Use `bytes::Bytes` for `binary`

### DIFF
--- a/changelog/@unreleased/pr-345.v2.yml
+++ b/changelog/@unreleased/pr-345.v2.yml
@@ -1,0 +1,5 @@
+type: break
+break:
+  description: The Conjure `binary` type is now backed by `bytes::Bytes`.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/345

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -331,7 +331,7 @@ impl Context {
                     }
                 }
                 PrimitiveType::Safelong => quote!(conjure_object::SafeLong),
-                PrimitiveType::Binary => quote!(conjure_object::ByteBuf),
+                PrimitiveType::Binary => quote!(conjure_object::Bytes),
                 PrimitiveType::Any => quote!(conjure_object::Any),
                 PrimitiveType::Boolean => quote!(bool),
                 PrimitiveType::Uuid => quote!(conjure_object::Uuid),
@@ -414,7 +414,7 @@ impl Context {
                 PrimitiveType::Integer => quote!(i32),
                 PrimitiveType::Double => quote!(f64),
                 PrimitiveType::Safelong => quote!(conjure_object::SafeLong),
-                PrimitiveType::Binary => quote!(&[u8]),
+                PrimitiveType::Binary => quote!(&conjure_object::Bytes),
                 PrimitiveType::Any => quote!(&conjure_object::Any),
                 PrimitiveType::Boolean => quote!(bool),
                 PrimitiveType::Uuid => quote!(conjure_object::Uuid),
@@ -466,8 +466,10 @@ impl Context {
         match def {
             Type::Primitive(def) => match *def {
                 PrimitiveType::String => quote!(&*#value),
-                PrimitiveType::Binary => quote!(&**#value),
-                PrimitiveType::Any | PrimitiveType::Rid | PrimitiveType::Bearertoken => {
+                PrimitiveType::Any
+                | PrimitiveType::Rid
+                | PrimitiveType::Bearertoken
+                | PrimitiveType::Binary => {
                     quote!(&#value)
                 }
                 PrimitiveType::Datetime
@@ -524,10 +526,9 @@ impl Context {
                 }
                 PrimitiveType::Binary => {
                     let into = self.into_ident(this_type);
-                    let vec = self.vec_ident(this_type);
                     SetterBounds::Generic {
-                        argument_bound: quote!(#into<#vec<u8>>),
-                        assign_rhs: quote!(conjure_object::ByteBuf::from(#value_ident)),
+                        argument_bound: quote!(#into<conjure_object::Bytes>),
+                        assign_rhs: quote!(#value_ident.into()),
                     }
                 }
                 PrimitiveType::Any => SetterBounds::Generic {
@@ -645,10 +646,9 @@ impl Context {
                 }
                 PrimitiveType::Binary => {
                     let into = self.into_ident(this_type);
-                    let vec = self.vec_ident(this_type);
                     CollectionSetterBounds::Generic {
-                        argument_bound: quote!(#into<#vec<u8>>),
-                        assign_rhs: quote!(conjure_object::ByteBuf::from(#value_ident)),
+                        argument_bound: quote!(#into<conjure_object::Bytes>),
+                        assign_rhs: quote!(#value_ident.into()),
                     }
                 }
                 PrimitiveType::Any => CollectionSetterBounds::Generic {

--- a/conjure-codegen/src/example_types/product/aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/aliased_binary.rs
@@ -1,34 +1,34 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct AliasedBinary(pub conjure_object::ByteBuf);
+pub struct AliasedBinary(pub conjure_object::Bytes);
 impl conjure_object::Plain for AliasedBinary {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         conjure_object::Plain::fmt(&self.0, fmt)
     }
 }
 impl conjure_object::FromPlain for AliasedBinary {
-    type Err = <conjure_object::ByteBuf as conjure_object::FromPlain>::Err;
+    type Err = <conjure_object::Bytes as conjure_object::FromPlain>::Err;
     #[inline]
     fn from_plain(s: &str) -> Result<AliasedBinary, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(AliasedBinary)
     }
 }
-impl std::convert::From<conjure_object::ByteBuf> for AliasedBinary {
+impl std::convert::From<conjure_object::Bytes> for AliasedBinary {
     #[inline]
-    fn from(v: conjure_object::ByteBuf) -> Self {
+    fn from(v: conjure_object::Bytes) -> Self {
         AliasedBinary(std::convert::From::from(v))
     }
 }
 impl std::ops::Deref for AliasedBinary {
-    type Target = conjure_object::ByteBuf;
+    type Target = conjure_object::Bytes;
     #[inline]
-    fn deref(&self) -> &conjure_object::ByteBuf {
+    fn deref(&self) -> &conjure_object::Bytes {
         &self.0
     }
 }
 impl std::ops::DerefMut for AliasedBinary {
     #[inline]
-    fn deref_mut(&mut self) -> &mut conjure_object::ByteBuf {
+    fn deref_mut(&mut self) -> &mut conjure_object::Bytes {
         &mut self.0
     }
 }

--- a/conjure-codegen/src/example_types/product/any_example.rs
+++ b/conjure-codegen/src/example_types/product/any_example.rs
@@ -39,8 +39,7 @@ impl Builder {
     where
         T: conjure_object::serde::Serialize,
     {
-        self
-            .any = Some(
+        self.any = Some(
             conjure_object::Any::new(any).expect("value failed to serialize"),
         );
         self

--- a/conjure-codegen/src/example_types/product/binary_alias_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_alias_example.rs
@@ -1,34 +1,34 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct BinaryAliasExample(pub conjure_object::ByteBuf);
+pub struct BinaryAliasExample(pub conjure_object::Bytes);
 impl conjure_object::Plain for BinaryAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         conjure_object::Plain::fmt(&self.0, fmt)
     }
 }
 impl conjure_object::FromPlain for BinaryAliasExample {
-    type Err = <conjure_object::ByteBuf as conjure_object::FromPlain>::Err;
+    type Err = <conjure_object::Bytes as conjure_object::FromPlain>::Err;
     #[inline]
     fn from_plain(s: &str) -> Result<BinaryAliasExample, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(BinaryAliasExample)
     }
 }
-impl std::convert::From<conjure_object::ByteBuf> for BinaryAliasExample {
+impl std::convert::From<conjure_object::Bytes> for BinaryAliasExample {
     #[inline]
-    fn from(v: conjure_object::ByteBuf) -> Self {
+    fn from(v: conjure_object::Bytes) -> Self {
         BinaryAliasExample(std::convert::From::from(v))
     }
 }
 impl std::ops::Deref for BinaryAliasExample {
-    type Target = conjure_object::ByteBuf;
+    type Target = conjure_object::Bytes;
     #[inline]
-    fn deref(&self) -> &conjure_object::ByteBuf {
+    fn deref(&self) -> &conjure_object::Bytes {
         &self.0
     }
 }
 impl std::ops::DerefMut for BinaryAliasExample {
     #[inline]
-    fn deref_mut(&mut self) -> &mut conjure_object::ByteBuf {
+    fn deref_mut(&mut self) -> &mut conjure_object::Bytes {
         &mut self.0
     }
 }

--- a/conjure-codegen/src/example_types/product/binary_example.rs
+++ b/conjure-codegen/src/example_types/product/binary_example.rs
@@ -3,17 +3,17 @@ use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BinaryExample {
-    binary: conjure_object::ByteBuf,
+    binary: conjure_object::Bytes,
 }
 impl BinaryExample {
     /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(binary: T) -> BinaryExample
     where
-        T: Into<Vec<u8>>,
+        T: Into<conjure_object::Bytes>,
     {
         BinaryExample {
-            binary: conjure_object::ByteBuf::from(binary),
+            binary: binary.into(),
         }
     }
     /// Returns a new builder.
@@ -22,14 +22,14 @@ impl BinaryExample {
         Default::default()
     }
     #[inline]
-    pub fn binary(&self) -> &[u8] {
-        &**self.binary
+    pub fn binary(&self) -> &conjure_object::Bytes {
+        &self.binary
     }
 }
 ///A builder for the `BinaryExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
-    binary: Option<conjure_object::ByteBuf>,
+    binary: Option<conjure_object::Bytes>,
 }
 impl Builder {
     ///
@@ -37,9 +37,9 @@ impl Builder {
     #[inline]
     pub fn binary<T>(&mut self, binary: T) -> &mut Self
     where
-        T: Into<Vec<u8>>,
+        T: Into<conjure_object::Bytes>,
     {
-        self.binary = Some(conjure_object::ByteBuf::from(binary));
+        self.binary = Some(binary.into());
         self
     }
     /// Constructs a new instance of the type.

--- a/conjure-codegen/src/example_types/product/invalid_service_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_service_definition.rs
@@ -63,8 +63,7 @@ impl Builder {
     where
         T: conjure_object::serde::Serialize,
     {
-        self
-            .service_def = Some(
+        self.service_def = Some(
             conjure_object::Any::new(service_def).expect("value failed to serialize"),
         );
         self

--- a/conjure-codegen/src/example_types/product/invalid_type_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_type_definition.rs
@@ -59,8 +59,7 @@ impl Builder {
     where
         T: conjure_object::serde::Serialize,
     {
-        self
-            .type_def = Some(
+        self.type_def = Some(
             conjure_object::Any::new(type_def).expect("value failed to serialize"),
         );
         self

--- a/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
+++ b/conjure-codegen/src/example_types/product/nested_aliased_binary.rs
@@ -13,9 +13,9 @@ impl conjure_object::FromPlain for NestedAliasedBinary {
         conjure_object::FromPlain::from_plain(s).map(NestedAliasedBinary)
     }
 }
-impl std::convert::From<conjure_object::ByteBuf> for NestedAliasedBinary {
+impl std::convert::From<conjure_object::Bytes> for NestedAliasedBinary {
     #[inline]
-    fn from(v: conjure_object::ByteBuf) -> Self {
+    fn from(v: conjure_object::Bytes) -> Self {
         NestedAliasedBinary(std::convert::From::from(v))
     }
 }

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -57,7 +57,7 @@
 //! | `integer`     | `i32`                                |
 //! | `double`      | `f64`                                |
 //! | `safelong`    | `conjure_object::SafeLong`           |
-//! | `binary`      | `serde_bytes::ByteBuf`               |
+//! | `binary`      | `bytes::Bytes`                       |
 //! | `any`         | `conjure_object::Any`                |
 //! | `boolean`     | `bool`                               |
 //! | `uuid`        | `uuid::Uuid`                         |

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/palantir/conjure-rust"
 readme = "../README.md"
 
 [dependencies]
+bytes = { version = "1.0", features = ["serde"] }
 base64 = "0.22"
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"] }
 educe = { version = "0.5", default-features = false, features = [
@@ -22,7 +23,6 @@ lazy_static = "1.0"
 ordered-float = { version = "4", features = ["serde"] }
 regex = { version = "1.3", default-features = false, features = ["std"] }
 serde = "1.0"
-serde_bytes = "0.11"
 uuid = { version = "1.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/conjure-object/src/lib.rs
+++ b/conjure-object/src/lib.rs
@@ -18,9 +18,9 @@
 //! This crate consists of reexports and definitions of the Rust types that correspond to Conjure types. It is a
 //! required dependency of crates which contain Conjure-generated code.
 
+pub use bytes::{self, Bytes};
 pub use chrono::{self, DateTime, Utc};
 pub use serde;
-pub use serde_bytes::{self, ByteBuf};
 pub use uuid::{self, Uuid};
 
 #[doc(inline)]

--- a/conjure-object/src/plain.rs
+++ b/conjure-object/src/plain.rs
@@ -17,9 +17,9 @@
 use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 use base64::{DecodeError, Engine};
+use bytes::Bytes;
 use chrono::format::{Fixed, Item, ParseError};
 use chrono::{DateTime, Utc};
-use serde_bytes::ByteBuf;
 use std::error::Error;
 use std::f64;
 use std::fmt;
@@ -97,13 +97,7 @@ impl Plain for [u8] {
     }
 }
 
-impl Plain for Vec<u8> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Plain::fmt(&**self, fmt)
-    }
-}
-
-impl Plain for ByteBuf {
+impl Plain for Bytes {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         Plain::fmt(&**self, fmt)
     }
@@ -167,13 +161,13 @@ as_from_str!(SafeLong);
 as_from_str!(String);
 as_from_str!(Uuid);
 
-impl FromPlain for ByteBuf {
+impl FromPlain for Bytes {
     type Err = ParseBinaryError;
 
     #[inline]
-    fn from_plain(s: &str) -> Result<ByteBuf, ParseBinaryError> {
+    fn from_plain(s: &str) -> Result<Self, ParseBinaryError> {
         let buf = STANDARD.decode(s).map_err(ParseBinaryError)?;
-        Ok(ByteBuf::from(buf))
+        Ok(Bytes::from(buf))
     }
 }
 

--- a/example-api/src/product/aliased_binary.rs
+++ b/example-api/src/product/aliased_binary.rs
@@ -1,34 +1,34 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct AliasedBinary(pub conjure_object::ByteBuf);
+pub struct AliasedBinary(pub conjure_object::Bytes);
 impl conjure_object::Plain for AliasedBinary {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         conjure_object::Plain::fmt(&self.0, fmt)
     }
 }
 impl conjure_object::FromPlain for AliasedBinary {
-    type Err = <conjure_object::ByteBuf as conjure_object::FromPlain>::Err;
+    type Err = <conjure_object::Bytes as conjure_object::FromPlain>::Err;
     #[inline]
     fn from_plain(s: &str) -> Result<AliasedBinary, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(AliasedBinary)
     }
 }
-impl std::convert::From<conjure_object::ByteBuf> for AliasedBinary {
+impl std::convert::From<conjure_object::Bytes> for AliasedBinary {
     #[inline]
-    fn from(v: conjure_object::ByteBuf) -> Self {
+    fn from(v: conjure_object::Bytes) -> Self {
         AliasedBinary(std::convert::From::from(v))
     }
 }
 impl std::ops::Deref for AliasedBinary {
-    type Target = conjure_object::ByteBuf;
+    type Target = conjure_object::Bytes;
     #[inline]
-    fn deref(&self) -> &conjure_object::ByteBuf {
+    fn deref(&self) -> &conjure_object::Bytes {
         &self.0
     }
 }
 impl std::ops::DerefMut for AliasedBinary {
     #[inline]
-    fn deref_mut(&mut self) -> &mut conjure_object::ByteBuf {
+    fn deref_mut(&mut self) -> &mut conjure_object::Bytes {
         &mut self.0
     }
 }

--- a/example-api/src/product/any_example.rs
+++ b/example-api/src/product/any_example.rs
@@ -39,8 +39,7 @@ impl Builder {
     where
         T: conjure_object::serde::Serialize,
     {
-        self
-            .any = Some(
+        self.any = Some(
             conjure_object::Any::new(any).expect("value failed to serialize"),
         );
         self

--- a/example-api/src/product/binary_alias_example.rs
+++ b/example-api/src/product/binary_alias_example.rs
@@ -1,34 +1,34 @@
 use conjure_object::serde::{ser, de};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct BinaryAliasExample(pub conjure_object::ByteBuf);
+pub struct BinaryAliasExample(pub conjure_object::Bytes);
 impl conjure_object::Plain for BinaryAliasExample {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         conjure_object::Plain::fmt(&self.0, fmt)
     }
 }
 impl conjure_object::FromPlain for BinaryAliasExample {
-    type Err = <conjure_object::ByteBuf as conjure_object::FromPlain>::Err;
+    type Err = <conjure_object::Bytes as conjure_object::FromPlain>::Err;
     #[inline]
     fn from_plain(s: &str) -> Result<BinaryAliasExample, Self::Err> {
         conjure_object::FromPlain::from_plain(s).map(BinaryAliasExample)
     }
 }
-impl std::convert::From<conjure_object::ByteBuf> for BinaryAliasExample {
+impl std::convert::From<conjure_object::Bytes> for BinaryAliasExample {
     #[inline]
-    fn from(v: conjure_object::ByteBuf) -> Self {
+    fn from(v: conjure_object::Bytes) -> Self {
         BinaryAliasExample(std::convert::From::from(v))
     }
 }
 impl std::ops::Deref for BinaryAliasExample {
-    type Target = conjure_object::ByteBuf;
+    type Target = conjure_object::Bytes;
     #[inline]
-    fn deref(&self) -> &conjure_object::ByteBuf {
+    fn deref(&self) -> &conjure_object::Bytes {
         &self.0
     }
 }
 impl std::ops::DerefMut for BinaryAliasExample {
     #[inline]
-    fn deref_mut(&mut self) -> &mut conjure_object::ByteBuf {
+    fn deref_mut(&mut self) -> &mut conjure_object::Bytes {
         &mut self.0
     }
 }

--- a/example-api/src/product/binary_example.rs
+++ b/example-api/src/product/binary_example.rs
@@ -3,17 +3,17 @@ use conjure_object::serde::ser::SerializeStruct as SerializeStruct_;
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BinaryExample {
-    binary: conjure_object::ByteBuf,
+    binary: conjure_object::Bytes,
 }
 impl BinaryExample {
     /// Constructs a new instance of the type.
     #[inline]
     pub fn new<T>(binary: T) -> BinaryExample
     where
-        T: Into<Vec<u8>>,
+        T: Into<conjure_object::Bytes>,
     {
         BinaryExample {
-            binary: conjure_object::ByteBuf::from(binary),
+            binary: binary.into(),
         }
     }
     /// Returns a new builder.
@@ -22,14 +22,14 @@ impl BinaryExample {
         Default::default()
     }
     #[inline]
-    pub fn binary(&self) -> &[u8] {
-        &**self.binary
+    pub fn binary(&self) -> &conjure_object::Bytes {
+        &self.binary
     }
 }
 ///A builder for the `BinaryExample` type.
 #[derive(Debug, Clone, Default)]
 pub struct Builder {
-    binary: Option<conjure_object::ByteBuf>,
+    binary: Option<conjure_object::Bytes>,
 }
 impl Builder {
     ///
@@ -37,9 +37,9 @@ impl Builder {
     #[inline]
     pub fn binary<T>(&mut self, binary: T) -> &mut Self
     where
-        T: Into<Vec<u8>>,
+        T: Into<conjure_object::Bytes>,
     {
-        self.binary = Some(conjure_object::ByteBuf::from(binary));
+        self.binary = Some(binary.into());
         self
     }
     /// Constructs a new instance of the type.

--- a/example-api/src/product/invalid_service_definition.rs
+++ b/example-api/src/product/invalid_service_definition.rs
@@ -63,8 +63,7 @@ impl Builder {
     where
         T: conjure_object::serde::Serialize,
     {
-        self
-            .service_def = Some(
+        self.service_def = Some(
             conjure_object::Any::new(service_def).expect("value failed to serialize"),
         );
         self

--- a/example-api/src/product/invalid_type_definition.rs
+++ b/example-api/src/product/invalid_type_definition.rs
@@ -59,8 +59,7 @@ impl Builder {
     where
         T: conjure_object::serde::Serialize,
     {
-        self
-            .type_def = Some(
+        self.type_def = Some(
             conjure_object::Any::new(type_def).expect("value failed to serialize"),
         );
         self

--- a/example-api/src/product/nested_aliased_binary.rs
+++ b/example-api/src/product/nested_aliased_binary.rs
@@ -13,9 +13,9 @@ impl conjure_object::FromPlain for NestedAliasedBinary {
         conjure_object::FromPlain::from_plain(s).map(NestedAliasedBinary)
     }
 }
-impl std::convert::From<conjure_object::ByteBuf> for NestedAliasedBinary {
+impl std::convert::From<conjure_object::Bytes> for NestedAliasedBinary {
     #[inline]
-    fn from(v: conjure_object::ByteBuf) -> Self {
+    fn from(v: conjure_object::Bytes) -> Self {
         NestedAliasedBinary(std::convert::From::from(v))
     }
 }


### PR DESCRIPTION
## Before this PR
The Conjure `binary` type was backed by `Vec<u8>`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The Conjure `binary` type is now backed by `bytes::Bytes`.
==COMMIT_MSG==

We already use `Bytes` in the conjure_http interfaces, and this more generally supports some zero-copy workflows.

Closes #340