### PR TITLE
improvement: special case the builder build keyword for object fields

### DIFF
--- a/conjure-codegen/example-types/example-types.yml
+++ b/conjure-codegen/example-types/example-types.yml
@@ -171,6 +171,8 @@ types:
             type: integer
           memoizedHashCode:
             type: integer
+          build:
+            type: string
       Union:
         union:
           foo: string

--- a/conjure-codegen/src/context.rs
+++ b/conjure-codegen/src/context.rs
@@ -886,6 +886,8 @@ impl Context {
             | "typeof" | "unsized" | "virtual" | "yield" => true,
             // weak keywords
             "union" | "dyn" => true,
+            // builder pattern methods
+            "build" => true,
             _ => false,
         };
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Generating a conjure object with a field named `build` succeeds, but the generated rust code will not compile since `build` conflicts with the builder's build method.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The `build` keyword is special-cased alongside other rust language keywords to be prefixed with an underscore on the generated builder object.
==COMMIT_MSG==


