### PR TITLE
Revert "Tag enums #[non_exhaustive]"

### DIFF
--- a/changelog/@unreleased/pr-453.v2.yml
+++ b/changelog/@unreleased/pr-453.v2.yml
@@ -1,6 +1,0 @@
-type: break
-break:
-  description: Enums are now tagged `#[non_exhaustive]` when the `exhaustive` flag
-    is not enabled.
-  links:
-  - https://github.com/palantir/conjure-rust/pull/453

--- a/conjure-codegen/src/enums.rs
+++ b/conjure-codegen/src/enums.rs
@@ -40,12 +40,6 @@ fn generate_enum(ctx: &Context, def: &EnumDefinition) -> TokenStream {
     let err = ctx.err_ident(def.type_name());
     let unknown = unknown(ctx, def);
 
-    let non_exhaustive = if ctx.exhaustive() {
-        quote!()
-    } else {
-        quote!(#[non_exhaustive])
-    };
-
     let variants = def.values().iter().map(|v| {
         let docs = ctx.docs(v.docs());
         let deprecated = ctx.deprecated(v.deprecated());
@@ -107,7 +101,6 @@ fn generate_enum(ctx: &Context, def: &EnumDefinition) -> TokenStream {
 
     quote! {
         #root_docs
-        #non_exhaustive
         #[derive(
             Debug,
             Clone,

--- a/conjure-codegen/src/example_types/objects/product/enum_example.rs
+++ b/conjure-codegen/src/example_types/objects/product/enum_example.rs
@@ -2,7 +2,6 @@
 use std::fmt;
 use std::str;
 /// This enumerates the numbers 1:2.
-#[non_exhaustive]
 #[derive(
     Debug,
     Clone,

--- a/conjure-codegen/src/example_types/objects/product/single_union.rs
+++ b/conjure-codegen/src/example_types/objects/product/single_union.rs
@@ -3,7 +3,6 @@ use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[non_exhaustive]
 pub enum SingleUnion {
     Foo(String),
     /// An unknown variant.

--- a/conjure-codegen/src/example_types/objects/product/union_.rs
+++ b/conjure-codegen/src/example_types/objects/product/union_.rs
@@ -3,7 +3,6 @@ use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[non_exhaustive]
 pub enum Union {
     Foo(String),
     Bar(i32),

--- a/conjure-codegen/src/example_types/objects/product/union_type_example.rs
+++ b/conjure-codegen/src/example_types/objects/product/union_type_example.rs
@@ -3,7 +3,6 @@ use conjure_object::serde::ser::SerializeMap as SerializeMap_;
 use conjure_object::private::{UnionField_, UnionTypeField_};
 use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[non_exhaustive]
 pub enum UnionTypeExample {
     /// Docs for when UnionTypeExample is of type StringExample.
     StringExample(super::StringExample),

--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -153,7 +153,7 @@
 //! match enum_value {
 //!     EnumExample::One => println!("found one"),
 //!     EnumExample::Two => println!("found two"),
-//!     _ => println!("got unknown variant: {}", enum_value),
+//!     EnumExample::Unknown(unknown) => println!("got unknown variant: {}", unknown),
 //! }
 //! ```
 //!

--- a/conjure-codegen/src/unions.rs
+++ b/conjure-codegen/src/unions.rs
@@ -73,10 +73,6 @@ fn generate_enum(ctx: &Context, def: &UnionDefinition) -> TokenStream {
     // The derive attr has to be before the educe attr, so insert rather than push
     type_attrs.insert(0, quote!(#[derive(#(#derives),*)]));
 
-    if !ctx.exhaustive() {
-        type_attrs.push(quote!(#[non_exhaustive]))
-    }
-
     let docs = def.union_().iter().map(|f| ctx.docs(f.docs()));
     let deprecated = def.union_().iter().map(|f| ctx.deprecated(f.deprecated()));
 


### PR DESCRIPTION
Reverts palantir/conjure-rust#453

This makes it harder for consumers to match against all of the variants they do know about, and we can't patch all of the back compat risks (e.g. adding a service endpoint) anyway.