### PR TITLE
Expose conjure tags as endpoint parameters

### DIFF
--- a/conjure-http/src/server/mod.rs
+++ b/conjure-http/src/server/mod.rs
@@ -66,6 +66,9 @@ pub trait EndpointMetadata {
 
     /// If the endpoint is deprecated, returns the deprecation documentation.
     fn deprecated(&self) -> Option<&str>;
+
+    /// Tags for additional metadata about the endpoint
+    fn tags(&self) -> &[&str];
 }
 
 impl<T> EndpointMetadata for Box<T>
@@ -94,6 +97,10 @@ where
 
     fn deprecated(&self) -> Option<&str> {
         (**self).deprecated()
+    }
+
+    fn tags(&self) -> &[&str] {
+        (**self).tags()
     }
 }
 
@@ -227,6 +234,10 @@ impl<I, O> EndpointMetadata for BoxAsyncEndpoint<'_, I, O> {
 
     fn deprecated(&self) -> Option<&str> {
         self.inner.deprecated()
+    }
+
+    fn tags(&self) -> &[&str] {
+        self.inner.tags()
     }
 }
 

--- a/conjure-macros/src/endpoints.rs
+++ b/conjure-macros/src/endpoints.rs
@@ -3,11 +3,12 @@ use crate::{Asyncness, Errors};
 use heck::ToUpperCamelCase;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
+use std::collections::BTreeSet;
 use structmeta::StructMeta;
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, Error, FnArg, GenericParam, Generics, ItemTrait, LitStr, Meta, Pat, PatType,
-    ReturnType, TraitItem, TraitItemFn, Type, Visibility,
+    parse_macro_input, punctuated::Punctuated, Error, FnArg, GenericParam, Generics, ItemTrait,
+    LitStr, Meta, Pat, PatType, ReturnType, Token, TraitItem, TraitItemFn, Type, Visibility,
 };
 
 pub fn generate(
@@ -240,6 +241,20 @@ fn generate_endpoint_metadata(service: &Service, endpoint: &Endpoint) -> TokenSt
             quote!(#name)
         }
     };
+    let tags = match &endpoint.params.tags {
+        Some(tags) => {
+            let tag_strings = tags.iter().map(|tag| quote!(#tag));
+            quote! {
+                {
+                    static TAGS: &[&str] = &[#(#tag_strings),*];
+                    TAGS
+                }
+            }
+        }
+        None => quote! {
+            &[]
+        },
+    };
 
     quote! {
         impl<T> conjure_http::server::EndpointMetadata for #struct_name<T> {
@@ -265,6 +280,10 @@ fn generate_endpoint_metadata(service: &Service, endpoint: &Endpoint) -> TokenSt
 
             fn deprecated(&self) -> conjure_http::private::Option<&str> {
                 conjure_http::private::Option::None
+            }
+
+            fn tags(&self) -> &[&str] {
+                #tags
             }
         }
     }
@@ -751,6 +770,37 @@ impl Endpoint {
     }
 }
 
+#[derive(Default, Clone)]
+struct Tags(BTreeSet<String>);
+
+impl std::ops::Deref for Tags {
+    type Target = BTreeSet<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl syn::parse::Parse for Tags {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut tags = BTreeSet::new();
+
+        if input.peek(syn::token::Bracket) {
+            let content;
+            syn::bracketed!(content in input);
+            let punctuated: Punctuated<LitStr, Token![,]> = Punctuated::parse_terminated(&content)?;
+
+            for lit_str in punctuated {
+                tags.insert(lit_str.value());
+            }
+        } else {
+            let lit_str: LitStr = input.parse()?;
+            tags.insert(lit_str.value());
+        }
+        Ok(Tags(tags))
+    }
+}
+
 #[derive(StructMeta)]
 struct ServiceParams {
     name: Option<LitStr>,
@@ -762,6 +812,7 @@ struct EndpointParams {
     path: LitStr,
     name: Option<LitStr>,
     produces: Option<Type>,
+    tags: Option<Tags>,
 }
 
 enum ArgType {


### PR DESCRIPTION
Tags were previously not exposed at the endpoint level. The only tags that were effective were 'server-request-context' and 'server-limit-request-size', both of which were interpreted by conjure-rust at codegen time.

Add a 'tags' function to Endpoint, which exposes the set of tags. This is similar to the java undertow generator.

Forgoes adding 'tags' to the client, unlike the java dialogue implementation. This is because the clients are used directly in rust, as opposed to being passed into a dialogue client generator.