### PR TITLE
Downgrade educe

### DIFF
--- a/changelog/@unreleased/pr-365.v2.yml
+++ b/changelog/@unreleased/pr-365.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Downgraded educe to 0.5 to fix codegen for recursive enums.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/365

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 bytes = { version = "1.0", features = ["serde"] }
 base64 = "0.22"
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "std", "serde"] }
-educe = { version = "0.6", default-features = false, features = [
+educe = { version = "0.5", default-features = false, features = [
     "Hash",
     "PartialEq",
     "Eq",

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -889,6 +889,30 @@
       } ]
     }
   }, {
+    "type" : "union",
+    "union" : {
+      "typeName" : {
+        "name" : "RecursiveUnion",
+        "package" : "com.palantir.conjure"
+      },
+      "union" : [ {
+        "fieldName" : "a",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DOUBLE"
+        }
+      }, {
+        "fieldName" : "b",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "RecursiveUnion",
+            "package" : "com.palantir.conjure"
+          }
+        }
+      } ]
+    }
+  }, {
     "type" : "alias",
     "alias" : {
       "typeName" : {

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -163,6 +163,10 @@ types:
       MapMapValue:
         fields:
           foo: map<string, map<string, set<string>>>
+      RecursiveUnion:
+        union:
+          a: double
+          b: RecursiveUnion
     errors:
       SimpleError:
         namespace: Test


### PR DESCRIPTION
## Before this PR
Educe 0.6 generates code for recursive enums that doesn't compile:

```
error[E0275]: overflow evaluating the requirement `types::recursive_union::RecursiveUnion: PartialEq`
 --> /Volumes/git/public/conjure-rust/target/debug/build/conjure-test-7686e1e9078feeba/out/conjure/recursive_union.rs:5:24
  |
5 | #[derive(Debug, Clone, conjure_object::private::Educe)]
  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: required for `Box<types::recursive_union::RecursiveUnion>` to implement `PartialEq`
  = help: see issue #48214
  = note: this error originates in the derive macro `conjure_object::private::Educe` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Downgraded educe to 0.5 to fix codegen for recursive enums.
==COMMIT_MSG==
