### PR TITLE
Explicitly configure autorelease

### DIFF
--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,0 +1,3 @@
+version: 3
+options:
+  repo_type: RUST


### PR DESCRIPTION
Autorelease's default detection logic doesn't realize this is a Rust repo since it has a build.gradle.