### PR TITLE
Fix dependency cycle

### DIFF
--- a/changelog/@unreleased/pr-432.v2.yml
+++ b/changelog/@unreleased/pr-432.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix dependency cycle
+  links:
+  - https://github.com/palantir/conjure-rust/pull/432

--- a/conjure-macros/Cargo.toml
+++ b/conjure-macros/Cargo.toml
@@ -17,10 +17,3 @@ proc-macro2 = "1.0.47"
 quote = "1.0.21"
 structmeta = "0.3.0"
 syn = { version = "2.0.15", features = ["full"] }
-
-[dev-dependencies]
-conjure-error = { path = "../conjure-error", version = "4.9.0" }
-conjure-http = { path = "../conjure-http", version = "4.9.0", features = [
-    "macros",
-] }
-conjure-object = { path = "../conjure-object", version = "4.9.0" }

--- a/conjure-macros/src/lib.rs
+++ b/conjure-macros/src/lib.rs
@@ -14,22 +14,6 @@
 //! Macros exposed by conjure-http.
 //!
 //! Do not consume directly.
-// Copyright 2022 Palantir Technologies, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//! Macros exposed by conjure-http.
-//!
-//! Do not consume directly.
 #![warn(missing_docs)]
 
 use proc_macro::TokenStream;
@@ -109,7 +93,7 @@ mod path;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,ignore
 /// use conjure_error::Error;
 /// use conjure_http::{conjure_client, endpoint};
 /// use conjure_http::client::{
@@ -313,7 +297,7 @@ pub fn conjure_client(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```rust,ignore
 /// use conjure_error::Error;
 /// use conjure_http::{conjure_endpoints, endpoint};
 /// use conjure_http::server::{


### PR DESCRIPTION
Cargo now requires that dev-dependencies have published before allowing a crate to be published, which prevents us from doing this cyclic setup :(