### PR TITLE
Derive Clone and Debug for clients

### DIFF
--- a/changelog/@unreleased/pr-425.v2.yml
+++ b/changelog/@unreleased/pr-425.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Derive Clone and Debug for clients
+  links:
+  - https://github.com/palantir/conjure-rust/pull/425

--- a/conjure-macros/src/client.rs
+++ b/conjure-macros/src/client.rs
@@ -125,6 +125,7 @@ fn generate_client(service: &Service) -> TokenStream {
         .map(|endpoint| generate_client_method(&client_param, service, endpoint));
 
     quote! {
+        #[derive(Clone, Debug)]
         #vis struct #type_name<C> {
             client: C,
         }


### PR DESCRIPTION
The old conjure-codegen logic does this and it makes clients a bit easier to work with.