### PR TITLE
Overhaul the ErrorType trait

### DIFF
--- a/conjure-codegen/src/errors.rs
+++ b/conjure-codegen/src/errors.rs
@@ -41,8 +41,6 @@ fn generate_error_type(ctx: &Context, def: &ErrorDefinition) -> TokenStream {
     let type_name = ctx.type_name(def.error_name().name());
     let code = ctx.type_name(def.code().as_str());
     let name = format!("{}:{}", def.namespace(), def.error_name().name());
-    let option = ctx.option_ident(def.error_name());
-    let none = ctx.none_ident(def.error_name());
 
     let mut safe_args = def
         .safe_args()
@@ -54,22 +52,17 @@ fn generate_error_type(ctx: &Context, def: &ErrorDefinition) -> TokenStream {
     quote! {
         impl conjure_error::ErrorType for #type_name {
             #[inline]
-            fn code(&self) -> conjure_error::ErrorCode {
+            fn code() -> conjure_error::ErrorCode {
                 conjure_error::ErrorCode::#code
             }
 
             #[inline]
-            fn name(&self) -> &str {
+            fn name() -> &'static str {
                 #name
             }
 
             #[inline]
-            fn instance_id(&self) -> #option<conjure_object::Uuid> {
-                #none
-            }
-
-            #[inline]
-            fn safe_args(&self) -> &'static [&'static str] {
+            fn safe_args() -> &'static [&'static str] {
                 &[#(#safe_args,)*]
             }
         }

--- a/conjure-codegen/src/example_types/another/different_package.rs
+++ b/conjure-codegen/src/example_types/another/different_package.rs
@@ -24,19 +24,15 @@ impl DifferentPackage {
 }
 impl conjure_error::ErrorType for DifferentPackage {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::Internal
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Conjure:DifferentPackage"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-codegen/src/example_types/product/invalid_service_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_service_definition.rs
@@ -49,19 +49,15 @@ impl InvalidServiceDefinition {
 }
 impl conjure_error::ErrorType for InvalidServiceDefinition {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::InvalidArgument
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Conjure:InvalidServiceDefinition"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &["serviceName"]
     }
 }

--- a/conjure-codegen/src/example_types/product/invalid_type_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_type_definition.rs
@@ -47,19 +47,15 @@ impl InvalidTypeDefinition {
 }
 impl conjure_error::ErrorType for InvalidTypeDefinition {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::InvalidArgument
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Conjure:InvalidTypeDefinition"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &["typeName"]
     }
 }

--- a/conjure-codegen/src/example_types/product/java_compilation_failed.rs
+++ b/conjure-codegen/src/example_types/product/java_compilation_failed.rs
@@ -24,19 +24,15 @@ impl JavaCompilationFailed {
 }
 impl conjure_error::ErrorType for JavaCompilationFailed {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::Internal
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "ConjureJava:JavaCompilationFailed"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/error.rs
+++ b/conjure-error/src/error.rs
@@ -88,7 +88,7 @@ impl Error {
             cause.into(),
             false,
             crate::encode(&error_type),
-            error_type.safe_args(),
+            T::safe_args(),
         )
     }
 
@@ -102,7 +102,7 @@ impl Error {
             cause.into(),
             true,
             crate::encode(&error_type),
-            error_type.safe_args(),
+            T::safe_args(),
         )
     }
 

--- a/conjure-error/src/types/conflict.rs
+++ b/conjure-error/src/types/conflict.rs
@@ -24,19 +24,15 @@ impl Conflict {
 }
 impl conjure_error::ErrorType for Conflict {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::Conflict
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:Conflict"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/types/failed_precondition.rs
+++ b/conjure-error/src/types/failed_precondition.rs
@@ -24,19 +24,15 @@ impl FailedPrecondition {
 }
 impl conjure_error::ErrorType for FailedPrecondition {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::FailedPrecondition
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:FailedPrecondition"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/types/internal.rs
+++ b/conjure-error/src/types/internal.rs
@@ -24,19 +24,15 @@ impl Internal {
 }
 impl conjure_error::ErrorType for Internal {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::Internal
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:Internal"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/types/invalid_argument.rs
+++ b/conjure-error/src/types/invalid_argument.rs
@@ -24,19 +24,15 @@ impl InvalidArgument {
 }
 impl conjure_error::ErrorType for InvalidArgument {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::InvalidArgument
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:InvalidArgument"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/types/not_found.rs
+++ b/conjure-error/src/types/not_found.rs
@@ -24,19 +24,15 @@ impl NotFound {
 }
 impl conjure_error::ErrorType for NotFound {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::NotFound
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:NotFound"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/types/permission_denied.rs
+++ b/conjure-error/src/types/permission_denied.rs
@@ -24,19 +24,15 @@ impl PermissionDenied {
 }
 impl conjure_error::ErrorType for PermissionDenied {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::PermissionDenied
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:PermissionDenied"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/types/request_entity_too_large.rs
+++ b/conjure-error/src/types/request_entity_too_large.rs
@@ -24,19 +24,15 @@ impl RequestEntityTooLarge {
 }
 impl conjure_error::ErrorType for RequestEntityTooLarge {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::RequestEntityTooLarge
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:RequestEntityTooLarge"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-error/src/types/timeout.rs
+++ b/conjure-error/src/types/timeout.rs
@@ -24,19 +24,15 @@ impl Timeout {
 }
 impl conjure_error::ErrorType for Timeout {
     #[inline]
-    fn code(&self) -> conjure_error::ErrorCode {
+    fn code() -> conjure_error::ErrorCode {
         conjure_error::ErrorCode::Timeout
     }
     #[inline]
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "Default:Timeout"
     }
     #[inline]
-    fn instance_id(&self) -> Option<conjure_object::Uuid> {
-        None
-    }
-    #[inline]
-    fn safe_args(&self) -> &'static [&'static str] {
+    fn safe_args() -> &'static [&'static str] {
         &[]
     }
 }

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -26,9 +26,9 @@ fn error_serialization() {
         .unsafe_foo(false)
         .build();
 
-    assert_eq!(error.code(), ErrorCode::Internal);
-    assert_eq!(error.name(), "Test:SimpleError");
-    assert_eq!(error.safe_args(), &["bar", "baz", "foo"]);
+    assert_eq!(SimpleError::code(), ErrorCode::Internal);
+    assert_eq!(SimpleError::name(), "Test:SimpleError");
+    assert_eq!(SimpleError::safe_args(), &["bar", "baz", "foo"]);
 
     let encoded = conjure_error::encode(&error);
 


### PR DESCRIPTION
## Before this PR
The `ErrorType` trait had some significant limitations (like the inability to statically retrieve an error type's name string), and retained functionality (like with_instance_id) that hasn't been used in many years.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Overhauled the `ErrorType` trait. Its methods are now static, allowing easier comparison of the type of a serialized error.
==COMMIT_MSG==

When we work out #418, we can add some utility methods to turn a `SerializableError` back into a typed error.

Closes #339 