### PR TITLE
Add support for setting a custom backtrace provider

### DIFF
--- a/conjure-error/src/error.rs
+++ b/conjure-error/src/error.rs
@@ -19,6 +19,7 @@ use std::borrow::Cow;
 use std::collections::hash_map::{self, HashMap};
 use std::fmt;
 use std::ops::Index;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::{backtrace, error};
 
@@ -403,6 +404,17 @@ impl<'a> Iterator for ParamsIter<'a> {
     }
 }
 
+static BACKTRACE_PROVIDER: OnceLock<fn() -> String> = OnceLock::new();
+
+/// Overrides backtrace capture. The returned string lands verbatim in the
+/// `stacktrace` field of service.1 records and is treated as safe-to-log. Used for platforms
+/// like wasm with that backtrace::Backtrace doesn't support.
+pub fn set_safe_custom_backtrace_provider(provider: fn() -> String) -> Result<(), Error> {
+    BACKTRACE_PROVIDER
+        .set(provider)
+        .or(Err(Error::internal_safe("backtrace provider already set")))
+}
+
 /// A backtrace associated with an `Error`.
 pub struct Backtrace(BacktraceInner);
 
@@ -418,7 +430,11 @@ impl fmt::Debug for Backtrace {
 impl Backtrace {
     #[inline]
     fn new() -> Backtrace {
-        Backtrace(BacktraceInner::Rust(backtrace::Backtrace::force_capture()))
+        if let Some(provider) = BACKTRACE_PROVIDER.get() {
+            Backtrace(BacktraceInner::Custom(provider()))
+        } else {
+            Backtrace(BacktraceInner::Rust(backtrace::Backtrace::force_capture()))
+        }
     }
 
     #[inline]

--- a/conjure-error/src/error.rs
+++ b/conjure-error/src/error.rs
@@ -404,14 +404,17 @@ impl<'a> Iterator for ParamsIter<'a> {
     }
 }
 
-static BACKTRACE_PROVIDER: OnceLock<fn() -> String> = OnceLock::new();
+static BACKTRACE_PROVIDER: OnceLock<Box<dyn Fn() -> String + Send + Sync>> = OnceLock::new();
 
 /// Overrides backtrace capture. The returned string lands verbatim in the
 /// `stacktrace` field of service.1 records and is treated as safe-to-log. Used for platforms
 /// like wasm with that backtrace::Backtrace doesn't support.
-pub fn set_safe_custom_backtrace_provider(provider: fn() -> String) -> Result<(), Error> {
+pub fn set_safe_custom_backtrace_provider<F>(provider: F) -> Result<(), Error>
+where
+    F: Fn() -> String + Send + Sync + 'static,
+{
     BACKTRACE_PROVIDER
-        .set(provider)
+        .set(Box::new(provider))
         .or(Err(Error::internal_safe("backtrace provider already set")))
 }
 


### PR DESCRIPTION
## Before this PR
`backtrace::Backtrace` doesn't support platforms like `wasm`. They are thus either stuck with no backtraces, or need to call `with_custom_safe_backtrace` on every error (at the point of creation to get the correct trace).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allows the setting of a custom backtrace provider on platforms without `backtrace::Backtrace` support.
==COMMIT_MSG==
An example provider would be constructing a string from `js_sys`'s stack view.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

