### PR TITLE
Cleanup the Smile UUID key fix

### DIFF
--- a/conjure-serde/Cargo.toml
+++ b/conjure-serde/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 base64 = "0.22"
 serde = "1.0"
 serde_json = "1.0"
-serde-smile = "0.2.0"
+serde-smile = "0.2.2"
 
 [dev-dependencies]
 conjure-object = "1.1.0"

--- a/conjure-serde/src/de/mod.rs
+++ b/conjure-serde/src/de/mod.rs
@@ -190,13 +190,6 @@ pub trait Behavior {
     {
         de.deserialize_struct(name, fields, visitor)
     }
-
-    fn is_human_readable<'de, D>(de: &D) -> bool
-    where
-        D: Deserializer<'de>,
-    {
-        de.is_human_readable()
-    }
 }
 
 pub struct Override<T, B> {
@@ -348,7 +341,7 @@ where
     }
 
     fn is_human_readable(&self) -> bool {
-        B::is_human_readable(&self.inner)
+        self.inner.is_human_readable()
     }
 }
 

--- a/conjure-serde/src/de/unknown_fields_behavior.rs
+++ b/conjure-serde/src/de/unknown_fields_behavior.rs
@@ -88,13 +88,6 @@ where
             DelegatingVisitor::new(StructVisitor { fields }, visitor),
         )
     }
-
-    fn is_human_readable<'de, D>(de: &D) -> bool
-    where
-        D: Deserializer<'de>,
-    {
-        B::is_human_readable(de)
-    }
 }
 
 struct StructVisitor {

--- a/conjure-serde/src/json/de/client.rs
+++ b/conjure-serde/src/json/de/client.rs
@@ -187,14 +187,6 @@ impl Behavior for KeyBehavior {
     {
         de.deserialize_str(ByteBufVisitor(visitor))
     }
-
-    // We don't need this for JSON, but it allows the Smile logic to work with this KeyBehavior
-    fn is_human_readable<'de, D>(_: &D) -> bool
-    where
-        D: de::Deserializer<'de>,
-    {
-        true
-    }
 }
 
 macro_rules! float_visitor {


### PR DESCRIPTION
## Before this PR
We fixed UUID key deserialization in #386 with some extra deserializer overrides, but the issue was actually in serde-smile and was fixed upstream in https://github.com/sfackler/serde-smile/pull/14.

## After this PR
The changes in #386 are gone in favor of a bumped serde-smile version constraint.