### PR TITLE
Fix smile serialization of nested values

### DIFF
--- a/conjure-serde/src/ser.rs
+++ b/conjure-serde/src/ser.rs
@@ -418,6 +418,10 @@ where
             .serialize_struct_variant(name, variant_index, variant, len)
             .map(Override::<_, B>::new)
     }
+
+    fn is_human_readable(&self) -> bool {
+        self.inner.is_human_readable()
+    }
 }
 
 impl<T, B> Serialize for Override<T, B>

--- a/conjure-serde/src/smile/test.rs
+++ b/conjure-serde/src/smile/test.rs
@@ -171,3 +171,24 @@ fn null_collections() {
         Collections::deserialize(&mut crate::smile::ClientDeserializer::from_slice(smile)).unwrap();
     assert_eq!(expected, actual);
 }
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct UuidField {
+    uuid: Uuid,
+}
+
+#[test]
+fn uuid_field() {
+    let smile = b":)\n\x05\xfa\x83uuid\xfd\x90\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xfb";
+
+    let value = UuidField { uuid: Uuid::nil() };
+
+    let actual = crate::smile::to_vec(&value).unwrap();
+    assert_eq!(actual, smile);
+
+    let actual = crate::smile::client_from_slice::<UuidField>(smile).unwrap();
+    assert_eq!(actual, value);
+
+    let actual = crate::smile::server_from_slice::<UuidField>(smile).unwrap();
+    assert_eq!(actual, value);
+}


### PR DESCRIPTION
## Before this PR
We failed to override `is_human_readable` in our nested serializers, so we would incorrectly serialize things like UUIDs whose behavior depends on that flag.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed Smile deserialization of nested UUIDs.
==COMMIT_MSG==
