### PR TITLE
Add a CLI flag to enable using external references

### DIFF
--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -330,6 +330,7 @@ pub struct Config {
     exhaustive: bool,
     serialize_empty_collections: bool,
     strip_prefix: Option<String>,
+    use_external_references: bool,
     version: Option<String>,
     build_crate: Option<CrateInfo>,
     extra_manifest_config: Option<Value>,
@@ -348,6 +349,7 @@ impl Config {
             exhaustive: false,
             serialize_empty_collections: false,
             strip_prefix: None,
+            use_external_references: false,
             version: None,
             build_crate: None,
             extra_manifest_config: None,
@@ -401,6 +403,17 @@ impl Config {
         T: Into<Option<String>>,
     {
         self.strip_prefix = strip_prefix.into();
+        self
+    }
+
+    /// Controls handling of external references.
+    ///
+    /// When enabled, external references will have their package names processed with strip_prefix
+    /// and their type names set to `strip_prefix(package) + "." + name`.
+    ///
+    /// Defaults to `false`.
+    pub fn use_external_references(&mut self, use_external_references: bool) -> &mut Config {
+        self.use_external_references = use_external_references;
         self
     }
 
@@ -486,6 +499,7 @@ impl Config {
             self.exhaustive,
             self.serialize_empty_collections,
             self.strip_prefix.as_deref(),
+            self.use_external_references,
             self.version
                 .as_deref()
                 .or_else(|| self.build_crate.as_ref().map(|v| &*v.version)),

--- a/conjure-rust/src/main.rs
+++ b/conjure-rust/src/main.rs
@@ -60,6 +60,9 @@ struct Args {
     /// The version of the generated crate. Defaults to `--productVersion`
     #[clap(long, value_name = "version", requires = "product_version")]
     crate_version: Option<String>,
+    /// Use external references with package name stripping
+    #[clap(long)]
+    use_external_references: bool,
     /// Path to a JSON-formatted Conjure IR file
     input_json: PathBuf,
     /// Directory to place generated code
@@ -101,6 +104,7 @@ fn main() {
     if let Some(prefix) = args.strip_prefix {
         config.strip_prefix(prefix);
     }
+    config.use_external_references(args.use_external_references);
     let crate_version = args
         .crate_version
         .as_deref()

--- a/conjure-test/build.rs
+++ b/conjure-test/build.rs
@@ -17,4 +17,13 @@ fn main() {
         .exhaustive(true)
         .generate_files(input, output)
         .unwrap();
+
+    let input_ext = "test-ir-ext.json";
+    println!("cargo:rerun-if-changed={}", input_ext);
+    let output = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("conjure-external-refs");
+    conjure_codegen::Config::new()
+        .strip_prefix("com.palantir".to_string())
+        .use_external_references(true)
+        .generate_files(input_ext, output)
+        .unwrap();
 }

--- a/conjure-test/src/lib.rs
+++ b/conjure-test/src/lib.rs
@@ -25,3 +25,27 @@ pub mod types {
 pub mod exhaustive_types {
     include!(concat!(env!("OUT_DIR"), "/conjure-exhaustive/mod.rs"));
 }
+
+#[allow(dead_code, unused_imports, clippy::all)]
+pub mod external_refs_types {
+    include!(concat!(env!("OUT_DIR"), "/conjure-external-refs/mod.rs"));
+}
+
+// Provide the external reference target that should be resolved
+// This needs to be at the root level where the generated code can find it
+#[allow(dead_code)]
+pub mod bar {
+    use conjure_object::serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+    #[serde(crate = "conjure_object::serde")]
+    pub struct Bar {
+        pub value: String,
+    }
+
+    impl Bar {
+        pub fn new(value: String) -> Self {
+            Self { value }
+        }
+    }
+}

--- a/conjure-test/src/test/external_refs.rs
+++ b/conjure-test/src/test/external_refs.rs
@@ -1,0 +1,37 @@
+// Copyright 2018 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{bar, external_refs_types::foo::*};
+
+#[test]
+fn test_external_reference() {
+    // This test verifies that external references resolve to the correct type
+    // when the target type is available in the compilation scope
+
+    // Create a Bar instance that should be compatible with the external reference
+    let bar_instance = bar::Bar::new("test_value".to_string());
+
+    // Try to create the test object using the Bar type
+    // This works because external references are properly resolved to crate::bar::Bar
+    let test_obj = ExternalReferenceTestObj::new(bar_instance.clone());
+
+    // Check if we can extract the value back
+    let ext_ref = test_obj.ext_ref();
+
+    // Verify the external reference is working correctly
+    assert_eq!(ext_ref.value, "test_value");
+
+    // Verify the type is resolved correctly
+    let type_name = std::any::type_name_of_val(ext_ref);
+    assert!(type_name.contains("bar::Bar"));
+}

--- a/conjure-test/src/test/mod.rs
+++ b/conjure-test/src/test/mod.rs
@@ -20,6 +20,7 @@ use std::task::{Context, Poll};
 
 mod clients;
 mod errors;
+mod external_refs;
 mod objects;
 mod servers;
 

--- a/conjure-test/test-ir-ext.json
+++ b/conjure-test/test-ir-ext.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "errors": [],
+  "types": [
+    {
+      "type": "object",
+      "object": {
+        "typeName": {
+          "name": "ExternalReferenceTestObj",
+          "package": "com.palantir.foo"
+        },
+        "fields": [
+          {
+            "fieldName": "extRef",
+            "type": {
+              "type": "external",
+              "external": {
+                "externalReference": {
+                  "name": "Bar",
+                  "package": "com.palantir.bar"
+                },
+                "fallback": {
+                  "type": "primitive",
+                  "primitive": "ANY"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "services": [],
+  "extensions": {
+    "recommended-product-dependencies": []
+  }
+}


### PR DESCRIPTION
## Before this PR
conjure-rust does not support external references

## After this PR
==COMMIT_MSG==
Add `--use-external-references` to resolve external references to Rust types.
==COMMIT_MSG==

## Possible downsides?
Opt-in, should be very little risk. Conjure only supports `java` as an `external` type key but the IR contains `externalReference` as a universal type, so users may find the config to generate IR where this feature is usable in conjure-rust a little weird.
