### PR TITLE
Support per-endpoint request size limits

### DIFF
--- a/changelog/@unreleased/pr-380.v2.yml
+++ b/changelog/@unreleased/pr-380.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: 'Added support for per-endpoint request size limits via the `server-limit-request-size:
+    N` tag.'
+  links:
+  - https://github.com/palantir/conjure-rust/pull/380

--- a/conjure-codegen/src/human_size.rs
+++ b/conjure-codegen/src/human_size.rs
@@ -1,0 +1,50 @@
+pub fn parse(s: &str) -> Result<usize, String> {
+    let split = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
+    let (number, unit) = s.split_at(split);
+
+    let number = number.trim().parse::<usize>().map_err(|e| e.to_string())?;
+
+    let multiple = match &*unit.trim().to_ascii_lowercase() {
+        "b" | "" => 1,
+        "k" | "kb" => 1000,
+        "ki" | "kib" => 1024,
+        "m" | "mb" => 1000 * 1000,
+        "mi" | "mib" => 1024 * 1024,
+        "g" | "gb" => 1000 * 1000 * 1000,
+        "gi" | "gib" => 1024 * 1024 * 1024,
+        "t" | "tb" => 1000 * 1000 * 1000 * 1000,
+        "ti" | "tib" => 1024 * 1024 * 1024 * 1024,
+        _ => return Err("invalid unit".to_string()),
+    };
+
+    Ok(number * multiple)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_ok() {
+        let tests = [
+            ("15", 15),
+            ("15b", 15),
+            ("15k", 15 * 1000),
+            ("15K", 15 * 1000),
+            ("15 kb", 15 * 1000),
+            ("15 KB", 15 * 1000),
+            ("15 Kb", 15 * 1000),
+            ("15ki", 15 * 1024),
+            ("15m", 15 * 1000 * 1000),
+            ("15mi", 15 * 1024 * 1024),
+            ("15g", 15 * 1000 * 1000 * 1000),
+            ("15gi", 15 * 1024 * 1024 * 1024),
+            ("15t", 15 * 1000 * 1000 * 1000 * 1000),
+            ("15ti", 15 * 1024 * 1024 * 1024 * 1024),
+        ];
+
+        for (s, expected) in tests {
+            assert_eq!(parse(s).unwrap(), expected, "{s}");
+        }
+    }
+}

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -306,6 +306,7 @@ mod servers;
 #[allow(dead_code, clippy::all)]
 #[rustfmt::skip]
 mod types;
+mod human_size;
 mod unions;
 
 /// Examples of generated Conjure code.

--- a/conjure-http/src/server/mod.rs
+++ b/conjure-http/src/server/mod.rs
@@ -503,7 +503,7 @@ pub trait AsyncDeserializeRequest<T, R> {
 ///
 /// It is parameterized by the maximum number of bytes that will be read from the request body
 /// before an error is returned. The limit defaults to 50 MiB.
-pub enum StdRequestDeserializer<const LIMIT: usize = { SERIALIZABLE_REQUEST_SIZE_LIMIT }> {}
+pub enum StdRequestDeserializer<const N: usize = { SERIALIZABLE_REQUEST_SIZE_LIMIT }> {}
 
 impl<const N: usize> StdRequestDeserializer<N> {
     fn check_content_type(headers: &HeaderMap) -> Result<(), Error> {

--- a/conjure-http/src/server/mod.rs
+++ b/conjure-http/src/server/mod.rs
@@ -500,9 +500,12 @@ pub trait AsyncDeserializeRequest<T, R> {
 }
 
 /// A request deserializer for standard body types.
-pub enum StdRequestDeserializer {}
+///
+/// It is parameterized by the maximum number of bytes that will be read from the request body
+/// before an error is returned. The limit defaults to 50 MiB.
+pub enum StdRequestDeserializer<const LIMIT: usize = { SERIALIZABLE_REQUEST_SIZE_LIMIT }> {}
 
-impl StdRequestDeserializer {
+impl<const N: usize> StdRequestDeserializer<N> {
     fn check_content_type(headers: &HeaderMap) -> Result<(), Error> {
         if headers.get(CONTENT_TYPE) != Some(&APPLICATION_JSON) {
             return Err(Error::service_safe(
@@ -515,26 +518,26 @@ impl StdRequestDeserializer {
     }
 }
 
-impl<T, R> DeserializeRequest<T, R> for StdRequestDeserializer
+impl<const N: usize, T, R> DeserializeRequest<T, R> for StdRequestDeserializer<N>
 where
     T: DeserializeOwned,
     R: Iterator<Item = Result<Bytes, Error>>,
 {
     fn deserialize(_: &ConjureRuntime, headers: &HeaderMap, body: R) -> Result<T, Error> {
         Self::check_content_type(headers)?;
-        let buf = private::read_body(body, Some(SERIALIZABLE_REQUEST_SIZE_LIMIT))?;
+        let buf = private::read_body(body, Some(N))?;
         json::server_from_slice(&buf).map_err(|e| Error::service(e, InvalidArgument::new()))
     }
 }
 
-impl<T, R> AsyncDeserializeRequest<T, R> for StdRequestDeserializer
+impl<const N: usize, T, R> AsyncDeserializeRequest<T, R> for StdRequestDeserializer<N>
 where
     T: DeserializeOwned,
     R: Stream<Item = Result<Bytes, Error>> + Send,
 {
     async fn deserialize(_: &ConjureRuntime, headers: &HeaderMap, body: R) -> Result<T, Error> {
         Self::check_content_type(headers)?;
-        let buf = private::async_read_body(body, Some(SERIALIZABLE_REQUEST_SIZE_LIMIT)).await?;
+        let buf = private::async_read_body(body, Some(N)).await?;
         json::server_from_slice(&buf).map_err(|e| Error::service(e, InvalidArgument::new()))
     }
 }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -1963,6 +1963,25 @@
       "args" : [ ],
       "markers" : [ ],
       "tags" : [ "server-request-context" ]
+    }, {
+      "endpointName" : "smallRequestBody",
+      "httpMethod" : "POST",
+      "httpPath" : "/test/smallRequestBody",
+      "args" : [ {
+        "argName" : "body",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "paramType" : {
+          "type" : "body",
+          "body" : { }
+        },
+        "markers" : [ ],
+        "tags" : [ ]
+      } ],
+      "markers" : [ ],
+      "tags" : [ "server-limit-request-size: 10b" ]
     } ]
   }, {
     "serviceName" : {

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -342,3 +342,9 @@ services:
         http: GET /contextNoArgs
         tags:
           - server-request-context
+      smallRequestBody:
+        http: POST /smallRequestBody
+        tags:
+          - "server-limit-request-size: 10b"
+        args:
+          body: string


### PR DESCRIPTION
## Before this PR
All endpoints with serializable request bodies limited them to 50MiB without the ability to configure that.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added support for per-endpoint request size limits via the `server-limit-request-size: N` tag.
==COMMIT_MSG==

There's a bit of jank in the codegen since up until now it's been totally infallible. To work around this, we inject `compile_error!` macro calls when the configured limit fails to parse properly. In the Java implementation, this parsing is deferred to runtime.

The limit is passed as a const generic parameter in the `StdRequestDeserializer`. I'm not sure if this is the "right" approach, but it lets us preserve back compat. Custom endpoints can set the parameter directly, which is workable but a bit weird. In the future it might make sense for the limit to be a more first-class concept in some way.

Closes #374