### PR TITLE
Add custom backtrace for conjure error

### DIFF
--- a/changelog/@unreleased/pr-361.v2.yml
+++ b/changelog/@unreleased/pr-361.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add custom backtrace for conjure error
+  links:
+  - https://github.com/palantir/conjure-rust/pull/361

--- a/conjure-error/src/error.rs
+++ b/conjure-error/src/error.rs
@@ -398,7 +398,6 @@ impl<'a> Iterator for ParamsIter<'a> {
 }
 
 /// A backtrace associated with an `Error`.
-// FIXME remove in favor of std backtrace directly in next major bump
 pub struct Backtrace(BacktraceInner);
 
 impl fmt::Debug for Backtrace {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

