### PR TITLE
Add '--extraManifestJson' arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Options:
           The version of the generated crate. Defaults to `--productVersion`
       --extraManifestJson <json>
           Extra manifest configuration as a JSON object.
-          This JSON will be convertd to TOML and merged into the generated Cargo.toml manifest.
+          This JSON will be converted to TOML and merged into the generated Cargo.toml manifest.
           
           Example:
               --extraManifestJson '{

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Options:
           The version of the product
       --crateVersion <version>
           The version of the generated crate. Defaults to `--productVersion`
+      --extraManifestToml <EXTRA_MANIFEST_TOML>
+          Extra manifest config as a TOML string literal.
+          Example:
+              conjure-rust generate --productName "foo" --productVersion "0.1.0" --extraManifestToml "
+                  [package]
+                  publish = [\"some-registry-name\"]
+                  license = \"MIT\"
+          
+                  [dependencies]
+                  serde = { version = \"1.0\", features = [\"default\"] }
+          
+                  [features]
+                  fancy-feature = [\"foo\", \"bar\"]
+                  " \
+              foo.conjure.json ./foo
   -h, --help
           Print help
 ```

--- a/README.md
+++ b/README.md
@@ -36,21 +36,18 @@ Options:
           The version of the product
       --crateVersion <version>
           The version of the generated crate. Defaults to `--productVersion`
-      --extraManifestToml <EXTRA_MANIFEST_TOML>
-          Extra manifest config as a TOML string literal.
+      --extraManifestJson <json>
+          Extra manifest configuration as a JSON object.
+          This JSON will be convertd to TOML and merged into the generated Cargo.toml manifest.
+          
           Example:
-              conjure-rust generate --productName "foo" --productVersion "0.1.0" --extraManifestToml "
-                  [package]
-                  publish = [\"some-registry-name\"]
-                  license = \"MIT\"
+              --extraManifestJson '{
+                  "package": { "publish": ["some-registry-name"], "license": "MIT" },
+                  "dependencies": { "serde": { "version": "1.0", "features": ["default"] } },
+                  "features": { "fancy-feature": ["foo", "bar"] }
+              }'
           
-                  [dependencies]
-                  serde = { version = \"1.0\", features = [\"default\"] }
-          
-                  [features]
-                  fancy-feature = [\"foo\", \"bar\"]
-                  " \
-              foo.conjure.json ./foo
+          Use single quotes to avoid shell escaping issues.
   -h, --help
           Print help
 ```

--- a/changelog/@unreleased/pr-456.v2.yml
+++ b/changelog/@unreleased/pr-456.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add '--extraManifestJson' arg
+  links:
+  - https://github.com/palantir/conjure-rust/pull/456

--- a/conjure-codegen/Cargo.toml
+++ b/conjure-codegen/Cargo.toml
@@ -21,6 +21,7 @@ heck = "0.5"
 quote = { version = "1.0", default-features = false }
 prettyplease = "0.2.0"
 proc-macro2 = { version = "1.0", default-features = false }
+thiserror = "2"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 syn = "2"

--- a/conjure-codegen/src/cargo_toml.rs
+++ b/conjure-codegen/src/cargo_toml.rs
@@ -1,12 +1,15 @@
 use conjure_object::Any;
 use serde::Serialize;
 use std::collections::BTreeMap;
+use toml::Value;
 
 #[derive(Serialize)]
 pub struct Manifest<'a> {
     pub package: Package<'a>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub dependencies: BTreeMap<&'a str, &'a str>,
+    pub dependencies: BTreeMap<&'a str, &'a Value>,
+    #[serde(flatten)]
+    pub miscellaneous: BTreeMap<&'a str, &'a Value>,
 }
 
 #[derive(Serialize)]
@@ -14,6 +17,8 @@ pub struct Package<'a> {
     pub name: &'a str,
     pub version: &'a str,
     pub edition: &'a str,
+    #[serde(flatten)]
+    pub extra_fields: BTreeMap<&'a str, &'a Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata<'a>>,
 }

--- a/conjure-codegen/src/cargo_toml.rs
+++ b/conjure-codegen/src/cargo_toml.rs
@@ -1,15 +1,12 @@
 use conjure_object::Any;
 use serde::Serialize;
 use std::collections::BTreeMap;
-use toml::Value;
 
 #[derive(Serialize)]
 pub struct Manifest<'a> {
     pub package: Package<'a>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub dependencies: BTreeMap<&'a str, &'a Value>,
-    #[serde(flatten)]
-    pub miscellaneous: BTreeMap<&'a str, &'a Value>,
+    pub dependencies: BTreeMap<&'a str, &'a str>,
 }
 
 #[derive(Serialize)]
@@ -17,8 +14,6 @@ pub struct Package<'a> {
     pub name: &'a str,
     pub version: &'a str,
     pub edition: &'a str,
-    #[serde(flatten)]
-    pub extra_fields: BTreeMap<&'a str, &'a Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata<'a>>,
 }

--- a/conjure-codegen/src/merge_toml.rs
+++ b/conjure-codegen/src/merge_toml.rs
@@ -1,0 +1,244 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::mem::discriminant;
+
+use thiserror::Error;
+use toml::Value;
+
+#[derive(Debug, Error)]
+pub(crate) enum TomlMergeError {
+    #[error("merge failed due to type mismatch: left: {left}, right: {right}")]
+    TypeMismatch { left: Value, right: Value },
+}
+
+pub(crate) fn left_merge(left: &mut Value, right: &Value) -> Result<(), TomlMergeError> {
+    match (left, right) {
+        (Value::Table(left_table), Value::Table(right_table)) => {
+            for (key, right_val) in right_table {
+                match left_table.get_mut(key) {
+                    Some(left_val) => left_merge(left_val, right_val)?,
+                    None => {
+                        left_table.insert(key.clone(), right_val.clone());
+                    }
+                }
+            }
+            Ok(())
+        }
+        (Value::Array(left_array), Value::Array(right_array)) => {
+            left_array.extend(right_array.clone());
+            Ok(())
+        }
+        (left_val, right_val) if discriminant(left_val) != discriminant(right_val) => {
+            Err(TomlMergeError::TypeMismatch {
+                left: left_val.clone(),
+                right: right_val.clone(),
+            })
+        }
+        _ => {
+            // Do nothing (i.e. keep left value)
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml::Value;
+
+    #[test]
+    fn test_left_merge_basic() {
+        let left_str = r#"
+            [package]
+            name = "foo-lib"
+            version = "0.0.0"
+            edition = "2018"
+
+            [[package.metadata.sls.recommended-product-dependencies]]
+            maximum-version = "0.x.x"
+            minimum-version = "0.1.0"
+            optional = false
+            product-group = "com.acme.foo"
+            product-name = "foo"
+
+            [dependencies]
+            conjure-error = "4.10.0"
+            conjure-http = "4.10.0"
+            conjure-object = "4.10.0"
+        "#;
+
+        let right_str = r#"
+            [package]
+            version = "0.1.0"
+            publish = ["some-registry-name"]
+            license = "MIT"
+
+            [dependencies]
+            serde = { version = "2.0", features = ["derive"] }
+            anyhow = "1.0"
+
+            [features]
+            fancy-feature = ["foo", "bar"]
+        "#;
+
+        let mut left: Value = left_str.parse().unwrap();
+        let right: Value = right_str.parse().unwrap();
+
+        left_merge(&mut left, &right).expect("merge should succeed");
+
+        // [package] fields from left are kept
+        let package = left.get("package").unwrap();
+        assert_eq!(
+            package.get("name").unwrap(),
+            &Value::String("foo-lib".to_string())
+        );
+        assert_eq!(
+            package.get("version").unwrap(),
+            &Value::String("0.0.0".to_string()) // conflicting right field ignored
+        );
+        assert_eq!(
+            package.get("edition").unwrap(),
+            &Value::String("2018".to_string())
+        );
+        // [package] fields from right are added
+        assert_eq!(
+            package.get("publish").unwrap(),
+            &Value::Array(vec![Value::String("some-registry-name".to_string())])
+        );
+        assert_eq!(
+            package.get("license").unwrap(),
+            &Value::String("MIT".to_string())
+        );
+
+        // Deep nested array of tables: [[package.metadata.sls.recommended-product-dependencies]]
+        let sls = package
+            .get("metadata")
+            .unwrap()
+            .get("sls")
+            .unwrap()
+            .get("recommended-product-dependencies")
+            .unwrap();
+        assert!(sls.is_array());
+        let arr = sls.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        let dep = &arr[0];
+        assert_eq!(
+            dep.get("maximum-version").unwrap(),
+            &Value::String("0.x.x".to_string())
+        );
+        assert_eq!(
+            dep.get("minimum-version").unwrap(),
+            &Value::String("0.1.0".to_string())
+        );
+        assert_eq!(dep.get("optional").unwrap(), &Value::Boolean(false));
+        assert_eq!(
+            dep.get("product-group").unwrap(),
+            &Value::String("com.acme.foo".to_string())
+        );
+        assert_eq!(
+            dep.get("product-name").unwrap(),
+            &Value::String("foo".to_string())
+        );
+
+        // [dependencies] from left are kept
+        let dependencies = left.get("dependencies").unwrap();
+        assert_eq!(
+            dependencies.get("conjure-error").unwrap(),
+            &Value::String("4.10.0".to_string())
+        );
+        assert_eq!(
+            dependencies.get("conjure-http").unwrap(),
+            &Value::String("4.10.0".to_string())
+        );
+        assert_eq!(
+            dependencies.get("conjure-object").unwrap(),
+            &Value::String("4.10.0".to_string())
+        );
+        // [dependencies] from right are are added
+        assert_eq!(
+            dependencies.get("serde").unwrap().get("version").unwrap(),
+            &Value::String("2.0".to_string())
+        );
+        assert_eq!(
+            dependencies.get("serde").unwrap().get("features").unwrap(),
+            &Value::Array(vec![Value::String("derive".to_string())])
+        );
+        assert_eq!(
+            dependencies.get("anyhow").unwrap(),
+            &Value::String("1.0".to_string())
+        );
+
+        // [features] table from right is added
+        let features = left.get("features").unwrap();
+        assert_eq!(
+            features.get("fancy-feature").unwrap(),
+            &Value::Array(vec![
+                Value::String("foo".to_string()),
+                Value::String("bar".to_string())
+            ])
+        );
+    }
+
+    #[test]
+    fn test_left_merge_empty_right() {
+        let left_str = r#"
+            [package]
+            license = "MIT"
+        "#;
+        let right_str = "";
+        let mut left: Value = left_str.parse().unwrap();
+        let right: Value = right_str
+            .parse()
+            .unwrap_or(Value::Table(Default::default()));
+
+        let expected = left.clone();
+        left_merge(&mut left, &right).expect("merge should succeed");
+        assert_eq!(left, expected);
+    }
+
+    #[test]
+    fn test_left_merge_empty_left() {
+        let left_str = "";
+        let right_str = r#"
+            [dependencies]
+            anyhow = "1.0"
+        "#;
+        let mut left: Value = left_str.parse().unwrap_or(Value::Table(Default::default()));
+        let right: Value = right_str.parse().unwrap();
+
+        left_merge(&mut left, &right).expect("merge should succeed");
+        assert_eq!(
+            left.get("dependencies").unwrap().get("anyhow").unwrap(),
+            &Value::String("1.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_left_merge_type_mismatch() {
+        let left_str = r#"
+            [package]
+            license = "MIT"
+        "#;
+        let right_str = r#"
+            [package]
+            license = ["MIT", "Apache-2.0"]
+        "#;
+        let mut left: Value = left_str.parse().unwrap();
+        let right: Value = right_str.parse().unwrap();
+
+        let result = left_merge(&mut left, &right);
+        assert!(matches!(result, Err(TomlMergeError::TypeMismatch { .. })));
+    }
+}

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
 
 conjure-codegen = { version = "4.10.0", path = "../conjure-codegen" }

--- a/conjure-rust/Cargo.toml
+++ b/conjure-rust/Cargo.toml
@@ -7,5 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+toml = "0.8"
 
 conjure-codegen = { version = "4.10.0", path = "../conjure-codegen" }

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -70,7 +70,7 @@ struct Args {
         value_name = "json",
         value_parser = parse_extra_manifest_json,
         help = r#"Extra manifest configuration as a JSON object.
-This JSON will be convertd to TOML and merged into the generated Cargo.toml manifest.
+This JSON will be converted to TOML and merged into the generated Cargo.toml manifest.
 
 Example:
     --extraManifestJson '{

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -105,10 +105,11 @@ fn main() {
         .crate_version
         .as_deref()
         .or(args.product_version.as_deref());
-    if let (Some(product_name), Some(crate_version), extra_config) =
-        (args.product_name, crate_version, args.extra_manifest)
-    {
-        config.build_crate(&product_name, crate_version, extra_config);
+    if let (Some(product_name), Some(crate_version)) = (args.product_name, crate_version) {
+        config.build_crate(&product_name, crate_version);
+    }
+    if let Some(extra_manifest_config) = args.extra_manifest {
+        config.extra_manifest_config(extra_manifest_config);
     }
     if let Some(product_version) = args.product_version {
         config.version(product_version);

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -16,7 +16,6 @@
 use clap::{ArgAction, Parser};
 use std::path::PathBuf;
 use std::process;
-use toml::Table;
 
 #[derive(Parser)]
 #[clap(rename_all = "camelCase")]
@@ -84,13 +83,13 @@ Example:
         " \
     foo.conjure.json ./foo"#,
     )]
-    extra_manifest_toml: Option<Table>,
+    extra_manifest_toml: Option<toml::Value>,
 }
 
 /// Parse a TOML string into a toml::Table
-fn parse_extra_manifest_toml(s: &str) -> Result<toml::Table, String> {
+fn parse_extra_manifest_toml(s: &str) -> Result<toml::Value, String> {
     let table = s
-        .parse::<Table>()
+        .parse::<toml::Value>()
         .map_err(|e| format!("Invalid TOML: {}", e))?;
     Ok(table)
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The only editable fields in the generated Cargo.toml were `name` and `version`. There was no way to specify other manifest fields such as `publish`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds `--extraManifestJson` arg, which allows specifying a JSON blob that will be converted to TOML and added to the generated Cargo.toml.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

