### PR TITLE
Fix object/submodule name conflict

### DIFF
--- a/conjure-codegen/src/lib.rs
+++ b/conjure-codegen/src/lib.rs
@@ -569,6 +569,8 @@ impl Config {
             );
         }
 
+        root.deconflict();
+
         root
     }
 
@@ -686,6 +688,18 @@ impl ModuleTrie {
                 .or_insert_with(ModuleTrie::new)
                 .insert(rest, type_),
             None => self.types.push(type_),
+        }
+    }
+
+    fn deconflict(&mut self) {
+        for type_ in &mut self.types {
+            if self.submodules.contains_key(&type_.module_name) {
+                type_.module_name.push('_');
+            }
+        }
+
+        for submodule in self.submodules.values_mut() {
+            submodule.deconflict();
         }
     }
 

--- a/conjure-test/test-ir.json
+++ b/conjure-test/test-ir.json
@@ -420,6 +420,15 @@
       "union" : [ ]
     }
   }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Foo",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ ]
+    }
+  }, {
     "type" : "alias",
     "alias" : {
       "typeName" : {

--- a/conjure-test/test.yml
+++ b/conjure-test/test.yml
@@ -106,6 +106,8 @@ types:
           list: list<OtherSubpackageObject>
           set: set<OtherSubpackageObject>
           map: map<integer, SubpackageObject>
+      Foo:
+        fields: {}
       CustomValueHandling:
         fields:
           binary: binary


### PR DESCRIPTION
## Before this PR
If you defined a object `my::package::Foo` and another object `my::package::foo::Bar`, we would codegen two speparate `foo` modules, breaking the build:

```
error[E0761]: file for module `foo` found at both "/home/sfackler/code/conjure-rust/target/debug/build/conjure-test-f2cecee095d4f5e9/out/conjure-exhaustive/objects/foo.rs" and "/home/sfackler/code/conjure-rust/target/debug/build/conjure-test-f2cecee095d4f5e9/out/conjure-exhaustive/objects/foo/mod.rs"
  --> /home/sfackler/code/conjure-rust/target/debug/build/conjure-test-f2cecee095d4f5e9/out/conjure-exhaustive/objects/mod.rs:98:1
   |
98 | pub mod foo;
   | ^^^^^^^^^^^^
   |
   = help: delete or rename one of them to remove the ambiguity

error[E0761]: file for module `foo` found at both "/home/sfackler/code/conjure-rust/target/debug/build/conjure-test-f2cecee095d4f5e9/out/conjure-exhaustive/objects/foo.rs" and "/home/sfackler/code/conjure-rust/target/debug/build/conjure-test-f2cecee095d4f5e9/out/conjure-exhaustive/objects/foo/mod.rs"
   --> /home/sfackler/code/conjure-rust/target/debug/build/conjure-test-f2cecee095d4f5e9/out/conjure-exhaustive/objects/mod.rs:131:1
    |
131 | pub mod foo;
    | ^^^^^^^^^^^^
    |
    = help: delete or rename one of them to remove the ambiguity

error[E0428]: the name `foo` is defined multiple times
   --> /home/sfackler/code/conjure-rust/target/debug/build/conjure-test-f2cecee095d4f5e9/out/conjure-exhaustive/objects/mod.rs:131:1
    |
98  | pub mod foo;
    | ------------ previous definition of the module `foo` here
...
131 | pub mod foo;
    | ^^^^^^^^^^^^ `foo` redefined here
    |
    = note: `foo` must be defined only once in the type namespace of this module
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed build errors caused by objects and package components with the same name.
==COMMIT_MSG==

The code now just appends a `_` to the type's module to deconflict them. Package names are supposed to follow Java conventions and so shouldn't have a `_` suffix: https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#namedtypesdefinition.