### PR TITLE
Serialize error parameters properly by default

### DIFF
--- a/changelog/@unreleased/pr-470.v2.yml
+++ b/changelog/@unreleased/pr-470.v2.yml
@@ -2,6 +2,6 @@ type: break
 break:
   description: Error parameters are now directly serialized by default. A new `stringify_parameters`
     function can be used to convert a `SerializableError` into the old style. The
-    parameter value type in `SerializableError` is now `Any` rather than `String.
+    parameter value type in `SerializableError` is now `Any` rather than `String`.
   links:
   - https://github.com/palantir/conjure-rust/pull/470

--- a/changelog/@unreleased/pr-470.v2.yml
+++ b/changelog/@unreleased/pr-470.v2.yml
@@ -1,0 +1,7 @@
+type: break
+break:
+  description: Error parameters are now directly serialized by default. A new `stringify_parameters`
+    function can be used to convert a `SerializableError` into the old style. The
+    parameter value type in `SerializableError` is now `Any` rather than `String.
+  links:
+  - https://github.com/palantir/conjure-rust/pull/470

--- a/conjure-error/error-types.conjure.json
+++ b/conjure-error/error-types.conjure.json
@@ -2,12 +2,32 @@
   "version" : 1,
   "errors" : [ {
     "errorName" : {
-      "name" : "PermissionDenied",
+      "name" : "Conflict",
       "package" : "com.palantir.conjure.error"
     },
-    "docs" : "A generic `PERMISSION_DENIED` error.",
+    "docs" : "A generic `CONFLICT` error.",
     "namespace" : "Default",
-    "code" : "PERMISSION_DENIED",
+    "code" : "CONFLICT",
+    "safeArgs" : [ ],
+    "unsafeArgs" : [ ]
+  }, {
+    "errorName" : {
+      "name" : "FailedPrecondition",
+      "package" : "com.palantir.conjure.error"
+    },
+    "docs" : "A generic `FAILED_PRECONDITION` error.",
+    "namespace" : "Default",
+    "code" : "FAILED_PRECONDITION",
+    "safeArgs" : [ ],
+    "unsafeArgs" : [ ]
+  }, {
+    "errorName" : {
+      "name" : "Internal",
+      "package" : "com.palantir.conjure.error"
+    },
+    "docs" : "A generic `INTERNAL` error.",
+    "namespace" : "Default",
+    "code" : "INTERNAL",
     "safeArgs" : [ ],
     "unsafeArgs" : [ ]
   }, {
@@ -32,12 +52,12 @@
     "unsafeArgs" : [ ]
   }, {
     "errorName" : {
-      "name" : "Conflict",
+      "name" : "PermissionDenied",
       "package" : "com.palantir.conjure.error"
     },
-    "docs" : "A generic `CONFLICT` error.",
+    "docs" : "A generic `PERMISSION_DENIED` error.",
     "namespace" : "Default",
-    "code" : "CONFLICT",
+    "code" : "PERMISSION_DENIED",
     "safeArgs" : [ ],
     "unsafeArgs" : [ ]
   }, {
@@ -48,26 +68,6 @@
     "docs" : "A generic `REQUEST_ENTITY_TOO_LARGE` error.",
     "namespace" : "Default",
     "code" : "REQUEST_ENTITY_TOO_LARGE",
-    "safeArgs" : [ ],
-    "unsafeArgs" : [ ]
-  }, {
-    "errorName" : {
-      "name" : "FailedPrecondition",
-      "package" : "com.palantir.conjure.error"
-    },
-    "docs" : "A generic `FAILED_PRECONDITION` error.",
-    "namespace" : "Default",
-    "code" : "FAILED_PRECONDITION",
-    "safeArgs" : [ ],
-    "unsafeArgs" : [ ]
-  }, {
-    "errorName" : {
-      "name" : "Internal",
-      "package" : "com.palantir.conjure.error"
-    },
-    "docs" : "A generic `INTERNAL` error.",
-    "namespace" : "Default",
-    "code" : "INTERNAL",
     "safeArgs" : [ ],
     "unsafeArgs" : [ ]
   }, {
@@ -153,7 +153,7 @@
             },
             "valueType" : {
               "type" : "primitive",
-              "primitive" : "STRING"
+              "primitive" : "ANY"
             }
           }
         },
@@ -162,5 +162,6 @@
       "docs" : "The JSON-serializable representation of an error."
     }
   } ],
-  "services" : [ ]
+  "services" : [ ],
+  "extensions" : { }
 }

--- a/conjure-error/error-types.yml
+++ b/conjure-error/error-types.yml
@@ -42,7 +42,7 @@ types:
             type: uuid
           parameters:
             docs: Parameters providing more information about the error.
-            type: map<string, string>
+            type: map<string, any>
     errors:
       PermissionDenied:
         docs: A generic `PERMISSION_DENIED` error.

--- a/conjure-error/src/types/mod.rs
+++ b/conjure-error/src/types/mod.rs
@@ -3,28 +3,28 @@ pub use self::error_code::ErrorCode;
 #[doc(inline)]
 pub use self::serializable_error::SerializableError;
 #[doc(inline)]
-pub use self::permission_denied::PermissionDenied;
-#[doc(inline)]
-pub use self::invalid_argument::InvalidArgument;
-#[doc(inline)]
-pub use self::not_found::NotFound;
-#[doc(inline)]
 pub use self::conflict::Conflict;
-#[doc(inline)]
-pub use self::request_entity_too_large::RequestEntityTooLarge;
 #[doc(inline)]
 pub use self::failed_precondition::FailedPrecondition;
 #[doc(inline)]
 pub use self::internal::Internal;
 #[doc(inline)]
+pub use self::invalid_argument::InvalidArgument;
+#[doc(inline)]
+pub use self::not_found::NotFound;
+#[doc(inline)]
+pub use self::permission_denied::PermissionDenied;
+#[doc(inline)]
+pub use self::request_entity_too_large::RequestEntityTooLarge;
+#[doc(inline)]
 pub use self::timeout::Timeout;
 pub mod error_code;
 pub mod serializable_error;
-pub mod permission_denied;
-pub mod invalid_argument;
-pub mod not_found;
 pub mod conflict;
-pub mod request_entity_too_large;
 pub mod failed_precondition;
 pub mod internal;
+pub mod invalid_argument;
+pub mod not_found;
+pub mod permission_denied;
+pub mod request_entity_too_large;
 pub mod timeout;

--- a/conjure-error/src/types/serializable_error.rs
+++ b/conjure-error/src/types/serializable_error.rs
@@ -21,13 +21,27 @@ pub struct SerializableError {
     error_name: String,
     #[serde(rename = "errorInstanceId")]
     error_instance_id: conjure_object::Uuid,
-    #[builder(default, map(key(type = String, into), value(type = String, into)))]
+    #[builder(
+        default,
+        map(
+            key(type = String, into),
+            value(
+                custom(
+                    type = impl
+                    conjure_object::serde::Serialize,
+                    convert = |v|conjure_object::Any::new(
+                        v
+                    ).expect("value failed to serialize")
+                )
+            )
+        )
+    )]
     #[serde(
         rename = "parameters",
         skip_serializing_if = "std::collections::BTreeMap::is_empty",
         default
     )]
-    parameters: std::collections::BTreeMap<String, String>,
+    parameters: std::collections::BTreeMap<String, conjure_object::Any>,
 }
 impl SerializableError {
     /// Constructs a new instance of the type.
@@ -67,7 +81,9 @@ impl SerializableError {
     }
     /// Parameters providing more information about the error.
     #[inline]
-    pub fn parameters(&self) -> &std::collections::BTreeMap<String, String> {
+    pub fn parameters(
+        &self,
+    ) -> &std::collections::BTreeMap<String, conjure_object::Any> {
         &self.parameters
     }
 }

--- a/conjure-test/src/test/errors.rs
+++ b/conjure-test/src/test/errors.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use conjure_error::{ErrorCode, ErrorType};
+use conjure_object::Any;
 use std::collections::BTreeMap;
 
 use crate::types::*;
@@ -36,8 +37,31 @@ fn error_serialization() {
     assert_eq!(encoded.error_name(), "Test:SimpleError");
 
     let mut params = BTreeMap::new();
-    params.insert("foo".to_string(), "hello".to_string());
-    params.insert("bar".to_string(), "15".to_string());
-    params.insert("unsafeFoo".to_string(), "false".to_string());
+    params.insert("foo".to_string(), Any::new("hello").unwrap());
+    params.insert("bar".to_string(), Any::new(15).unwrap());
+    params.insert("unsafeFoo".to_string(), Any::new(false).unwrap());
+    params.insert("baz".to_string(), Any::new(EmptyObject::new()).unwrap());
+    assert_eq!(*encoded.parameters(), params);
+}
+
+#[test]
+fn stringified_error_serialization() {
+    let error = SimpleError::builder()
+        .foo("hello")
+        .bar(15)
+        .baz(EmptyObject::new())
+        .unsafe_foo(false)
+        .build();
+
+    let encoded = conjure_error::encode(&error);
+    let encoded = conjure_error::stringify_parameters(encoded);
+
+    assert_eq!(*encoded.error_code(), ErrorCode::Internal);
+    assert_eq!(encoded.error_name(), "Test:SimpleError");
+
+    let mut params = BTreeMap::new();
+    params.insert("foo".to_string(), Any::new("hello").unwrap());
+    params.insert("bar".to_string(), Any::new("15").unwrap());
+    params.insert("unsafeFoo".to_string(), Any::new("false").unwrap());
     assert_eq!(*encoded.parameters(), params);
 }


### PR DESCRIPTION
## Before this PR
Scalar error parameters were always stringified, and composite error parameters were dropped. This was done for pseudo-compatibility with the Java implementation, which `toString()`'s everything. This behavior was also baked into error deserialization, as the parameter value type in `SerializableError` was `String` rather than `Any`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Error parameters are now directly serialized by default. A new `stringify_parameters` function can be used to convert a `SerializableError` into the old style. The parameter value type in `SerializableError` is now `Any` rather than `String`.
==COMMIT_MSG==

## Possible downsides?
We do need to figure out how to control the emission of new vs old style errors in witchcraft-server - it is probably (?) not acceptable to just make the change for existing endpoints. In the short term it can just unconditionally stringify the parameters to avoid wire breaks.

cc #418