### PR TITLE
Add a js feature to conjure-object

### DIFF
--- a/changelog/@unreleased/pr-448.v2.yml
+++ b/changelog/@unreleased/pr-448.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Added a `js` feature to conjure-object.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/448

--- a/conjure-object/Cargo.toml
+++ b/conjure-object/Cargo.toml
@@ -8,6 +8,9 @@ description = "Runtime support for generated Conjure objects"
 repository = "https://github.com/palantir/conjure-rust"
 readme = "../README.md"
 
+[features]
+js = ["uuid/js"]
+
 [dependencies]
 bytes = { version = "1.0", features = ["serde"] }
 base64 = "0.22"


### PR DESCRIPTION
## Before this PR
When targeting JavaScript runtimes with wasm32-unknown-unknown, the uuid crate needed the `js` feature to be manually enabled. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added a `js` feature to conjure-object.
==COMMIT_MSG==
