### PR TITLE
Endpoints need to be 'static

### DIFF
--- a/conjure-http/src/server/mod.rs
+++ b/conjure-http/src/server/mod.rs
@@ -287,7 +287,7 @@ pub trait Service<I, O> {
 /// An async Conjure service.
 pub trait AsyncService<I, O> {
     /// Returns the endpoints in the service.
-    fn endpoints(&self, runtime: &Arc<ConjureRuntime>) -> Vec<BoxAsyncEndpoint<I, O>>;
+    fn endpoints(&self, runtime: &Arc<ConjureRuntime>) -> Vec<BoxAsyncEndpoint<'static, I, O>>;
 }
 
 /// A type providing server logic that is configured at runtime.

--- a/conjure-macros/src/endpoints.rs
+++ b/conjure-macros/src/endpoints.rs
@@ -63,7 +63,7 @@ fn generate_endpoints(service: &Service) -> TokenStream {
             >
         },
         Asyncness::Async => {
-            quote!(conjure_http::server::BoxAsyncEndpoint<'_, #request_body, #response_writer>)
+            quote!(conjure_http::server::BoxAsyncEndpoint<'static, #request_body, #response_writer>)
         }
     };
 


### PR DESCRIPTION
## Before this PR
Async endpoints borrowed from `&self` implicitly, which is not what we want here.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`AsyncService` must return `'static` endpoints.
==COMMIT_MSG==
