### PR TITLE
Parse bools case insensitively

### DIFF
--- a/changelog/@unreleased/pr-459.v2.yml
+++ b/changelog/@unreleased/pr-459.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The `FromPlain` implementation for `bool` is now case insensitive.
+    This affects handling of boolean path, header, and query params.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/459

--- a/conjure-object/src/plain.rs
+++ b/conjure-object/src/plain.rs
@@ -25,7 +25,7 @@ use std::f64;
 use std::fmt;
 use std::iter;
 use std::num::ParseFloatError;
-use std::str::FromStr;
+use std::str::{FromStr, ParseBoolError};
 use uuid::Uuid;
 
 use crate::{BearerToken, ResourceIdentifier, SafeLong};
@@ -154,12 +154,27 @@ macro_rules! as_from_str {
 }
 
 as_from_str!(BearerToken);
-as_from_str!(bool);
 as_from_str!(i32);
 as_from_str!(ResourceIdentifier);
 as_from_str!(SafeLong);
 as_from_str!(String);
 as_from_str!(Uuid);
+
+impl FromPlain for bool {
+    type Err = ParseBoolError;
+
+    #[inline]
+    fn from_plain(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("true") {
+            Ok(true)
+        } else if s.eq_ignore_ascii_case("false") {
+            Ok(false)
+        } else {
+            // this will always fail, but we can't construct a ParseBoolError directly otherwise
+            s.parse()
+        }
+    }
+}
 
 impl FromPlain for Bytes {
     type Err = ParseBinaryError;


### PR DESCRIPTION
## Before this PR
The implementation of the PLAIN format parser for booleans only accepted `true` and `false` per the Conjure spec. However, the Java implementation was inadvertently case insensitive and some client code has begun to rely on that fact.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The `FromPlain` implementation for `bool` is now case insensitive. This affects handling of boolean path, header, and query params.
==COMMIT_MSG==

The JSON parser does not currently use the `FromPlain` trait in its handling of non-string map keys, but we could make that change later if desired. It would probably be good from a consistency perspective regardless of this change.