### PR TITLE
Deserialize null into empty collections

### DIFF
--- a/changelog/@unreleased/pr-464.v2.yml
+++ b/changelog/@unreleased/pr-464.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Conjure deserializers now deserialize `null` into empty collection
+    values.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/464

--- a/conjure-object/src/any/de.rs
+++ b/conjure-object/src/any/de.rs
@@ -305,6 +305,29 @@ impl<'de> Deserializer<'de> for Any {
         }
     }
 
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Inner::Null => visitor.visit_seq(SeqDeserializer(Vec::new().into_iter())),
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.0 {
+            Inner::Null => visitor.visit_map(MapDeserializer {
+                it: BTreeMap::new().into_iter(),
+                value: None,
+            }),
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
     fn deserialize_enum<V>(
         self,
         _: &'static str,
@@ -342,7 +365,7 @@ impl<'de> Deserializer<'de> for Any {
     }
 
     forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 u8 u16 u32 u64 char str string unit unit_struct newtype_struct seq tuple tuple_struct map
+        bool i8 i16 i32 i64 u8 u16 u32 u64 char str string unit unit_struct newtype_struct tuple tuple_struct
         struct identifier ignored_any
     }
 }

--- a/conjure-serde/src/de/mod.rs
+++ b/conjure-serde/src/de/mod.rs
@@ -17,6 +17,7 @@ use std::marker::PhantomData;
 
 pub mod delegating_deserializer;
 pub mod delegating_visitor;
+pub mod null_collections_behavior;
 pub mod unknown_fields_behavior;
 pub mod wrapping_deserializer;
 
@@ -178,6 +179,22 @@ pub trait Behavior {
         de.deserialize_byte_buf(visitor)
     }
 
+    fn deserialize_seq<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: Visitor<'de>,
+    {
+        de.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: Visitor<'de>,
+    {
+        de.deserialize_map(visitor)
+    }
+
     fn deserialize_struct<'de, D, V>(
         de: D,
         name: &'static str,
@@ -256,8 +273,6 @@ where
         deserialize_string,
         deserialize_option,
         deserialize_unit,
-        deserialize_seq,
-        deserialize_map,
         deserialize_identifier,
         deserialize_ignored_any,
     );
@@ -268,6 +283,8 @@ where
         deserialize_f64,
         deserialize_bytes,
         deserialize_byte_buf,
+        deserialize_seq,
+        deserialize_map,
     }
 
     fn deserialize_unit_struct<V>(

--- a/conjure-serde/src/de/null_collections_behavior.rs
+++ b/conjure-serde/src/de/null_collections_behavior.rs
@@ -1,0 +1,163 @@
+use crate::de::delegating_visitor::{DelegatingVisitor, Visitor2};
+use crate::de::Behavior;
+use serde::de;
+use std::marker::PhantomData;
+
+pub struct NullCollectionsBehavior<B> {
+    _p: PhantomData<B>,
+}
+
+impl<B> Behavior for NullCollectionsBehavior<B>
+where
+    B: Behavior,
+{
+    type KeyBehavior = NullCollectionsBehavior<B::KeyBehavior>;
+
+    fn deserialize_bool<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        B::deserialize_bool(de, visitor)
+    }
+
+    fn deserialize_f32<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        B::deserialize_f32(de, visitor)
+    }
+
+    fn deserialize_f64<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        B::deserialize_f64(de, visitor)
+    }
+
+    fn deserialize_bytes<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        B::deserialize_bytes(de, visitor)
+    }
+
+    fn deserialize_byte_buf<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        B::deserialize_byte_buf(de, visitor)
+    }
+
+    fn deserialize_seq<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        de.deserialize_any(DelegatingVisitor::new(EmptySeqVisitor, visitor))
+    }
+
+    fn deserialize_map<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        de.deserialize_any(DelegatingVisitor::new(EmptyMapVisitor, visitor))
+    }
+
+    fn deserialize_struct<'de, D, V>(
+        de: D,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        V: de::Visitor<'de>,
+    {
+        B::deserialize_struct(de, name, fields, visitor)
+    }
+}
+
+struct EmptySeqVisitor;
+
+impl<'de, V> Visitor2<'de, V> for EmptySeqVisitor
+where
+    V: de::Visitor<'de>,
+{
+    fn visit_unit<E>(self, visitor: V) -> Result<V::Value, E>
+    where
+        E: de::Error,
+    {
+        visitor.visit_seq(EmptySeqAccess { _p: PhantomData })
+    }
+}
+
+struct EmptySeqAccess<E> {
+    _p: PhantomData<E>,
+}
+
+impl<'de, E> de::SeqAccess<'de> for EmptySeqAccess<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    fn next_element_seed<T>(&mut self, _: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        Ok(None)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+struct EmptyMapVisitor;
+
+impl<'de, V> Visitor2<'de, V> for EmptyMapVisitor
+where
+    V: de::Visitor<'de>,
+{
+    fn visit_unit<E>(self, visitor: V) -> Result<V::Value, E>
+    where
+        E: de::Error,
+    {
+        visitor.visit_map(EmptyMapAccess { _p: PhantomData })
+    }
+}
+
+struct EmptyMapAccess<E> {
+    _p: PhantomData<E>,
+}
+
+impl<'de, E> de::MapAccess<'de> for EmptyMapAccess<E>
+where
+    E: de::Error,
+{
+    type Error = E;
+
+    fn next_key_seed<K>(&mut self, _: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: de::DeserializeSeed<'de>,
+    {
+        Ok(None)
+    }
+
+    fn next_value_seed<V>(&mut self, _: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        unreachable!()
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(0)
+    }
+}

--- a/conjure-serde/src/de/unknown_fields_behavior.rs
+++ b/conjure-serde/src/de/unknown_fields_behavior.rs
@@ -71,6 +71,22 @@ where
         B::deserialize_byte_buf(de, visitor)
     }
 
+    fn deserialize_seq<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: Visitor<'de>,
+    {
+        B::deserialize_seq(de, visitor)
+    }
+
+    fn deserialize_map<'de, D, V>(de: D, visitor: V) -> Result<V::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+        V: Visitor<'de>,
+    {
+        B::deserialize_map(de, visitor)
+    }
+
     fn deserialize_struct<'de, D, V>(
         de: D,
         name: &'static str,

--- a/conjure-serde/src/json/de/client.rs
+++ b/conjure-serde/src/json/de/client.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::de::delegating_visitor::{DelegatingVisitor, Visitor2};
+use crate::de::null_collections_behavior::NullCollectionsBehavior;
 use crate::de::Behavior;
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
@@ -97,7 +98,10 @@ impl<'a, 'de, R> de::Deserializer<'de> for &'a mut ClientDeserializer<R>
 where
     R: Read<'de>,
 {
-    impl_deserialize_body!(&'a mut serde_json::Deserializer<R>, ValueBehavior);
+    impl_deserialize_body!(
+        &'a mut serde_json::Deserializer<R>,
+        NullCollectionsBehavior<ValueBehavior>
+    );
 
     // we can't delegate this due to the signature, but luckily we know the answer
     fn is_human_readable(&self) -> bool {

--- a/conjure-serde/src/json/de/server.rs
+++ b/conjure-serde/src/json/de/server.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::de::null_collections_behavior::NullCollectionsBehavior;
 use crate::de::unknown_fields_behavior::UnknownFieldsBehavior;
 use crate::json::de::client::ValueBehavior;
 use serde::de;
@@ -99,7 +100,7 @@ where
 {
     impl_deserialize_body!(
         &'a mut serde_json::Deserializer<R>,
-        UnknownFieldsBehavior<ValueBehavior>
+        UnknownFieldsBehavior<NullCollectionsBehavior<ValueBehavior>>
     );
 
     // we can't delegate this due to the signature, but luckily we know the answer

--- a/conjure-serde/src/json/mod.rs
+++ b/conjure-serde/src/json/mod.rs
@@ -19,6 +19,7 @@
 //!   `"-Infinity"`, and `"NaN"` as appropriate.
 //! * serde_json serializes byte sequences as arrays of numbers, while Conjure specifies Base64-encoded strings.
 //! * serde_json does not support binary, floating point, or boolean keys, while Conjure does.
+//! * serde_json does not deserialize `null` into empty collection types, while Conjure does.
 //!
 //! Additionally, Conjure clients should ignore unknown fields while Conjure servers should trigger errors.
 //!

--- a/conjure-serde/src/smile/de/client.rs
+++ b/conjure-serde/src/smile/de/client.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::de::null_collections_behavior::NullCollectionsBehavior;
 use crate::de::Behavior;
 use crate::json::de::client::KeyBehavior;
 use serde::de;
@@ -108,7 +109,10 @@ impl<'a, 'de, R> de::Deserializer<'de> for &'a mut ClientDeserializer<'de, R>
 where
     R: Read<'de>,
 {
-    impl_deserialize_body!(&'a mut serde_smile::Deserializer<'de, R>, ValueBehavior);
+    impl_deserialize_body!(
+        &'a mut serde_smile::Deserializer<'de, R>,
+        NullCollectionsBehavior<ValueBehavior>
+    );
 
     fn is_human_readable(&self) -> bool {
         false

--- a/conjure-serde/src/smile/de/server.rs
+++ b/conjure-serde/src/smile/de/server.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use crate::de::null_collections_behavior::NullCollectionsBehavior;
 use crate::de::unknown_fields_behavior::UnknownFieldsBehavior;
 use crate::smile::de::client::ValueBehavior;
 use serde::de;
@@ -110,7 +111,7 @@ where
 {
     impl_deserialize_body!(
         &'a mut serde_smile::Deserializer<'de, R>,
-        UnknownFieldsBehavior<ValueBehavior>
+        UnknownFieldsBehavior<NullCollectionsBehavior<ValueBehavior>>
     );
 
     fn is_human_readable(&self) -> bool {

--- a/conjure-serde/src/smile/mod.rs
+++ b/conjure-serde/src/smile/mod.rs
@@ -16,6 +16,7 @@
 //! Conjure specifies behavior that differs from serde-smile's in a couple of ways:
 //!
 //! * serde-smile does not support binary, floating point, or boolean keys, while Conjure does.
+//! * serde_smile does not deserialize `null` into empty collection types, while Conjure does.
 //!
 //! Additionally, Conjure clients should ignore unknown fields while Conjure servers should trigger errors.
 //!

--- a/conjure-test/src/test/objects.rs
+++ b/conjure-test/src/test/objects.rs
@@ -99,6 +99,23 @@ fn empty_fields() {
 }
 
 #[test]
+fn null_fields() {
+    let object = EmptyFields::builder().build();
+
+    test_de(
+        &object,
+        r#"
+        {
+            "optional": null,
+            "list": null,
+            "set": null,
+            "map": null
+        }
+        "#,
+    );
+}
+
+#[test]
 fn enums() {
     test_serde(&TestEnum::One, r#""ONE""#);
     assert_eq!(TestEnum::One.as_str(), "ONE");


### PR DESCRIPTION
## Before this PR
The deserializers in `conjure-serde` would refuse to deserialize `null` into collection types, but the Conjure spec requires this: https://github.com/palantir/conjure/blob/master/docs/spec/wire.md#561-coercing-json-null--absent-to-conjure-types.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Conjure deserializers now deserialize `null` into empty collection values.
==COMMIT_MSG==

## Possible downsides?
The Conjure spec only requires this in the value position in a map, but this PR allows it universally. In particular, this means that a top-level `null` will deserialize into an empty list, set, or map, and similarly `[null]` will deserialize into a list containing an empty list.