### PR TITLE
Fix handling of nested maps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             - root/project
             - usr/local/cargo/registry
 
-  test:
+  circle-all:
     executor: rust
     environment:
       RUSTFLAGS: -D warnings
@@ -133,26 +133,26 @@ workflows:
     jobs:
       - checkout:
           filters: { tags: { only: /.*/ } }
-      - test:
+      - circle-all:
           requires: [checkout]
           filters: { tags: { only: /.*/ } }
       - dist-linux:
-          requires: [checkout]
+          requires: [circle-all]
           filters:
             tags: { only: /.*/ }
             branches: { only: master }
       - dist-macos:
-          requires: [checkout]
+          requires: [circle-all]
           filters:
             tags: { only: /.*/ }
             branches: { only: master }
       - dist-windows:
-          requires: [checkout]
+          requires: [circle-all]
           filters:
             tags: { only: /.*/ }
             branches: { only: master }
       - publish:
-          requires: [test, dist-linux, dist-macos, dist-windows]
+          requires: [circle-all, dist-linux, dist-macos, dist-windows]
           filters:
             tags: { only: /.*/ }
             branches: { only: master }

--- a/changelog/@unreleased/pr-359.v2.yml
+++ b/changelog/@unreleased/pr-359.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixed handling of nested maps fields.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/359

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -593,7 +593,7 @@ impl Context {
             Type::Map(def) => {
                 let into_iterator = self.into_iterator_ident(this_type);
                 let key_type = self.rust_type_inner(this_type, def.key_type(), true);
-                let value_type = self.rust_type(this_type, def.key_type());
+                let value_type = self.rust_type(this_type, def.value_type());
                 BuilderItemConfig::Custom {
                     type_: quote!(impl #into_iterator<Item = (#key_type, #value_type)>),
                     convert: quote!(|v| v.into_iter().collect()),

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -573,6 +573,44 @@
     "type" : "object",
     "object" : {
       "typeName" : {
+        "name" : "MapMapValue",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "foo",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "map",
+              "map" : {
+                "keyType" : {
+                  "type" : "primitive",
+                  "primitive" : "STRING"
+                },
+                "valueType" : {
+                  "type" : "set",
+                  "set" : {
+                    "itemType" : {
+                      "type" : "primitive",
+                      "primitive" : "STRING"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
         "name" : "MixedFields",
         "package" : "com.palantir.conjure"
       },

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -160,6 +160,9 @@ types:
         alias: set<double>
       EmptyUnion:
         union: {}
+      MapMapValue:
+        fields:
+          foo: map<string, map<string, set<string>>>
     errors:
       SimpleError:
         namespace: Test


### PR DESCRIPTION
## Before this PR
Types using nested maps would fail to compile due to bad builder configuration:

```
error[E0277]: a value of type `BTreeMap<std::string::String, BTreeSet<std::string::String>>` cannot be built from an iterator over elements of type `(std::string::String, std::string::String)`
    --> /Volumes/git/public/conjure-rust/target/debug/build/conjure-test-43c1963ddae97566/out/conjure/map_map_value.rs:16:48
     |
16   |                     convert = |v|v.into_iter().collect()
     |                                                ^^^^^^^ value of type `BTreeMap<std::string::String, BTreeSet<std::string::String>>` cannot be built from `std::iter::Iterator<Item=(std::string::String, std::string::String)>`
     |
     = help: the trait `FromIterator<(std::string::String, std::string::String)>` is not implemented for `BTreeMap<std::string::String, BTreeSet<std::string::String>>`
     = help: the trait `FromIterator<(std::string::String, BTreeSet<std::string::String>)>` is implemented for `BTreeMap<std::string::String, BTreeSet<std::string::String>>`
     = help: for that trait implementation, expected `BTreeSet<std::string::String>`, found `std::string::String`
note: the method call chain might not have had the expected associated types
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed handling of nested maps fields.
==COMMIT_MSG==
