### PR TITLE
Update output of `conjure-rust generate --help` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ https://github.com/palantir/conjure/blob/master/docs/rfc/002-contract-for-conjur
 be used via a build tool like [gradle-conjure](https://github.com/palantir/gradle-conjure), or manually:
 
 ```
-USAGE:
-    conjure-rust generate [OPTIONS] <inputJson> <outputDirectory>
+Generate Rust code from a conjure IR file
 
-ARGS:
-    <inputJson>          Path to a JSON-formatted Conjure IR file
-    <outputDirectory>    Directory to place generated code
+Usage: conjure-rust generate [OPTIONS] <INPUT_JSON> <OUTPUT_DIRECTORY>
 
-OPTIONS:
-        --exhaustive                  Generate exhaustively matchable enums and unions
-        --useStagedBuilders           Generate compile-time safe builders to ensure all required
-                                      attributes are set
-        --stripPrefix <prefix>        Strip a prefix from types's package paths
-        --productName <name>          The name of the generated crate
-        --productVersion <version>    The version of the generated crate
-    -h, --help                        Print help information
+Arguments:
+  <INPUT_JSON>        Path to a JSON-formatted Conjure IR file
+  <OUTPUT_DIRECTORY>  Directory to place generated code
+
+Options:
+      --exhaustive[=<EXHAUSTIVE>]  Generate exhaustively matchable enums and unions [default: false] [possible values: true, false]
+      --stripPrefix <prefix>       Strip a prefix from types's package paths
+      --productName <name>         The name of the product
+      --productVersion <version>   The version of the product
+      --crateVersion <version>     The version of the generated crate. Defaults to `--productVersion`
+  -h, --help                       Print help
 ```
 
 ## conjure-codegen


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The readme showed an outdated output of `conjure-rust generate --help`. 

The old help command listed the `--useStagedBuilders` option which is not supported since 4.0.0.

## After this PR
We now have the most recent output of `conjure-rust generate --help` in the README.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

