### PR TITLE
Allow non-Send clients

### DIFF
--- a/changelog/@unreleased/pr-442.v2.yml
+++ b/changelog/@unreleased/pr-442.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Added a set of non-Send async client APIs.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/442

--- a/conjure-http/src/client.rs
+++ b/conjure-http/src/client.rs
@@ -122,6 +122,16 @@ pub enum AsyncRequestBody<'a, W> {
     Streaming(BoxAsyncWriteBody<'a, W>),
 }
 
+/// The body of a local async Conjure request.
+pub enum LocalAsyncRequestBody<'a, W> {
+    /// No body.
+    Empty,
+    /// A body already buffered in memory.
+    Fixed(Bytes),
+    /// A streaming body.
+    Streaming(BoxLocalAsyncWriteBody<'a, W>),
+}
+
 /// A trait implemented by HTTP client implementations.
 pub trait Client {
     /// The client's binary request write type.
@@ -161,6 +171,27 @@ pub trait AsyncClient {
         &self,
         req: Request<AsyncRequestBody<'_, Self::BodyWriter>>,
     ) -> impl Future<Output = Result<Response<Self::ResponseBody>, Error>> + Send;
+}
+
+/// A trait implemented by local async HTTP client implementations.
+pub trait LocalAsyncClient {
+    /// The client's binary request body write type.
+    type BodyWriter;
+    /// The client's binary response body type.
+    type ResponseBody: Stream<Item = Result<Bytes, Error>>;
+
+    /// Makes an HTTP request.
+    ///
+    /// The client is responsible for assembling the request URI. It is provided with the path template, unencoded path
+    /// parameters, unencoded query parameters, header parameters, and request body.
+    ///
+    /// A response must only be returned if it has a 2xx status code. The client is responsible for handling all other
+    /// status codes (for example, converting a 5xx response into a service error). The client is also responsible for
+    /// decoding the response body if necessary.
+    fn send(
+        &self,
+        req: Request<LocalAsyncRequestBody<'_, Self::BodyWriter>>,
+    ) -> impl Future<Output = Result<Response<Self::ResponseBody>, Error>>;
 }
 
 /// A trait implemented by streaming bodies.
@@ -288,6 +319,99 @@ where
     }
 }
 
+/// A trait implemented by local async streaming bodies.
+///
+/// # Examples
+///
+/// ```ignore
+/// use conjure_error::Error;
+/// use conjure_http::client::LocalAsyncWriteBody;
+/// use std::pin::Pin;
+/// use tokio_io::{AsyncWrite, AsyncWriteExt};
+///
+/// pub struct SimpleBodyWriter;
+///
+/// impl<W> LocalAsyncWriteBody<W> for SimpleBodyWriter
+/// where
+///     W: AsyncWrite,
+/// {
+///     async fn write_body(self: Pin<&mut Self>, mut w: Pin<&mut W>) -> Result<(), Error> {
+///         w.write_all(b"hello world").await.map_err(Error::internal_safe)
+///     }
+///
+///     async fn reset(self: Pin<&mut Self>) -> bool {
+///         true
+///     }
+/// }
+/// ```
+pub trait LocalAsyncWriteBody<W> {
+    /// Writes the body out, in its entirety.
+    ///
+    /// Behavior is unspecified if this method is called twice without a successful call to `reset` in between.
+    fn write_body(self: Pin<&mut Self>, w: Pin<&mut W>) -> impl Future<Output = Result<(), Error>>;
+
+    /// Attempts to reset the body so that it can be written out again.
+    ///
+    /// Returns `true` if successful. Behavior is unspecified if this is not called after a call to `write_body`.
+    fn reset(self: Pin<&mut Self>) -> impl Future<Output = bool>;
+}
+
+// An internal object-safe version of LocalAsyncWriteBody used to implement BoxLocalAsyncWriteBody.
+trait LocalAsyncWriteBodyEraser<W> {
+    fn write_body<'a>(
+        self: Pin<&'a mut Self>,
+        w: Pin<&'a mut W>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + 'a>>;
+
+    fn reset<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = bool> + 'a>>
+    where
+        W: 'a;
+}
+
+impl<T, W> LocalAsyncWriteBodyEraser<W> for T
+where
+    T: LocalAsyncWriteBody<W> + ?Sized,
+{
+    fn write_body<'a>(
+        self: Pin<&'a mut Self>,
+        w: Pin<&'a mut W>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + 'a>> {
+        Box::pin(self.write_body(w))
+    }
+
+    fn reset<'a>(self: Pin<&'a mut Self>) -> Pin<Box<dyn Future<Output = bool> + 'a>>
+    where
+        W: 'a,
+    {
+        Box::pin(self.reset())
+    }
+}
+
+/// A boxed [`LocalAsyncWriteBody`] trait object.
+pub struct BoxLocalAsyncWriteBody<'a, W> {
+    inner: Pin<Box<dyn LocalAsyncWriteBodyEraser<W> + 'a>>,
+}
+
+impl<'a, W> BoxLocalAsyncWriteBody<'a, W> {
+    /// Creates a new `BoxLocalAsyncWriteBody`.
+    pub fn new<T>(v: T) -> Self
+    where
+        T: LocalAsyncWriteBody<W> + 'a,
+    {
+        BoxLocalAsyncWriteBody { inner: Box::pin(v) }
+    }
+}
+
+impl<W> LocalAsyncWriteBody<W> for BoxLocalAsyncWriteBody<'_, W> {
+    async fn write_body(mut self: Pin<&mut Self>, w: Pin<&mut W>) -> Result<(), Error> {
+        self.inner.as_mut().write_body(w).await
+    }
+
+    async fn reset(mut self: Pin<&mut Self>) -> bool {
+        self.inner.as_mut().reset().await
+    }
+}
+
 /// A trait implemented by request body serializers used by custom Conjure client trait
 /// implementations.
 pub trait SerializeRequest<'a, T, W> {
@@ -328,6 +452,26 @@ pub trait AsyncSerializeRequest<'a, T, W> {
     fn serialize(value: T) -> Result<AsyncRequestBody<'a, W>, Error>;
 }
 
+/// A trait implemented by request body serializers used by custom local async Conjure client trait
+/// implementations.
+pub trait LocalAsyncSerializeRequest<'a, T, W> {
+    /// Returns the body's content type.
+    fn content_type(value: &T) -> HeaderValue;
+
+    /// Returns the body's length, if known.
+    ///
+    /// Empty and fixed size bodies will have their content length filled in automatically.
+    ///
+    /// The default implementation returns `None`.
+    fn content_length(value: &T) -> Option<u64> {
+        let _value = value;
+        None
+    }
+
+    /// Serializes the body.
+    fn serialize(value: T) -> Result<LocalAsyncRequestBody<'a, W>, Error>;
+}
+
 /// A body serializer which acts like a Conjure-generated client would.
 pub enum ConjureRequestSerializer {}
 
@@ -359,6 +503,20 @@ where
     }
 }
 
+impl<'a, T, W> LocalAsyncSerializeRequest<'a, T, W> for ConjureRequestSerializer
+where
+    T: Serialize,
+{
+    fn content_type(_: &T) -> HeaderValue {
+        APPLICATION_JSON
+    }
+
+    fn serialize(value: T) -> Result<LocalAsyncRequestBody<'a, W>, Error> {
+        let buf = json::to_vec(&value).map_err(Error::internal)?;
+        Ok(LocalAsyncRequestBody::Fixed(Bytes::from(buf)))
+    }
+}
+
 /// A trait implemented by response deserializers used by custom Conjure client trait
 /// implementations.
 pub trait DeserializeResponse<T, R> {
@@ -379,6 +537,16 @@ pub trait AsyncDeserializeResponse<T, R> {
     fn deserialize(response: Response<R>) -> impl Future<Output = Result<T, Error>> + Send;
 }
 
+/// A trait implemented by response deserializers used by custom local async Conjure client trait
+/// implementations.
+pub trait LocalAsyncDeserializeResponse<T, R> {
+    /// Returns the value of the `Accept` header to be included in the request.
+    fn accept() -> Option<HeaderValue>;
+
+    /// Deserializes the response.
+    fn deserialize(response: Response<R>) -> impl Future<Output = Result<T, Error>>;
+}
+
 /// A response deserializer which ignores the response and returns `()`.
 pub enum UnitResponseDeserializer {}
 
@@ -396,6 +564,16 @@ impl<R> AsyncDeserializeResponse<(), R> for UnitResponseDeserializer
 where
     R: Send,
 {
+    fn accept() -> Option<HeaderValue> {
+        None
+    }
+
+    async fn deserialize(_: Response<R>) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl<R> LocalAsyncDeserializeResponse<(), R> for UnitResponseDeserializer {
     fn accept() -> Option<HeaderValue> {
         None
     }
@@ -430,6 +608,24 @@ impl<T, R> AsyncDeserializeResponse<T, R> for ConjureResponseDeserializer
 where
     T: DeserializeOwned,
     R: Stream<Item = Result<Bytes, Error>> + Send,
+{
+    fn accept() -> Option<HeaderValue> {
+        Some(APPLICATION_JSON)
+    }
+
+    async fn deserialize(response: Response<R>) -> Result<T, Error> {
+        if response.headers().get(CONTENT_TYPE) != Some(&APPLICATION_JSON) {
+            return Err(Error::internal_safe("invalid response Content-Type"));
+        }
+        let buf = private::async_read_body(response.into_body(), None).await?;
+        json::client_from_slice(&buf).map_err(Error::internal)
+    }
+}
+
+impl<T, R> LocalAsyncDeserializeResponse<T, R> for ConjureResponseDeserializer
+where
+    T: DeserializeOwned,
+    R: Stream<Item = Result<Bytes, Error>>,
 {
     fn accept() -> Option<HeaderValue> {
         Some(APPLICATION_JSON)

--- a/conjure-macros/src/client.rs
+++ b/conjure-macros/src/client.rs
@@ -78,7 +78,7 @@ fn generate_client(service: &Service) -> TokenStream {
 
     let service_trait = match service.asyncness {
         Asyncness::Sync => quote!(Service),
-        Asyncness::Async => quote!(AsyncService),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(AsyncService),
     };
 
     let (_, type_generics, _) = service.generics.split_for_impl();
@@ -92,6 +92,7 @@ fn generate_client(service: &Service) -> TokenStream {
     let client_trait = match service.asyncness {
         Asyncness::Sync => quote!(Client),
         Asyncness::Async => quote!(AsyncClient),
+        Asyncness::LocalAsync => quote!(LocalAsyncClient),
     };
     let mut client_bindings = vec![];
     if let Some(param) = &service.request_writer_param {
@@ -103,6 +104,7 @@ fn generate_client(service: &Service) -> TokenStream {
     let extra_client_predicates = match service.asyncness {
         Asyncness::Sync => quote!(),
         Asyncness::Async => quote!(+ conjure_http::private::Sync + conjure_http::private::Send),
+        Asyncness::LocalAsync => quote!(),
     };
     where_clause.predicates.push(
         syn::parse2(quote! {
@@ -151,17 +153,18 @@ fn generate_client_method(
 ) -> TokenStream {
     let async_ = match service.asyncness {
         Asyncness::Sync => quote!(),
-        Asyncness::Async => quote!(async),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(async),
     };
 
     let client_trait = match service.asyncness {
         Asyncness::Sync => quote!(Client),
         Asyncness::Async => quote!(AsyncClient),
+        Asyncness::LocalAsync => quote!(LocalAsyncClient),
     };
 
     let await_ = match service.asyncness {
         Asyncness::Sync => quote!(),
-        Asyncness::Async => quote!(.await),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(.await),
     };
 
     let name = &endpoint.ident;
@@ -219,6 +222,7 @@ fn create_request(
         let body = match service.asyncness {
             Asyncness::Sync => quote!(RequestBody),
             Asyncness::Async => quote!(AsyncRequestBody),
+            Asyncness::LocalAsync => quote!(LocalAsyncRequestBody),
         };
         return quote! {
             let mut #request = conjure_http::private::Request::new(
@@ -230,6 +234,7 @@ fn create_request(
     let trait_ = match service.asyncness {
         Asyncness::Sync => quote!(SerializeRequest),
         Asyncness::Async => quote!(AsyncSerializeRequest),
+        Asyncness::LocalAsync => quote!(LocalAsyncSerializeRequest),
     };
 
     let serializer = arg.attr.serializer.as_ref().map_or_else(
@@ -372,6 +377,7 @@ fn add_accept(
     let trait_ = match service.asyncness {
         Asyncness::Sync => quote!(DeserializeResponse),
         Asyncness::Async => quote!(AsyncDeserializeResponse),
+        Asyncness::LocalAsync => quote!(LocalAsyncDeserializeResponse),
     };
 
     let ret_ty = &endpoint.ret_ty;
@@ -480,10 +486,11 @@ fn handle_response(response: &TokenStream, service: &Service, endpoint: &Endpoin
     let trait_ = match service.asyncness {
         Asyncness::Sync => quote!(DeserializeResponse),
         Asyncness::Async => quote!(AsyncDeserializeResponse),
+        Asyncness::LocalAsync => quote!(LocalAsyncDeserializeResponse),
     };
     let await_ = match service.asyncness {
         Asyncness::Sync => quote!(),
-        Asyncness::Async => quote!(.await),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(.await),
     };
 
     quote! {
@@ -514,6 +521,7 @@ impl Service {
                 ServiceParams {
                     name: None,
                     version: None,
+                    local: false,
                 }
             }
         };
@@ -536,7 +544,7 @@ impl Service {
             }
         }
 
-        let asyncness = match Asyncness::resolve(trait_) {
+        let asyncness = match Asyncness::resolve(trait_, service_params.local) {
             Ok(asyncness) => Some(asyncness),
             Err(e) => {
                 errors.push(e);
@@ -562,7 +570,9 @@ impl Service {
         }
 
         strip_trait(trait_);
-        make_send(trait_);
+        if !service_params.local {
+            make_send(trait_);
+        }
         errors.build()?;
 
         Ok(Service {
@@ -788,6 +798,7 @@ fn validate_args(
 struct ServiceParams {
     name: Option<LitStr>,
     version: Option<Expr>,
+    local: bool,
 }
 
 #[derive(StructMeta)]

--- a/conjure-macros/src/endpoints.rs
+++ b/conjure-macros/src/endpoints.rs
@@ -38,7 +38,7 @@ fn generate_endpoints(service: &Service) -> TokenStream {
 
     let service_trait = match service.asyncness {
         Asyncness::Sync => quote!(Service),
-        Asyncness::Async => quote!(AsyncService),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(AsyncService),
     };
 
     let ImplParams {
@@ -62,14 +62,14 @@ fn generate_endpoints(service: &Service) -> TokenStream {
                 + conjure_http::private::Send
             >
         },
-        Asyncness::Async => {
+        Asyncness::Async | Asyncness::LocalAsync => {
             quote!(conjure_http::server::BoxAsyncEndpoint<'static, #request_body, #response_writer>)
         }
     };
 
     let wrapper = match service.asyncness {
         Asyncness::Sync => quote!(conjure_http::private::Box),
-        Asyncness::Async => quote!(conjure_http::server::BoxAsyncEndpoint),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(conjure_http::server::BoxAsyncEndpoint),
     };
 
     let endpoint_values = service.endpoints.iter().map(|e| {
@@ -176,7 +176,7 @@ fn input_bounds(service: &Service) -> TokenStream {
 
     match service.asyncness {
         Asyncness::Sync => quote!(conjure_http::private::Iterator<Item = #item>),
-        Asyncness::Async => quote! {
+        Asyncness::Async | Asyncness::LocalAsync => quote! {
             conjure_http::private::Stream<Item = #item>
             + conjure_http::private::Sync
             + conjure_http::private::Send
@@ -292,17 +292,17 @@ fn generate_endpoint_handler(service: &Service, endpoint: &Endpoint) -> TokenStr
 
     let endpoint_trait = match service.asyncness {
         Asyncness::Sync => quote!(Endpoint),
-        Asyncness::Async => quote!(AsyncEndpoint),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(AsyncEndpoint),
     };
 
     let async_ = match service.asyncness {
         Asyncness::Sync => quote!(),
-        Asyncness::Async => quote!(async),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(async),
     };
 
     let response_body = match service.asyncness {
         Asyncness::Sync => quote!(ResponseBody),
-        Asyncness::Async => quote!(AsyncResponseBody),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(AsyncResponseBody),
     };
 
     let generate_query_params = if has_query_params(endpoint) {
@@ -338,7 +338,7 @@ fn generate_endpoint_handler(service: &Service, endpoint: &Endpoint) -> TokenStr
 
     let await_ = match service.asyncness {
         Asyncness::Sync => quote!(),
-        Asyncness::Async => quote!(.await),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(.await),
     };
 
     let generate_response = generate_response(&parts, &response, service, endpoint);
@@ -490,7 +490,7 @@ fn generate_body_arg(
     let name = &arg.ident;
     let function = match service.asyncness {
         Asyncness::Sync => quote!(body_arg),
-        Asyncness::Async => quote!(async_body_arg),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(async_body_arg),
     };
     let deserializer = arg.params.deserializer.as_ref().map_or_else(
         || quote!(conjure_http::server::StdRequestDeserializer),
@@ -499,7 +499,7 @@ fn generate_body_arg(
     let log_as = arg.log_as();
     let await_ = match service.asyncness {
         Asyncness::Sync => quote!(),
-        Asyncness::Async => quote!(.await),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(.await),
     };
     quote! {
         let #name = conjure_http::private::#function::<#deserializer, _, _>(
@@ -530,7 +530,7 @@ fn generate_response(
 ) -> TokenStream {
     let function = match service.asyncness {
         Asyncness::Sync => quote!(response),
-        Asyncness::Async => quote!(async_response),
+        Asyncness::Async | Asyncness::LocalAsync => quote!(async_response),
     };
     let serializer = endpoint.params.produces.as_ref().map_or_else(
         || quote!(conjure_http::server::EmptyResponseSerializer),
@@ -587,7 +587,7 @@ impl Service {
             }
         }
 
-        let asyncness = match Asyncness::resolve(trait_) {
+        let asyncness = match Asyncness::resolve(trait_, false) {
             Ok(asyncness) => Some(asyncness),
             Err(e) => {
                 errors.push(e);


### PR DESCRIPTION
## Before this PR
The structs generated by the `#[conjure_client]` macro always required the inner client type to be `Send`. However, clients in wasm targets backed by the Javascript `fetch` API will not be `Send` and can't be cleanly used.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added a set of non-Send async client APIs.
==COMMIT_MSG==

I'm not updating the conjure-codegen logic now, since that'll be backed by the macro once #417 lands.

## Possible downsides?
This adds a third variant of the client APIs (on top of the old blocking and Send-requiring async versions) that are almost but not perfectly identical. In the future, the mandatory Send injection can probably removed once return type notation is stabilized (e.g. `where <T as AsyncClient>::send(): Send`).

