### PR TITLE
Fix deserialization of Smile maps with UUID keys

### DIFF
--- a/changelog/@unreleased/pr-386.v2.yml
+++ b/changelog/@unreleased/pr-386.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix deserialization of Smile maps with UUID keys
+  links:
+  - https://github.com/palantir/conjure-rust/pull/386

--- a/conjure-serde/src/de/mod.rs
+++ b/conjure-serde/src/de/mod.rs
@@ -190,6 +190,13 @@ pub trait Behavior {
     {
         de.deserialize_struct(name, fields, visitor)
     }
+
+    fn is_human_readable<'de, D>(de: &D) -> bool
+    where
+        D: Deserializer<'de>,
+    {
+        de.is_human_readable()
+    }
 }
 
 pub struct Override<T, B> {
@@ -341,7 +348,7 @@ where
     }
 
     fn is_human_readable(&self) -> bool {
-        self.inner.is_human_readable()
+        B::is_human_readable(&self.inner)
     }
 }
 

--- a/conjure-serde/src/de/unknown_fields_behavior.rs
+++ b/conjure-serde/src/de/unknown_fields_behavior.rs
@@ -88,6 +88,13 @@ where
             DelegatingVisitor::new(StructVisitor { fields }, visitor),
         )
     }
+
+    fn is_human_readable<'de, D>(de: &D) -> bool
+    where
+        D: Deserializer<'de>,
+    {
+        B::is_human_readable(de)
+    }
 }
 
 struct StructVisitor {

--- a/conjure-serde/src/json/de/client.rs
+++ b/conjure-serde/src/json/de/client.rs
@@ -187,6 +187,14 @@ impl Behavior for KeyBehavior {
     {
         de.deserialize_str(ByteBufVisitor(visitor))
     }
+
+    // We don't need this for JSON, but it allows the Smile logic to work with this KeyBehavior
+    fn is_human_readable<'de, D>(_: &D) -> bool
+    where
+        D: de::Deserializer<'de>,
+    {
+        true
+    }
 }
 
 macro_rules! float_visitor {

--- a/conjure-serde/src/smile/test.rs
+++ b/conjure-serde/src/smile/test.rs
@@ -109,6 +109,22 @@ fn double_keys() {
     )
 }
 
+#[test]
+fn uuid_keys() {
+    test_serde(
+        &BTreeMap::from([(Uuid::nil(), 1)]),
+        b":)\n\x05\xfa\xa300000000-0000-0000-0000-000000000000\xc2\xfb",
+    );
+}
+
+#[test]
+fn uuid_values() {
+    test_serde(
+        &Uuid::nil(),
+        b":)\n\x05\xfd\x90\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+    )
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct Foo {
     foo: i32,
@@ -128,12 +144,4 @@ fn server_unknown_fields() {
 
     assert!(e.to_string().contains("foo"));
     assert!(e.to_string().contains("bogus"));
-}
-
-#[test]
-fn uuid_keys() {
-    test_serde(
-        &BTreeMap::from([(Uuid::nil(), 1)]),
-        b":)\n\x05\xfa\xa300000000-0000-0000-0000-000000000000\xc2\xfb",
-    );
 }

--- a/conjure-serde/src/smile/test.rs
+++ b/conjure-serde/src/smile/test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use conjure_object::DoubleKey;
+use conjure_object::{DoubleKey, Uuid};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
@@ -128,4 +128,12 @@ fn server_unknown_fields() {
 
     assert!(e.to_string().contains("foo"));
     assert!(e.to_string().contains("bogus"));
+}
+
+#[test]
+fn uuid_keys() {
+    test_serde(
+        &BTreeMap::from([(Uuid::nil(), 1)]),
+        b":)\n\x05\xfa\xa300000000-0000-0000-0000-000000000000\xc2\xfb",
+    );
 }


### PR DESCRIPTION
## Before this PR
The Smile serde `Deserializer` used for map keys incorrectly reported itself as not "human readable", which causes UUID deserialization logic to expect raw bytes instead of the string encoding. While maps keyed by UUIDs would serialize properly, they would not deserialize, failing with

```
Error(Custom("invalid value: string \"820eea12-894b-4e6e-96a0-668b79b9edb4\", expected a base64 string"))
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

We now override `is_human_readable` to `true` in the key deserializer instead of delegating to the underlying Deserializer.
