### PR TITLE
Fix deprecation for public fields

### DIFF
--- a/conjure-codegen/src/objects.rs
+++ b/conjure-codegen/src/objects.rs
@@ -64,7 +64,7 @@ pub fn generate(ctx: &Context, base_module: BaseModule, def: &ObjectDefinition) 
             quote!()
         };
         let (docs, deprecated) = if ctx.public_fields() {
-            (ctx.docs(s.docs()), ctx.deprecated(s.docs()))
+            (ctx.docs(s.docs()), ctx.deprecated(s.deprecated()))
         } else {
             (quote!(), quote!())
         };


### PR DESCRIPTION
## Before this PR
We accidentally used a field's docs as its deprecation message when public fields were enabled.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixed field deprecation handling with the public fields feature.
==COMMIT_MSG==
