### PR TITLE
Prevent doc code blocks from turning into doctests

### DIFF
--- a/changelog/@unreleased/pr-429.v2.yml
+++ b/changelog/@unreleased/pr-429.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Code blocks in Conjure documentation are no longer treated as Rust
+    doctests.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/429

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -800,7 +800,7 @@ impl Context {
                             }
 
                             if s.trim() == "```" {
-                                s.push_str("not_rust");
+                                s.push_str("ignore");
                             }
                             in_code_block = true;
 

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -780,7 +780,33 @@ impl Context {
     pub fn docs(&self, docs: Option<&Documentation>) -> TokenStream {
         match docs {
             Some(docs) => {
-                let docs = docs.lines();
+                let docs = docs
+                    .lines()
+                    // Add a leading space to align with standard doc comments.
+                    .map(|s| format!(" {s}"))
+                    // Docs may have code blocks, which will turn into rust doctests by default,
+                    // and probably not build. Sticking a `ignore` info string onto the opening
+                    // fence makes rustdoc skip them.
+                    .map({
+                        let mut in_code_block = false;
+                        move |mut s| {
+                            if !s.trim().starts_with("```") {
+                                return s;
+                            }
+
+                            if in_code_block {
+                                in_code_block = false;
+                                return s;
+                            }
+
+                            if s.trim() == "```" {
+                                s.push_str("not_rust");
+                            }
+                            in_code_block = true;
+
+                            s
+                        }
+                    });
                 quote!(#(#[doc = #docs])*)
             }
             None => quote!(),

--- a/conjure-codegen/src/example_types/another/different_package.rs
+++ b/conjure-codegen/src/example_types/another/different_package.rs
@@ -1,4 +1,4 @@
-///Different package.
+/// Different package.
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/example_types/another/test_service.rs
+++ b/conjure-codegen/src/example_types/another/test_service.rs
@@ -1,4 +1,4 @@
-///A Markdown description of the service.
+/// A Markdown description of the service.
 #[derive(Clone, Debug)]
 pub struct TestServiceAsyncClient<T>(T);
 impl<T> conjure_http::client::AsyncService<T> for TestServiceAsyncClient<T>
@@ -13,7 +13,7 @@ impl<T> TestServiceAsyncClient<T>
 where
     T: conjure_http::client::AsyncClient,
 {
-    ///Returns a mapping from file system id to backing file system configuration.
+    /// Returns a mapping from file system id to backing file system configuration.
     pub async fn get_file_systems(
         &self,
         auth_: &conjure_object::BearerToken,
@@ -300,7 +300,7 @@ where
         conjure_http::private::async_decode_default_serializable_response(response_)
             .await
     }
-    ///Gets all branches of this dataset.
+    /// Gets all branches of this dataset.
     #[deprecated(note = "use getBranches instead")]
     pub async fn get_branches_deprecated(
         &self,
@@ -592,7 +592,7 @@ where
         conjure_http::private::async_decode_empty_response(response_).await
     }
 }
-///A Markdown description of the service.
+/// A Markdown description of the service.
 #[derive(Clone, Debug)]
 pub struct TestServiceClient<T>(T);
 impl<T> conjure_http::client::Service<T> for TestServiceClient<T>
@@ -607,7 +607,7 @@ impl<T> TestServiceClient<T>
 where
     T: conjure_http::client::Client,
 {
-    ///Returns a mapping from file system id to backing file system configuration.
+    /// Returns a mapping from file system id to backing file system configuration.
     pub fn get_file_systems(
         &self,
         auth_: &conjure_object::BearerToken,
@@ -889,7 +889,7 @@ where
         let response_ = self.0.send(request_)?;
         conjure_http::private::decode_default_serializable_response(response_)
     }
-    ///Gets all branches of this dataset.
+    /// Gets all branches of this dataset.
     #[deprecated(note = "use getBranches instead")]
     pub fn get_branches_deprecated(
         &self,
@@ -1174,7 +1174,7 @@ where
     }
 }
 use conjure_http::endpoint;
-///A Markdown description of the service.
+/// A Markdown description of the service.
 #[conjure_http::conjure_endpoints(name = "TestService")]
 pub trait TestService<#[request_body] I, #[response_writer] O> {
     ///The body type returned by the `get_raw_data` method.
@@ -1183,7 +1183,7 @@ pub trait TestService<#[request_body] I, #[response_writer] O> {
     type GetAliasedRawDataBody: conjure_http::server::WriteBody<O> + 'static;
     ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::WriteBody<O> + 'static;
-    ///Returns a mapping from file system id to backing file system configuration.
+    /// Returns a mapping from file system id to backing file system configuration.
     #[endpoint(
         method = GET,
         path = "/catalog/fileSystems",
@@ -1349,7 +1349,7 @@ pub trait TestService<#[request_body] I, #[response_writer] O> {
         )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
-    ///Gets all branches of this dataset.
+    /// Gets all branches of this dataset.
     #[endpoint(
         method = GET,
         path = "/catalog/datasets/{datasetRid}/branchesDeprecated",
@@ -1559,7 +1559,7 @@ pub trait TestService<#[request_body] I, #[response_writer] O> {
         maybe_double: Option<f64>,
     ) -> Result<(), conjure_http::private::Error>;
 }
-///A Markdown description of the service.
+/// A Markdown description of the service.
 #[conjure_http::conjure_endpoints(name = "TestService")]
 pub trait AsyncTestService<#[request_body] I, #[response_writer] O> {
     ///The body type returned by the `get_raw_data` method.
@@ -1568,7 +1568,7 @@ pub trait AsyncTestService<#[request_body] I, #[response_writer] O> {
     type GetAliasedRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
     ///The body type returned by the `maybe_get_raw_data` method.
     type MaybeGetRawDataBody: conjure_http::server::AsyncWriteBody<O> + 'static + Send;
-    ///Returns a mapping from file system id to backing file system configuration.
+    /// Returns a mapping from file system id to backing file system configuration.
     #[endpoint(
         method = GET,
         path = "/catalog/fileSystems",
@@ -1734,7 +1734,7 @@ pub trait AsyncTestService<#[request_body] I, #[response_writer] O> {
         )]
         dataset_rid: conjure_object::ResourceIdentifier,
     ) -> Result<std::collections::BTreeSet<String>, conjure_http::private::Error>;
-    ///Gets all branches of this dataset.
+    /// Gets all branches of this dataset.
     #[endpoint(
         method = GET,
         path = "/catalog/datasets/{datasetRid}/branchesDeprecated",

--- a/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
+++ b/conjure-codegen/src/example_types/product/datasets/backing_file_system.rs
@@ -33,7 +33,7 @@ impl BackingFileSystem {
     pub fn new(file_system_id: impl Into<String>, base_uri: impl Into<String>) -> Self {
         Self::builder().file_system_id(file_system_id).base_uri(base_uri).build()
     }
-    ///The name by which this file system is identified.
+    /// The name by which this file system is identified.
     #[inline]
     pub fn file_system_id(&self) -> &str {
         &*self.file_system_id

--- a/conjure-codegen/src/example_types/product/datasets/dataset.rs
+++ b/conjure-codegen/src/example_types/product/datasets/dataset.rs
@@ -32,7 +32,7 @@ impl Dataset {
     pub fn file_system_id(&self) -> &str {
         &*self.file_system_id
     }
-    ///Uniquely identifies this dataset.
+    /// Uniquely identifies this dataset.
     #[inline]
     pub fn rid(&self) -> &conjure_object::ResourceIdentifier {
         &self.rid

--- a/conjure-codegen/src/example_types/product/enum_example.rs
+++ b/conjure-codegen/src/example_types/product/enum_example.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 use std::fmt;
 use std::str;
-///This enumerates the numbers 1:2.
+/// This enumerates the numbers 1:2.
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/example_types/product/invalid_service_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_service_definition.rs
@@ -1,4 +1,4 @@
-///Invalid Conjure service definition.
+/// Invalid Conjure service definition.
 #[derive(
     Debug,
     Clone,
@@ -36,12 +36,12 @@ impl InvalidServiceDefinition {
     ) -> Self {
         Self::builder().service_name(service_name).service_def(service_def).build()
     }
-    ///Name of the invalid service definition.
+    /// Name of the invalid service definition.
     #[inline]
     pub fn service_name(&self) -> &str {
         &*self.service_name
     }
-    ///Details of the invalid service definition.
+    /// Details of the invalid service definition.
     #[inline]
     pub fn service_def(&self) -> &conjure_object::Any {
         &self.service_def

--- a/conjure-codegen/src/example_types/product/invalid_type_definition.rs
+++ b/conjure-codegen/src/example_types/product/invalid_type_definition.rs
@@ -1,4 +1,4 @@
-///Invalid Conjure type definition.
+/// Invalid Conjure type definition.
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/example_types/product/java_compilation_failed.rs
+++ b/conjure-codegen/src/example_types/product/java_compilation_failed.rs
@@ -1,4 +1,4 @@
-///Failed to compile Conjure definition to Java code.
+/// Failed to compile Conjure definition to Java code.
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/example_types/product/many_field_example.rs
+++ b/conjure-codegen/src/example_types/product/many_field_example.rs
@@ -46,42 +46,42 @@ pub struct ManyFieldExample {
     alias: super::StringAliasExample,
 }
 impl ManyFieldExample {
-    ///docs for string field
+    /// docs for string field
     #[inline]
     pub fn string(&self) -> &str {
         &*self.string
     }
-    ///docs for integer field
+    /// docs for integer field
     #[inline]
     pub fn integer(&self) -> i32 {
         self.integer
     }
-    ///docs for doubleValue field
+    /// docs for doubleValue field
     #[inline]
     pub fn double_value(&self) -> f64 {
         self.double_value
     }
-    ///docs for optionalItem field
+    /// docs for optionalItem field
     #[inline]
     pub fn optional_item(&self) -> Option<&str> {
         self.optional_item.as_ref().map(|o| &**o)
     }
-    ///docs for items field
+    /// docs for items field
     #[inline]
     pub fn items(&self) -> &[String] {
         &*self.items
     }
-    ///docs for set field
+    /// docs for set field
     #[inline]
     pub fn set(&self) -> &std::collections::BTreeSet<String> {
         &self.set
     }
-    ///docs for map field
+    /// docs for map field
     #[inline]
     pub fn map(&self) -> &std::collections::BTreeMap<String, String> {
         &self.map
     }
-    ///docs for alias field
+    /// docs for alias field
     #[inline]
     pub fn alias(&self) -> &super::StringAliasExample {
         &self.alias

--- a/conjure-codegen/src/example_types/product/union_type_example.rs
+++ b/conjure-codegen/src/example_types/product/union_type_example.rs
@@ -4,7 +4,7 @@ use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum UnionTypeExample {
-    ///Docs for when UnionTypeExample is of type StringExample.
+    /// Docs for when UnionTypeExample is of type StringExample.
     StringExample(super::StringExample),
     Set(std::collections::BTreeSet<String>),
     ThisFieldIsAnInteger(i32),

--- a/conjure-codegen/src/types/argument_name.rs
+++ b/conjure-codegen/src/types/argument_name.rs
@@ -1,4 +1,4 @@
-///Must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed argument names: "fooBar", "build2Request". Disallowed names: "FooBar", "2BuildRequest".
+/// Must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed argument names: "fooBar", "build2Request". Disallowed names: "FooBar", "2BuildRequest".
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/types/endpoint_name.rs
+++ b/conjure-codegen/src/types/endpoint_name.rs
@@ -1,4 +1,4 @@
-///Should be in lowerCamelCase.
+/// Should be in lowerCamelCase.
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/types/external_reference.rs
+++ b/conjure-codegen/src/types/external_reference.rs
@@ -26,12 +26,12 @@ impl ExternalReference {
     pub fn new(external_reference: super::TypeName, fallback: super::Type) -> Self {
         Self::builder().external_reference(external_reference).fallback(fallback).build()
     }
-    ///An identifier for a non-Conjure type which is already defined in a different language (e.g. Java).
+    /// An identifier for a non-Conjure type which is already defined in a different language (e.g. Java).
     #[inline]
     pub fn external_reference(&self) -> &super::TypeName {
         &*self.external_reference
     }
-    ///Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable.
+    /// Other language generators may use the provided fallback if the non-Conjure type is not available. The ANY PrimitiveType is permissible for all external types, but a more specific definition is preferable.
     #[inline]
     pub fn fallback(&self) -> &super::Type {
         &*self.fallback

--- a/conjure-codegen/src/types/field_name.rs
+++ b/conjure-codegen/src/types/field_name.rs
@@ -1,4 +1,4 @@
-///Should be in lowerCamelCase, but kebab-case and snake_case are also permitted.
+/// Should be in lowerCamelCase, but kebab-case and snake_case are also permitted.
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/types/log_safety.rs
+++ b/conjure-codegen/src/types/log_safety.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 use std::fmt;
 use std::str;
-///Safety with regards to logging based on [safe-logging](https://github.com/palantir/safe-logging) concepts.
+/// Safety with regards to logging based on [safe-logging](https://github.com/palantir/safe-logging) concepts.
 #[derive(
     Debug,
     Clone,
@@ -15,13 +15,13 @@ use std::str;
 )]
 #[serde(crate = "conjure_object::serde")]
 pub enum LogSafety {
-    ///Explicitly marks an element as safe.
+    /// Explicitly marks an element as safe.
     #[serde(rename = "SAFE")]
     Safe,
-    ///Explicitly marks an element as unsafe, diallowing contents from being logged as `SAFE`.
+    /// Explicitly marks an element as unsafe, diallowing contents from being logged as `SAFE`.
     #[serde(rename = "UNSAFE")]
     Unsafe,
-    ///Marks elements that must never be logged. For example, credentials, keys, and other secrets cannot be logged because such an action would compromise security.
+    /// Marks elements that must never be logged. For example, credentials, keys, and other secrets cannot be logged because such an action would compromise security.
     #[serde(rename = "DO_NOT_LOG")]
     DoNotLog,
 }

--- a/conjure-codegen/src/types/parameter_id.rs
+++ b/conjure-codegen/src/types/parameter_id.rs
@@ -1,4 +1,4 @@
-///For header parameters, the parameter id must be in Upper-Kebab-Case. For query parameters, the parameter id must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word.
+/// For header parameters, the parameter id must be in Upper-Kebab-Case. For query parameters, the parameter id must be in lowerCamelCase. Numbers are permitted, but not at the beginning of a word.
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/types/type_.rs
+++ b/conjure-codegen/src/types/type_.rs
@@ -9,7 +9,7 @@ pub enum Type {
     List(super::ListType),
     Set(super::SetType),
     Map(super::MapType),
-    ///The name and package of a custom Conjure type. The custom type must be defined in the "types" section.
+    /// The name and package of a custom Conjure type. The custom type must be defined in the "types" section.
     Reference(super::TypeName),
     External(super::ExternalReference),
 }

--- a/conjure-codegen/src/types/type_name.rs
+++ b/conjure-codegen/src/types/type_name.rs
@@ -26,12 +26,12 @@ impl TypeName {
     pub fn new(name: impl Into<String>, package: impl Into<String>) -> Self {
         Self::builder().name(name).package(package).build()
     }
-    ///The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: "FooBar", "XYCoordinate", "Build2Request". Disallowed names: "fooBar", "2BuildRequest".
+    /// The name of the custom Conjure type or service. It must be in UpperCamelCase. Numbers are permitted, but not at the beginning of a word. Allowed names: "FooBar", "XYCoordinate", "Build2Request". Disallowed names: "fooBar", "2BuildRequest".
     #[inline]
     pub fn name(&self) -> &str {
         &*self.name
     }
-    ///A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: "foo", "com.palantir.bar", "com.palantir.foo.thing2". Disallowed packages: "Foo", "com.palantir.foo.2thing".
+    /// A period-delimited string of package names. The package names must be lowercase. Numbers are permitted, but not at the beginning of a package name. Allowed packages: "foo", "com.palantir.bar", "com.palantir.foo.thing2". Disallowed packages: "Foo", "com.palantir.foo.2thing".
     #[inline]
     pub fn package(&self) -> &str {
         &*self.package

--- a/conjure-error/src/types/conflict.rs
+++ b/conjure-error/src/types/conflict.rs
@@ -1,4 +1,4 @@
-///A generic `CONFLICT` error.
+/// A generic `CONFLICT` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/error_code.rs
+++ b/conjure-error/src/types/error_code.rs
@@ -1,9 +1,9 @@
 #![allow(deprecated)]
 use std::fmt;
 use std::str;
-///The broad category of a Conjure error.
+/// The broad category of a Conjure error.
 ///
-///When an error is transmitted over HTTP, this determines the response's status code.
+/// When an error is transmitted over HTTP, this determines the response's status code.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/failed_precondition.rs
+++ b/conjure-error/src/types/failed_precondition.rs
@@ -1,4 +1,4 @@
-///A generic `FAILED_PRECONDITION` error.
+/// A generic `FAILED_PRECONDITION` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/internal.rs
+++ b/conjure-error/src/types/internal.rs
@@ -1,4 +1,4 @@
-///A generic `INTERNAL` error.
+/// A generic `INTERNAL` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/invalid_argument.rs
+++ b/conjure-error/src/types/invalid_argument.rs
@@ -1,4 +1,4 @@
-///A generic `INVALID_ARGUMENT` error.
+/// A generic `INVALID_ARGUMENT` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/not_found.rs
+++ b/conjure-error/src/types/not_found.rs
@@ -1,4 +1,4 @@
-///A generic `NOT_FOUND` error.
+/// A generic `NOT_FOUND` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/permission_denied.rs
+++ b/conjure-error/src/types/permission_denied.rs
@@ -1,4 +1,4 @@
-///A generic `PERMISSION_DENIED` error.
+/// A generic `PERMISSION_DENIED` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/request_entity_too_large.rs
+++ b/conjure-error/src/types/request_entity_too_large.rs
@@ -1,4 +1,4 @@
-///A generic `REQUEST_ENTITY_TOO_LARGE` error.
+/// A generic `REQUEST_ENTITY_TOO_LARGE` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-error/src/types/serializable_error.rs
+++ b/conjure-error/src/types/serializable_error.rs
@@ -1,4 +1,4 @@
-///The JSON-serializable representation of an error.
+/// The JSON-serializable representation of an error.
 #[derive(
     Debug,
     Clone,
@@ -43,29 +43,29 @@ impl SerializableError {
             .error_instance_id(error_instance_id)
             .build()
     }
-    ///The broad category of the error.
+    /// The broad category of the error.
     ///
-    ///When transmitted over HTTP, this determines the response's status code.
+    /// When transmitted over HTTP, this determines the response's status code.
     #[inline]
     pub fn error_code(&self) -> &super::ErrorCode {
         &self.error_code
     }
-    ///The error's name.
+    /// The error's name.
     ///
-    ///The name is made up of a namespace and more specific error name, separated by a `:`.
+    /// The name is made up of a namespace and more specific error name, separated by a `:`.
     #[inline]
     pub fn error_name(&self) -> &str {
         &*self.error_name
     }
-    ///A unique identifier for this error instance.
+    /// A unique identifier for this error instance.
     ///
-    ///This can be used to correlate reporting about the error as it transfers between components of a
-    ///distributed system.
+    /// This can be used to correlate reporting about the error as it transfers between components of a
+    /// distributed system.
     #[inline]
     pub fn error_instance_id(&self) -> conjure_object::Uuid {
         self.error_instance_id
     }
-    ///Parameters providing more information about the error.
+    /// Parameters providing more information about the error.
     #[inline]
     pub fn parameters(&self) -> &std::collections::BTreeMap<String, String> {
         &self.parameters

--- a/conjure-error/src/types/timeout.rs
+++ b/conjure-error/src/types/timeout.rs
@@ -1,4 +1,4 @@
-///A generic `TIMEOUT` error.
+/// A generic `TIMEOUT` error.
 #[derive(
     Debug,
     Clone,

--- a/conjure-test/Cargo.toml
+++ b/conjure-test/Cargo.toml
@@ -4,9 +4,6 @@ version.workspace = true
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2021"
 
-[lib]
-doctest = false
-
 [dependencies]
 conjure-object = { path = "../conjure-object" }
 conjure-error = { path = "../conjure-error" }

--- a/conjure-test/src/lib.rs
+++ b/conjure-test/src/lib.rs
@@ -17,11 +17,11 @@
 mod test;
 
 #[allow(dead_code, unused_imports, clippy::all)]
-mod types {
+pub mod types {
     include!(concat!(env!("OUT_DIR"), "/conjure/mod.rs"));
 }
 
 #[allow(dead_code, unused_imports, clippy::all)]
-mod exhaustive_types {
+pub mod exhaustive_types {
     include!(concat!(env!("OUT_DIR"), "/conjure-exhaustive/mod.rs"));
 }

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -429,7 +429,8 @@
       "alias" : {
         "type" : "primitive",
         "primitive" : "INTEGER"
-      }
+      },
+      "docs" : "Here's some math\n\n```\n1 + 2 = 3\n```\n"
     }
   }, {
     "type" : "alias",

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -32,6 +32,12 @@ types:
             deprecated: Don't use me!
       IntegerAlias:
         alias: integer
+        docs: |
+          Here's some math
+
+          ```
+          1 + 2 = 3
+          ```
       DoubleAlias:
         alias: double
       BooleanAlias:


### PR DESCRIPTION
## Before this PR
Code blocks in Conjure documentation would get picked up as Rust doctests, and probably fail to build.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Code blocks in Conjure documentation are no longer treated as Rust doctests.
==COMMIT_MSG==